### PR TITLE
Add Master/Standby Pool Selection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,12 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Verify Go dependencies

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ build-cli:
 	mkdir -p bin
 	go build -o bin/$(APP)-cli cmd/db-cli/main.go
 
-
 run: build-db
 	go run ./cmd/db/.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The project consists of two main components:
 - Command-line interface for database operations
 - In-memory key-value storage engine
 - Connection limiting to prevent resource exhaustion
+- **Master/Standby Connection Pooling** with automatic failover
+- Configurable server selection strategies (master_first, round_robin, random)
 
 ## Commands
 
@@ -55,6 +57,8 @@ DEL user_name
 
 ## Configuration
 
+### Server Configuration
+
 The server can be configured using a YAML file. Example configuration:
 
 ```yaml
@@ -70,10 +74,10 @@ logging:
   output: "/log/output.log"
 ```
 
-### Configuration Options
+#### Server Configuration Options
 
 - **engine.type**: Storage engine type (currently only "in_memory")
-- **network.address**: Server listening address 
+- **network.address**: Server listening address
 - **network.max_connections**: Maximum concurrent client connections (enforced by server)
 - **network.max_message_size**: Maximum message size in KB
 - **network.idle_timeout**: Client idle timeout duration
@@ -102,7 +106,7 @@ make run
 
 The CLI client supports both configuration files and command-line flags for flexibility.
 
-### Client Configuration
+### Basic Client Configuration
 
 The client can be configured using a YAML file:
 
@@ -112,6 +116,45 @@ network:
   max_message_size: 4
   idle_timeout: 1m
 ```
+
+### Client with Connection Pool
+
+For distributed deployments with master/standby servers:
+
+```yaml
+network:
+  address: "127.0.0.1:3223"
+  max_message_size: 4
+  idle_timeout: 1m
+
+pool:
+  enabled: true
+
+  servers:
+    - address: "127.0.0.1:3223"
+      role: master
+    - address: "127.0.0.1:3224"
+      role: master
+    - address: "127.0.0.1:3225"
+      role: standby
+
+  selection_strategy: master_first
+  max_retries: 3
+  retry_delay: 1s
+  failure_timeout: 30s
+```
+
+#### Pool Configuration Options
+
+- **pool.enabled**: Enable connection pooling (default: false)
+- **pool.servers**: List of servers with address and role (master or standby)
+- **pool.selection_strategy**: How to select servers from the pool
+  - `master_first`: Try master servers first, fall back to standby on failure
+  - `round_robin`: Rotate through all servers in order
+  - `random`: Pick servers randomly
+- **pool.max_retries**: Maximum number of retry attempts when a server fails
+- **pool.retry_delay**: Delay between retry attempts
+- **pool.failure_timeout**: Time after which failed servers are automatically retried
 
 ### Usage Examples
 
@@ -191,23 +234,15 @@ go build -o bin/db-cli ./cmd/db-cli
 │       └── main.go
 ├── config.client.example.yaml   # Example client configuration
 ├── config.server.example.yaml   # Example server configuration
+├── example-pool-config.yaml     # Example pool configuration
 └── internal/                    # Internal packages
     ├── compute/                 # Request handling and command execution
-    │   └── compute.go
     ├── config/                  # Configuration management
-    │   ├── config.go           # Common configuration utilities
-    │   ├── client.go           # Client configuration
-    │   └── server.go           # Server configuration
     ├── engine/                  # Storage engine implementation
-    │   └── engine.go
     ├── network/                 # TCP networking layer
-    │   ├── client.go           # TCP client implementation
-    │   ├── server.go           # TCP server implementation
-    │   └── options.go          # Functional options
     ├── parser/                  # Command parsing
-    │   └── parser.go
+    ├── pool/                    # Connection pooling and failover
     └── storage/                 # Storage layer
-        └── storage.go
 ```
 
 ## Development
@@ -227,6 +262,11 @@ Clean build artifacts:
 make clean
 ```
 
+Generate mocks:
+```bash
+make generate
+```
+
 ## Network Protocol
 
 The server uses a simple text-based protocol over TCP:
@@ -238,7 +278,7 @@ The server uses a simple text-based protocol over TCP:
 ## Error Handling
 
 - Invalid commands return error messages
-- Missing arguments return error messages  
+- Missing arguments return error messages
 - Too many arguments return error messages
 - Unknown commands return error messages
 - Network errors are logged and handled gracefully
@@ -254,6 +294,17 @@ The server implements connection limiting to prevent resource exhaustion:
 - **Graceful Handling**: Existing connections continue to work normally
 - **Logging**: Connection rejections are logged with client address for monitoring
 - **Resource Cleanup**: Connection slots are automatically released when clients disconnect
+
+## Connection Pooling (Client-side)
+
+The client supports connection pooling for distributed deployments:
+
+- **Multiple Servers**: Configure multiple server addresses with master/standby roles
+- **Automatic Failover**: Failed servers are temporarily excluded and automatically retried after a timeout
+- **Selection Strategies**: Choose how servers are selected (master_first, round_robin, random)
+- **Connection Caching**: Established connections are reused to minimize overhead
+- **Concurrent Safety**: Serialized sends prevent TCP message corruption from concurrent requests
+- **Configurable Retries**: Control retry attempts and delays for transient failures
 
 ## Logging
 

--- a/cmd/db-cli/main.go
+++ b/cmd/db-cli/main.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/OutOfStack/db/internal/client"
 	"github.com/OutOfStack/db/internal/config"
-	"github.com/OutOfStack/db/internal/network"
 )
 
 func main() {
@@ -34,21 +34,22 @@ func main() {
 		cfg.Network.IdleTimeout = timeout
 	}
 
-	client, err := network.NewTCPClient(cfg.Network.Address,
-		network.WithClientIdleTimeout(cfg.Network.IdleTimeout),
-		network.WithClientBufferSize(cfg.Network.MaxMessageSizeKB*1024),
-	)
+	dbClient, err := client.New(cfg)
 	if err != nil {
-		fmt.Printf("Failed to connect to database server at %s: %v\n", cfg.Network.Address, err)
+		fmt.Printf("Failed to connect to database server: %v\n", err)
 		os.Exit(1)
 	}
 	defer func() {
-		if err = client.Close(); err != nil {
+		if err = dbClient.Close(); err != nil {
 			fmt.Printf("Failed to close connection: %v\n", err)
 		}
 	}()
 
-	fmt.Printf("Connected to database server at %s\n", cfg.Network.Address)
+	if cfg.Pool.Enabled {
+		fmt.Printf("Connected to database pool (%d servers)\n", len(cfg.Pool.Servers))
+	} else {
+		fmt.Printf("Connected to database server at %s\n", cfg.Network.Address)
+	}
 	fmt.Println("Available commands:")
 	fmt.Println("  SET key value")
 	fmt.Println("  GET key")
@@ -72,7 +73,7 @@ func main() {
 			continue
 		}
 
-		response, sErr := client.Send([]byte(input + "\n"))
+		response, sErr := dbClient.Send([]byte(input + "\n"))
 		if sErr != nil {
 			fmt.Printf("Failed to send command: %v\n", sErr)
 			break

--- a/example-pool-config.yaml
+++ b/example-pool-config.yaml
@@ -1,0 +1,36 @@
+# Example client configuration with pool enabled
+network:
+  # This address is used when pool is disabled
+  address: "127.0.0.1:3223"
+  max_message_size: 4
+  idle_timeout: 1m
+
+pool:
+  # Enable connection pool with master/standby servers
+  enabled: true
+
+  # List of servers in the pool
+  servers:
+    - address: "127.0.0.1:3223"
+      role: master
+    - address: "127.0.0.1:3224"
+      role: master
+    - address: "127.0.0.1:3225"
+      role: standby
+    - address: "127.0.0.1:3226"
+      role: standby
+
+  # Selection strategy: master_first, round_robin, or random
+  # - master_first: Try master servers first, fall back to standby on failure
+  # - round_robin: Rotate through all servers in order
+  # - random: Pick servers randomly
+  selection_strategy: master_first
+
+  # Maximum number of retry attempts when a server fails
+  max_retries: 3
+
+  # Delay between retry attempts
+  retry_delay: 1s
+
+  # Health check period (for future use)
+  health_check_period: 10s

--- a/example-pool-config.yaml
+++ b/example-pool-config.yaml
@@ -34,3 +34,8 @@ pool:
 
   # Health check period (for future use)
   health_check_period: 10s
+
+  # Time after which failed servers are automatically retried
+  # Failed servers are temporarily excluded from the pool but will
+  # be retried after this timeout, allowing recovery from transient failures
+  failure_timeout: 30s

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -1,0 +1,18 @@
+# Example commands for the Simple DB service
+
+# Basic operations
+SET user_name John
+GET user_name
+
+# Delete and verify
+DEL user_name
+GET user_name
+
+# Special characters
+SET path/to/file.txt /home/user/documents/file.txt
+GET path/to/file.txt
+
+# Invalid commands
+SET invalid_key  # Missing value
+GET invalid_key invalid_value  # Too many args
+UNKNOWN invalid_command  # Unknown command

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/OutOfStack/db
 
-go 1.24.0
+go 1.25
 
 tool go.uber.org/mock/gomock
 
 require (
-	github.com/stretchr/testify v1.10.0
-	go.uber.org/mock v0.5.2
+	github.com/stretchr/testify v1.11.1
+	go.uber.org/mock v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golangci/golangci-lint/v2 v2.2.2 h1:vuzwYGPzDx9WqN85Fu8F8wqDSZqk8q76ypnznXk6MvM=
-github.com/golangci/golangci-lint/v2 v2.2.2/go.mod h1:F0BBgvaCGCAfnrlRQ729JSLrAJT172WwOpaQrbluz8E=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -16,10 +14,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
-go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/pool"
+)
+
+// New creates a new client based on the configuration
+// If pool is enabled, returns a pooled client; otherwise returns a single TCP client
+func New(cfg *config.ClientConfig) (network.Client, error) {
+	if cfg.Pool.Enabled {
+		// Create pooled client
+		poolClient, err := pool.NewClient(&cfg.Pool,
+			network.WithClientIdleTimeout(cfg.Network.IdleTimeout),
+			network.WithClientBufferSize(cfg.Network.MaxMessageSizeKB*1024),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create pool client: %w", err)
+		}
+		return poolClient, nil
+	}
+
+	// Create single TCP client
+	tcpClient, err := network.NewTCPClient(cfg.Network.Address,
+		network.WithClientIdleTimeout(cfg.Network.IdleTimeout),
+		network.WithClientBufferSize(cfg.Network.MaxMessageSizeKB*1024),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TCP client: %w", err)
+	}
+	return tcpClient, nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,8 @@ import (
 
 // New creates a new client based on the configuration
 // If pool is enabled, returns a pooled client; otherwise returns a single TCP client
+//
+//nolint:ireturn // Factory function intentionally returns interface
 func New(cfg *config.ClientConfig) (network.Client, error) {
 	if cfg.Pool.Enabled {
 		// Create pooled client

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -3,11 +3,14 @@ package config
 import (
 	"errors"
 	"time"
+
+	"github.com/OutOfStack/db/internal/pool"
 )
 
 // ClientConfig - configuration for the database client
 type ClientConfig struct {
 	Network ClientNetworkConfig `yaml:"network"`
+	Pool    pool.PoolConfig     `yaml:"pool"`
 }
 
 // ClientNetworkConfig - network-related configuration for the database client
@@ -27,13 +30,22 @@ func DefaultClientConfig() *ClientConfig {
 			MaxMessageSizeKB: 4,
 			IdleTimeout:      time.Minute,
 		},
+		Pool: *pool.DefaultPoolConfig(),
 	}
 }
 
 // Validate checks if the configuration values are valid
 func (c *ClientConfig) Validate() error {
-	if c.Network.Address == "" {
-		return errors.New("network address cannot be empty")
+	// If pool is enabled, validate pool config instead of single address
+	if c.Pool.Enabled {
+		if err := c.Pool.Validate(); err != nil {
+			return err
+		}
+	} else {
+		// Validate single server config
+		if c.Network.Address == "" {
+			return errors.New("network address cannot be empty")
+		}
 	}
 
 	if c.Network.MaxMessageSizeKB <= 0 {

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -21,7 +22,10 @@ type TCPClient struct {
 
 // NewTCPClient creates a new TCP client connection
 func NewTCPClient(address string, options ...TCPClientOption) (*TCPClient, error) {
-	conn, err := net.Dial("tcp", address)
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+	}
+	conn, err := dialer.DialContext(context.Background(), "tcp", address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to %s: %w", address, err)
 	}
@@ -133,7 +137,10 @@ func (tc *TCPClient) reconnect() error {
 	}
 
 	// establish new connection
-	conn, err := net.Dial("tcp", tc.address)
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+	}
+	conn, err := dialer.DialContext(context.Background(), "tcp", tc.address)
 	if err != nil {
 		return fmt.Errorf("failed to reconnect to %s: %w", tc.address, err)
 	}

--- a/internal/network/interface.go
+++ b/internal/network/interface.go
@@ -1,0 +1,9 @@
+package network
+
+// Client represents a generic database client interface
+type Client interface {
+	// Send sends data to the database server and returns the response
+	Send(data []byte) ([]byte, error)
+	// Close closes the client connection
+	Close() error
+}

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -37,7 +37,8 @@ func NewTCPServer(address string, logger *slog.Logger, options ...TCPServerOptio
 		logger = slog.Default()
 	}
 
-	listener, err := net.Listen("tcp", address)
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(context.Background(), "tcp", address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start server: %w", err)
 	}

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -1,0 +1,159 @@
+package pool
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/OutOfStack/db/internal/network"
+)
+
+// Client represents a pooled client that can connect to multiple servers
+type Client struct {
+	mu          sync.RWMutex
+	config      *PoolConfig
+	selector    ServerSelector
+	connections map[string]*network.TCPClient
+	options     []network.TCPClientOption
+}
+
+// NewClient creates a new pooled client
+func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid pool config: %w", err)
+	}
+
+	return &Client{
+		config:      config,
+		selector:    NewSelector(config),
+		connections: make(map[string]*network.TCPClient),
+		options:     options,
+	}, nil
+}
+
+// Send sends data using the pool, with automatic failover
+func (c *Client) Send(data []byte) ([]byte, error) {
+	var lastErr error
+	attempts := 0
+	maxAttempts := c.config.MaxRetries + 1 // initial attempt + retries
+
+	for attempts < maxAttempts {
+		// Select a server
+		server := c.selector.Select()
+		if server == nil {
+			// No servers available, reset and try one more time
+			c.selector.Reset()
+			server = c.selector.Select()
+			if server == nil {
+				return nil, fmt.Errorf("no servers available in pool")
+			}
+		}
+
+		// Get or create connection
+		conn, err := c.getConnection(server.Address)
+		if err != nil {
+			c.selector.MarkFailed(server.Address)
+			lastErr = err
+			attempts++
+			if attempts < maxAttempts {
+				time.Sleep(c.config.RetryDelay)
+			}
+			continue
+		}
+
+		// Try to send
+		resp, err := conn.Send(data)
+		if err != nil {
+			// Connection failed, mark server as failed and retry
+			c.selector.MarkFailed(server.Address)
+			c.removeConnection(server.Address)
+			lastErr = fmt.Errorf("failed to send to %s: %w", server.Address, err)
+			attempts++
+			if attempts < maxAttempts {
+				time.Sleep(c.config.RetryDelay)
+			}
+			continue
+		}
+
+		// Success!
+		return resp, nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("all servers failed after %d attempts: %w", attempts, lastErr)
+	}
+	return nil, fmt.Errorf("all servers failed after %d attempts", attempts)
+}
+
+// getConnection gets or creates a connection to the specified address
+func (c *Client) getConnection(address string) (*network.TCPClient, error) {
+	c.mu.RLock()
+	conn, exists := c.connections[address]
+	c.mu.RUnlock()
+
+	if exists {
+		return conn, nil
+	}
+
+	// Create new connection
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if conn, exists := c.connections[address]; exists {
+		return conn, nil
+	}
+
+	// Create new TCP client
+	newConn, err := network.NewTCPClient(address, c.options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection to %s: %w", address, err)
+	}
+
+	c.connections[address] = newConn
+	return newConn, nil
+}
+
+// removeConnection removes a connection from the pool
+func (c *Client) removeConnection(address string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if conn, exists := c.connections[address]; exists {
+		conn.Close()
+		delete(c.connections, address)
+	}
+}
+
+// Close closes all connections in the pool
+func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var lastErr error
+	for address, conn := range c.connections {
+		if err := conn.Close(); err != nil {
+			lastErr = fmt.Errorf("failed to close connection to %s: %w", address, err)
+		}
+	}
+
+	c.connections = make(map[string]*network.TCPClient)
+	return lastErr
+}
+
+// Reset resets the pool selector state
+func (c *Client) Reset() {
+	c.selector.Reset()
+}
+
+// GetActiveServers returns the addresses of servers with active connections
+func (c *Client) GetActiveServers() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	servers := make([]string, 0, len(c.connections))
+	for addr := range c.connections {
+		servers = append(servers, addr)
+	}
+	return servers
+}

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -1,6 +1,7 @@
 package pool
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -45,7 +46,7 @@ func (c *Client) Send(data []byte) ([]byte, error) {
 			c.selector.Reset()
 			server = c.selector.Select()
 			if server == nil {
-				return nil, fmt.Errorf("no servers available in pool")
+				return nil, errors.New("no servers available in pool")
 			}
 		}
 
@@ -120,7 +121,10 @@ func (c *Client) removeConnection(address string) {
 	defer c.mu.Unlock()
 
 	if conn, exists := c.connections[address]; exists {
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			// Log the error but continue with cleanup
+			_ = err
+		}
 		delete(c.connections, address)
 	}
 }

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -9,12 +9,32 @@ import (
 	"github.com/OutOfStack/db/internal/network"
 )
 
+// syncedConnection wraps a TCPClient with a mutex to serialize Send() calls
+type syncedConnection struct {
+	mu     sync.Mutex
+	client *network.TCPClient
+}
+
+// Send serializes Send() calls to prevent concurrent access corruption
+func (sc *syncedConnection) Send(data []byte) ([]byte, error) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.client.Send(data)
+}
+
+// Close closes the underlying connection
+func (sc *syncedConnection) Close() error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.client.Close()
+}
+
 // Client represents a pooled client that can connect to multiple servers
 type Client struct {
 	mu          sync.RWMutex
 	config      *PoolConfig
 	selector    ServerSelector
-	connections map[string]*network.TCPClient
+	connections map[string]*syncedConnection
 	options     []network.TCPClientOption
 }
 
@@ -27,7 +47,7 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	return &Client{
 		config:      config,
 		selector:    NewSelector(config),
-		connections: make(map[string]*network.TCPClient),
+		connections: make(map[string]*syncedConnection),
 		options:     options,
 	}, nil
 }
@@ -87,7 +107,7 @@ func (c *Client) Send(data []byte) ([]byte, error) {
 }
 
 // getConnection gets or creates a connection to the specified address
-func (c *Client) getConnection(address string) (*network.TCPClient, error) {
+func (c *Client) getConnection(address string) (*syncedConnection, error) {
 	c.mu.RLock()
 	conn, exists := c.connections[address]
 	c.mu.RUnlock()
@@ -106,13 +126,18 @@ func (c *Client) getConnection(address string) (*network.TCPClient, error) {
 	}
 
 	// Create new TCP client
-	newConn, err := network.NewTCPClient(address, c.options...)
+	tcpClient, err := network.NewTCPClient(address, c.options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection to %s: %w", address, err)
 	}
 
-	c.connections[address] = newConn
-	return newConn, nil
+	// Wrap with synchronized connection
+	syncedConn := &syncedConnection{
+		client: tcpClient,
+	}
+
+	c.connections[address] = syncedConn
+	return syncedConn, nil
 }
 
 // removeConnection removes a connection from the pool
@@ -141,7 +166,7 @@ func (c *Client) Close() error {
 		}
 	}
 
-	c.connections = make(map[string]*network.TCPClient)
+	c.connections = make(map[string]*syncedConnection)
 	return lastErr
 }
 

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -1,0 +1,127 @@
+package pool
+
+import (
+	"errors"
+	"time"
+)
+
+// ServerRole represents the role of a server in the pool
+type ServerRole string
+
+const (
+	RoleMaster  ServerRole = "master"
+	RoleStandby ServerRole = "standby"
+)
+
+// SelectionStrategy defines how servers are selected from the pool
+type SelectionStrategy string
+
+const (
+	StrategyMasterFirst SelectionStrategy = "master_first" // Try master first, fallback to standby
+	StrategyRoundRobin  SelectionStrategy = "round_robin"  // Rotate through all servers
+	StrategyRandom      SelectionStrategy = "random"       // Pick random server
+)
+
+// ServerConfig represents a single server in the pool
+type ServerConfig struct {
+	Address string     `yaml:"address"`
+	Role    ServerRole `yaml:"role"`
+}
+
+// PoolConfig represents the configuration for a connection pool
+type PoolConfig struct {
+	Enabled           bool              `yaml:"enabled"`
+	Servers           []ServerConfig    `yaml:"servers"`
+	SelectionStrategy SelectionStrategy `yaml:"selection_strategy"`
+	MaxRetries        int               `yaml:"max_retries"`
+	RetryDelay        time.Duration     `yaml:"retry_delay"`
+	HealthCheckPeriod time.Duration     `yaml:"health_check_period"`
+}
+
+// DefaultPoolConfig returns a PoolConfig with sensible defaults
+func DefaultPoolConfig() *PoolConfig {
+	return &PoolConfig{
+		Enabled:           false,
+		Servers:           []ServerConfig{},
+		SelectionStrategy: StrategyMasterFirst,
+		MaxRetries:        3,
+		RetryDelay:        time.Second,
+		HealthCheckPeriod: 10 * time.Second,
+	}
+}
+
+// Validate checks if the pool configuration is valid
+func (p *PoolConfig) Validate() error {
+	if !p.Enabled {
+		return nil
+	}
+
+	if len(p.Servers) == 0 {
+		return errors.New("pool enabled but no servers configured")
+	}
+
+	masterCount := 0
+	for i, server := range p.Servers {
+		if server.Address == "" {
+			return errors.New("server address cannot be empty")
+		}
+		if server.Role == "" {
+			return errors.New("server role cannot be empty")
+		}
+		if server.Role != RoleMaster && server.Role != RoleStandby {
+			return errors.New("server role must be 'master' or 'standby'")
+		}
+		if server.Role == RoleMaster {
+			masterCount++
+		}
+
+		// Check for duplicate addresses
+		for j := i + 1; j < len(p.Servers); j++ {
+			if server.Address == p.Servers[j].Address {
+				return errors.New("duplicate server address: " + server.Address)
+			}
+		}
+	}
+
+	if masterCount == 0 {
+		return errors.New("at least one master server is required")
+	}
+
+	if p.SelectionStrategy != StrategyMasterFirst &&
+		p.SelectionStrategy != StrategyRoundRobin &&
+		p.SelectionStrategy != StrategyRandom {
+		return errors.New("invalid selection strategy")
+	}
+
+	if p.MaxRetries < 0 {
+		return errors.New("max_retries cannot be negative")
+	}
+
+	if p.RetryDelay < 0 {
+		return errors.New("retry_delay cannot be negative")
+	}
+
+	return nil
+}
+
+// GetMasters returns all servers with master role
+func (p *PoolConfig) GetMasters() []ServerConfig {
+	masters := []ServerConfig{}
+	for _, server := range p.Servers {
+		if server.Role == RoleMaster {
+			masters = append(masters, server)
+		}
+	}
+	return masters
+}
+
+// GetStandbys returns all servers with standby role
+func (p *PoolConfig) GetStandbys() []ServerConfig {
+	standbys := []ServerConfig{}
+	for _, server := range p.Servers {
+		if server.Role == RoleStandby {
+			standbys = append(standbys, server)
+		}
+	}
+	return standbys
+}

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -36,6 +36,7 @@ type PoolConfig struct {
 	MaxRetries        int               `yaml:"max_retries"`
 	RetryDelay        time.Duration     `yaml:"retry_delay"`
 	HealthCheckPeriod time.Duration     `yaml:"health_check_period"`
+	FailureTimeout    time.Duration     `yaml:"failure_timeout"` // Time after which failed servers are retried
 }
 
 // DefaultPoolConfig returns a PoolConfig with sensible defaults
@@ -47,6 +48,7 @@ func DefaultPoolConfig() *PoolConfig {
 		MaxRetries:        3,
 		RetryDelay:        time.Second,
 		HealthCheckPeriod: 10 * time.Second,
+		FailureTimeout:    30 * time.Second, // Retry failed servers after 30 seconds
 	}
 }
 

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -60,26 +60,36 @@ func (p *PoolConfig) Validate() error {
 		return errors.New("pool enabled but no servers configured")
 	}
 
+	if err := p.validateServers(); err != nil {
+		return err
+	}
+
+	if err := p.validateStrategy(); err != nil {
+		return err
+	}
+
+	if err := p.validateRetrySettings(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateServers validates server configuration
+func (p *PoolConfig) validateServers() error {
 	masterCount := 0
 	for i, server := range p.Servers {
-		if server.Address == "" {
-			return errors.New("server address cannot be empty")
+		if err := validateServer(server); err != nil {
+			return err
 		}
-		if server.Role == "" {
-			return errors.New("server role cannot be empty")
-		}
-		if server.Role != RoleMaster && server.Role != RoleStandby {
-			return errors.New("server role must be 'master' or 'standby'")
-		}
+
 		if server.Role == RoleMaster {
 			masterCount++
 		}
 
 		// Check for duplicate addresses
-		for j := i + 1; j < len(p.Servers); j++ {
-			if server.Address == p.Servers[j].Address {
-				return errors.New("duplicate server address: " + server.Address)
-			}
+		if err := checkDuplicateAddress(server.Address, p.Servers[i+1:]); err != nil {
+			return err
 		}
 	}
 
@@ -87,12 +97,45 @@ func (p *PoolConfig) Validate() error {
 		return errors.New("at least one master server is required")
 	}
 
+	return nil
+}
+
+// validateServer validates a single server configuration
+func validateServer(server ServerConfig) error {
+	if server.Address == "" {
+		return errors.New("server address cannot be empty")
+	}
+	if server.Role == "" {
+		return errors.New("server role cannot be empty")
+	}
+	if server.Role != RoleMaster && server.Role != RoleStandby {
+		return errors.New("server role must be 'master' or 'standby'")
+	}
+	return nil
+}
+
+// checkDuplicateAddress checks if an address appears in the remaining servers
+func checkDuplicateAddress(address string, remaining []ServerConfig) error {
+	for _, server := range remaining {
+		if server.Address == address {
+			return errors.New("duplicate server address: " + address)
+		}
+	}
+	return nil
+}
+
+// validateStrategy validates the selection strategy
+func (p *PoolConfig) validateStrategy() error {
 	if p.SelectionStrategy != StrategyMasterFirst &&
 		p.SelectionStrategy != StrategyRoundRobin &&
 		p.SelectionStrategy != StrategyRandom {
 		return errors.New("invalid selection strategy")
 	}
+	return nil
+}
 
+// validateRetrySettings validates retry-related settings
+func (p *PoolConfig) validateRetrySettings() error {
 	if p.MaxRetries < 0 {
 		return errors.New("max_retries cannot be negative")
 	}

--- a/internal/pool/config_test.go
+++ b/internal/pool/config_test.go
@@ -1,0 +1,164 @@
+package pool
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPoolConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *PoolConfig
+		wantErr bool
+	}{
+		{
+			name: "disabled pool is valid",
+			config: &PoolConfig{
+				Enabled: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid pool with master and standby",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3223", Role: RoleMaster},
+					{Address: "127.0.0.1:3224", Role: RoleStandby},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+				MaxRetries:        3,
+				RetryDelay:        time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled pool with no servers",
+			config: &PoolConfig{
+				Enabled:           true,
+				Servers:           []ServerConfig{},
+				SelectionStrategy: StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with no master",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3224", Role: RoleStandby},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with empty address",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "", Role: RoleMaster},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with duplicate addresses",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3223", Role: RoleMaster},
+					{Address: "127.0.0.1:3223", Role: RoleStandby},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with invalid role",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3223", Role: "invalid"},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with invalid strategy",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3223", Role: RoleMaster},
+				},
+				SelectionStrategy: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool with negative max retries",
+			config: &PoolConfig{
+				Enabled: true,
+				Servers: []ServerConfig{
+					{Address: "127.0.0.1:3223", Role: RoleMaster},
+				},
+				SelectionStrategy: StrategyMasterFirst,
+				MaxRetries:        -1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PoolConfig.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPoolConfig_GetMasters(t *testing.T) {
+	config := &PoolConfig{
+		Servers: []ServerConfig{
+			{Address: "127.0.0.1:3223", Role: RoleMaster},
+			{Address: "127.0.0.1:3224", Role: RoleStandby},
+			{Address: "127.0.0.1:3225", Role: RoleMaster},
+		},
+	}
+
+	masters := config.GetMasters()
+	if len(masters) != 2 {
+		t.Errorf("Expected 2 masters, got %d", len(masters))
+	}
+
+	for _, m := range masters {
+		if m.Role != RoleMaster {
+			t.Errorf("Expected master role, got %s", m.Role)
+		}
+	}
+}
+
+func TestPoolConfig_GetStandbys(t *testing.T) {
+	config := &PoolConfig{
+		Servers: []ServerConfig{
+			{Address: "127.0.0.1:3223", Role: RoleMaster},
+			{Address: "127.0.0.1:3224", Role: RoleStandby},
+			{Address: "127.0.0.1:3225", Role: RoleStandby},
+		},
+	}
+
+	standbys := config.GetStandbys()
+	if len(standbys) != 2 {
+		t.Errorf("Expected 2 standbys, got %d", len(standbys))
+	}
+
+	for _, s := range standbys {
+		if s.Role != RoleStandby {
+			t.Errorf("Expected standby role, got %s", s.Role)
+		}
+	}
+}

--- a/internal/pool/config_test.go
+++ b/internal/pool/config_test.go
@@ -1,32 +1,34 @@
-package pool
+package pool_test
 
 import (
 	"testing"
 	"time"
+
+	"github.com/OutOfStack/db/internal/pool"
 )
 
 func TestPoolConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  *PoolConfig
+		config  *pool.PoolConfig
 		wantErr bool
 	}{
 		{
 			name: "disabled pool is valid",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: false,
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid pool with master and standby",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "127.0.0.1:3223", Role: RoleMaster},
-					{Address: "127.0.0.1:3224", Role: RoleStandby},
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
+					{Address: "127.0.0.1:3224", Role: pool.RoleStandby},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 				MaxRetries:        3,
 				RetryDelay:        time.Second,
 			},
@@ -34,64 +36,64 @@ func TestPoolConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "enabled pool with no servers",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled:           true,
-				Servers:           []ServerConfig{},
-				SelectionStrategy: StrategyMasterFirst,
+				Servers:           []pool.ServerConfig{},
+				SelectionStrategy: pool.StrategyMasterFirst,
 			},
 			wantErr: true,
 		},
 		{
 			name: "pool with no master",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "127.0.0.1:3224", Role: RoleStandby},
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3224", Role: pool.RoleStandby},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 			},
 			wantErr: true,
 		},
 		{
 			name: "pool with empty address",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "", Role: RoleMaster},
+				Servers: []pool.ServerConfig{
+					{Address: "", Role: pool.RoleMaster},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 			},
 			wantErr: true,
 		},
 		{
 			name: "pool with duplicate addresses",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "127.0.0.1:3223", Role: RoleMaster},
-					{Address: "127.0.0.1:3223", Role: RoleStandby},
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
+					{Address: "127.0.0.1:3223", Role: pool.RoleStandby},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 			},
 			wantErr: true,
 		},
 		{
 			name: "pool with invalid role",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
+				Servers: []pool.ServerConfig{
 					{Address: "127.0.0.1:3223", Role: "invalid"},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 			},
 			wantErr: true,
 		},
 		{
 			name: "pool with invalid strategy",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "127.0.0.1:3223", Role: RoleMaster},
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
 				},
 				SelectionStrategy: "invalid",
 			},
@@ -99,12 +101,12 @@ func TestPoolConfig_Validate(t *testing.T) {
 		},
 		{
 			name: "pool with negative max retries",
-			config: &PoolConfig{
+			config: &pool.PoolConfig{
 				Enabled: true,
-				Servers: []ServerConfig{
-					{Address: "127.0.0.1:3223", Role: RoleMaster},
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
 				},
-				SelectionStrategy: StrategyMasterFirst,
+				SelectionStrategy: pool.StrategyMasterFirst,
 				MaxRetries:        -1,
 			},
 			wantErr: true,
@@ -122,11 +124,11 @@ func TestPoolConfig_Validate(t *testing.T) {
 }
 
 func TestPoolConfig_GetMasters(t *testing.T) {
-	config := &PoolConfig{
-		Servers: []ServerConfig{
-			{Address: "127.0.0.1:3223", Role: RoleMaster},
-			{Address: "127.0.0.1:3224", Role: RoleStandby},
-			{Address: "127.0.0.1:3225", Role: RoleMaster},
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
+			{Address: "127.0.0.1:3224", Role: pool.RoleStandby},
+			{Address: "127.0.0.1:3225", Role: pool.RoleMaster},
 		},
 	}
 
@@ -136,18 +138,18 @@ func TestPoolConfig_GetMasters(t *testing.T) {
 	}
 
 	for _, m := range masters {
-		if m.Role != RoleMaster {
+		if m.Role != pool.RoleMaster {
 			t.Errorf("Expected master role, got %s", m.Role)
 		}
 	}
 }
 
 func TestPoolConfig_GetStandbys(t *testing.T) {
-	config := &PoolConfig{
-		Servers: []ServerConfig{
-			{Address: "127.0.0.1:3223", Role: RoleMaster},
-			{Address: "127.0.0.1:3224", Role: RoleStandby},
-			{Address: "127.0.0.1:3225", Role: RoleStandby},
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
+			{Address: "127.0.0.1:3224", Role: pool.RoleStandby},
+			{Address: "127.0.0.1:3225", Role: pool.RoleStandby},
 		},
 	}
 
@@ -157,7 +159,7 @@ func TestPoolConfig_GetStandbys(t *testing.T) {
 	}
 
 	for _, s := range standbys {
-		if s.Role != RoleStandby {
+		if s.Role != pool.RoleStandby {
 			t.Errorf("Expected standby role, got %s", s.Role)
 		}
 	}

--- a/internal/pool/selector.go
+++ b/internal/pool/selector.go
@@ -24,14 +24,16 @@ type MasterFirstSelector struct {
 	failedServers  map[string]time.Time
 	currentMaster  int
 	currentStandby int
+	failureTimeout time.Duration // Time after which failed servers are retried
 }
 
 // NewMasterFirstSelector creates a new master-first selector
 func NewMasterFirstSelector(config *PoolConfig) *MasterFirstSelector {
 	return &MasterFirstSelector{
-		masters:       config.GetMasters(),
-		standbys:      config.GetStandbys(),
-		failedServers: make(map[string]time.Time),
+		masters:        config.GetMasters(),
+		standbys:       config.GetStandbys(),
+		failedServers:  make(map[string]time.Time),
+		failureTimeout: config.FailureTimeout,
 	}
 }
 
@@ -80,23 +82,35 @@ func (s *MasterFirstSelector) Reset() {
 }
 
 func (s *MasterFirstSelector) isFailed(address string) bool {
-	_, failed := s.failedServers[address]
-	return failed
+	failedTime, failed := s.failedServers[address]
+	if !failed {
+		return false
+	}
+
+	// If failure timeout has passed, remove from failed list and allow retry
+	if time.Since(failedTime) >= s.failureTimeout {
+		delete(s.failedServers, address)
+		return false
+	}
+
+	return true
 }
 
 // RoundRobinSelector rotates through all servers in order
 type RoundRobinSelector struct {
-	mu            sync.RWMutex
-	servers       []ServerConfig
-	current       int
-	failedServers map[string]time.Time
+	mu             sync.RWMutex
+	servers        []ServerConfig
+	current        int
+	failedServers  map[string]time.Time
+	failureTimeout time.Duration
 }
 
 // NewRoundRobinSelector creates a new round-robin selector
 func NewRoundRobinSelector(config *PoolConfig) *RoundRobinSelector {
 	return &RoundRobinSelector{
-		servers:       config.Servers,
-		failedServers: make(map[string]time.Time),
+		servers:        config.Servers,
+		failedServers:  make(map[string]time.Time),
+		failureTimeout: config.FailureTimeout,
 	}
 }
 
@@ -137,22 +151,34 @@ func (s *RoundRobinSelector) Reset() {
 }
 
 func (s *RoundRobinSelector) isFailed(address string) bool {
-	_, failed := s.failedServers[address]
-	return failed
+	failedTime, failed := s.failedServers[address]
+	if !failed {
+		return false
+	}
+
+	// If failure timeout has passed, remove from failed list and allow retry
+	if time.Since(failedTime) >= s.failureTimeout {
+		delete(s.failedServers, address)
+		return false
+	}
+
+	return true
 }
 
 // RandomSelector picks servers randomly
 type RandomSelector struct {
-	mu            sync.RWMutex
-	servers       []ServerConfig
-	failedServers map[string]time.Time
+	mu             sync.RWMutex
+	servers        []ServerConfig
+	failedServers  map[string]time.Time
+	failureTimeout time.Duration
 }
 
 // NewRandomSelector creates a new random selector
 func NewRandomSelector(config *PoolConfig) *RandomSelector {
 	return &RandomSelector{
-		servers:       config.Servers,
-		failedServers: make(map[string]time.Time),
+		servers:        config.Servers,
+		failedServers:  make(map[string]time.Time),
+		failureTimeout: config.FailureTimeout,
 	}
 }
 
@@ -197,8 +223,18 @@ func (s *RandomSelector) Reset() {
 }
 
 func (s *RandomSelector) isFailed(address string) bool {
-	_, failed := s.failedServers[address]
-	return failed
+	failedTime, failed := s.failedServers[address]
+	if !failed {
+		return false
+	}
+
+	// If failure timeout has passed, remove from failed list and allow retry
+	if time.Since(failedTime) >= s.failureTimeout {
+		delete(s.failedServers, address)
+		return false
+	}
+
+	return true
 }
 
 // NewSelector creates a selector based on the strategy

--- a/internal/pool/selector.go
+++ b/internal/pool/selector.go
@@ -1,0 +1,217 @@
+package pool
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// ServerSelector is responsible for selecting servers from the pool
+type ServerSelector interface {
+	// Select returns the next server to use, or nil if no servers available
+	Select() *ServerConfig
+	// MarkFailed marks a server as failed
+	MarkFailed(address string)
+	// Reset resets the selector state
+	Reset()
+}
+
+// MasterFirstSelector tries master servers first, then falls back to standbys
+type MasterFirstSelector struct {
+	mu             sync.RWMutex
+	masters        []ServerConfig
+	standbys       []ServerConfig
+	failedServers  map[string]time.Time
+	currentMaster  int
+	currentStandby int
+}
+
+// NewMasterFirstSelector creates a new master-first selector
+func NewMasterFirstSelector(config *PoolConfig) *MasterFirstSelector {
+	return &MasterFirstSelector{
+		masters:       config.GetMasters(),
+		standbys:      config.GetStandbys(),
+		failedServers: make(map[string]time.Time),
+	}
+}
+
+// Select picks the next available server (master first, then standby)
+func (s *MasterFirstSelector) Select() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Try masters first
+	for i := 0; i < len(s.masters); i++ {
+		idx := (s.currentMaster + i) % len(s.masters)
+		server := &s.masters[idx]
+		if !s.isFailed(server.Address) {
+			s.currentMaster = (idx + 1) % len(s.masters)
+			return server
+		}
+	}
+
+	// Fall back to standbys
+	for i := 0; i < len(s.standbys); i++ {
+		idx := (s.currentStandby + i) % len(s.standbys)
+		server := &s.standbys[idx]
+		if !s.isFailed(server.Address) {
+			s.currentStandby = (idx + 1) % len(s.standbys)
+			return server
+		}
+	}
+
+	return nil
+}
+
+// MarkFailed marks a server as failed
+func (s *MasterFirstSelector) MarkFailed(address string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers[address] = time.Now()
+}
+
+// Reset resets the failed servers list
+func (s *MasterFirstSelector) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers = make(map[string]time.Time)
+	s.currentMaster = 0
+	s.currentStandby = 0
+}
+
+func (s *MasterFirstSelector) isFailed(address string) bool {
+	_, failed := s.failedServers[address]
+	return failed
+}
+
+// RoundRobinSelector rotates through all servers in order
+type RoundRobinSelector struct {
+	mu            sync.RWMutex
+	servers       []ServerConfig
+	current       int
+	failedServers map[string]time.Time
+}
+
+// NewRoundRobinSelector creates a new round-robin selector
+func NewRoundRobinSelector(config *PoolConfig) *RoundRobinSelector {
+	return &RoundRobinSelector{
+		servers:       config.Servers,
+		failedServers: make(map[string]time.Time),
+	}
+}
+
+// Select picks the next server in round-robin order
+func (s *RoundRobinSelector) Select() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.servers) == 0 {
+		return nil
+	}
+
+	for i := 0; i < len(s.servers); i++ {
+		idx := (s.current + i) % len(s.servers)
+		server := &s.servers[idx]
+		if !s.isFailed(server.Address) {
+			s.current = (idx + 1) % len(s.servers)
+			return server
+		}
+	}
+
+	return nil
+}
+
+// MarkFailed marks a server as failed
+func (s *RoundRobinSelector) MarkFailed(address string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers[address] = time.Now()
+}
+
+// Reset resets the failed servers list
+func (s *RoundRobinSelector) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers = make(map[string]time.Time)
+	s.current = 0
+}
+
+func (s *RoundRobinSelector) isFailed(address string) bool {
+	_, failed := s.failedServers[address]
+	return failed
+}
+
+// RandomSelector picks servers randomly
+type RandomSelector struct {
+	mu            sync.RWMutex
+	servers       []ServerConfig
+	failedServers map[string]time.Time
+	rnd           *rand.Rand
+}
+
+// NewRandomSelector creates a new random selector
+func NewRandomSelector(config *PoolConfig) *RandomSelector {
+	return &RandomSelector{
+		servers:       config.Servers,
+		failedServers: make(map[string]time.Time),
+		rnd:           rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Select picks a random available server
+func (s *RandomSelector) Select() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.servers) == 0 {
+		return nil
+	}
+
+	// Get available servers
+	available := []int{}
+	for i := range s.servers {
+		if !s.isFailed(s.servers[i].Address) {
+			available = append(available, i)
+		}
+	}
+
+	if len(available) == 0 {
+		return nil
+	}
+
+	idx := available[s.rnd.Intn(len(available))]
+	return &s.servers[idx]
+}
+
+// MarkFailed marks a server as failed
+func (s *RandomSelector) MarkFailed(address string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers[address] = time.Now()
+}
+
+// Reset resets the failed servers list
+func (s *RandomSelector) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failedServers = make(map[string]time.Time)
+}
+
+func (s *RandomSelector) isFailed(address string) bool {
+	_, failed := s.failedServers[address]
+	return failed
+}
+
+// NewSelector creates a selector based on the strategy
+func NewSelector(config *PoolConfig) ServerSelector {
+	switch config.SelectionStrategy {
+	case StrategyMasterFirst:
+		return NewMasterFirstSelector(config)
+	case StrategyRoundRobin:
+		return NewRoundRobinSelector(config)
+	case StrategyRandom:
+		return NewRandomSelector(config)
+	default:
+		return NewMasterFirstSelector(config)
+	}
+}

--- a/internal/pool/selector.go
+++ b/internal/pool/selector.go
@@ -1,7 +1,7 @@
 package pool
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
@@ -41,7 +41,7 @@ func (s *MasterFirstSelector) Select() *ServerConfig {
 	defer s.mu.Unlock()
 
 	// Try masters first
-	for i := 0; i < len(s.masters); i++ {
+	for i := range len(s.masters) {
 		idx := (s.currentMaster + i) % len(s.masters)
 		server := &s.masters[idx]
 		if !s.isFailed(server.Address) {
@@ -51,7 +51,7 @@ func (s *MasterFirstSelector) Select() *ServerConfig {
 	}
 
 	// Fall back to standbys
-	for i := 0; i < len(s.standbys); i++ {
+	for i := range len(s.standbys) {
 		idx := (s.currentStandby + i) % len(s.standbys)
 		server := &s.standbys[idx]
 		if !s.isFailed(server.Address) {
@@ -109,7 +109,7 @@ func (s *RoundRobinSelector) Select() *ServerConfig {
 		return nil
 	}
 
-	for i := 0; i < len(s.servers); i++ {
+	for i := range len(s.servers) {
 		idx := (s.current + i) % len(s.servers)
 		server := &s.servers[idx]
 		if !s.isFailed(server.Address) {
@@ -146,7 +146,6 @@ type RandomSelector struct {
 	mu            sync.RWMutex
 	servers       []ServerConfig
 	failedServers map[string]time.Time
-	rnd           *rand.Rand
 }
 
 // NewRandomSelector creates a new random selector
@@ -154,7 +153,6 @@ func NewRandomSelector(config *PoolConfig) *RandomSelector {
 	return &RandomSelector{
 		servers:       config.Servers,
 		failedServers: make(map[string]time.Time),
-		rnd:           rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -179,7 +177,8 @@ func (s *RandomSelector) Select() *ServerConfig {
 		return nil
 	}
 
-	idx := available[s.rnd.Intn(len(available))]
+	//nolint:gosec // Non-cryptographic random is sufficient for server selection
+	idx := available[rand.IntN(len(available))]
 	return &s.servers[idx]
 }
 
@@ -203,6 +202,8 @@ func (s *RandomSelector) isFailed(address string) bool {
 }
 
 // NewSelector creates a selector based on the strategy
+//
+//nolint:ireturn // Factory function intentionally returns interface
 func NewSelector(config *PoolConfig) ServerSelector {
 	switch config.SelectionStrategy {
 	case StrategyMasterFirst:

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -72,7 +72,7 @@ func TestRoundRobinSelector(t *testing.T) {
 
 	// Track which servers we get
 	seen := make(map[string]int)
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		server := selector.Select()
 		if server == nil {
 			t.Fatal("Expected server, got nil")
@@ -101,7 +101,7 @@ func TestRandomSelector(t *testing.T) {
 	selector := NewRandomSelector(config)
 
 	// Select multiple times and ensure we get valid servers
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		server := selector.Select()
 		if server == nil {
 			t.Fatal("Expected server, got nil")
@@ -124,7 +124,7 @@ func TestRandomSelector(t *testing.T) {
 	selector.MarkFailed("server2")
 
 	// Should always return server3 now
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		server := selector.Select()
 		if server == nil {
 			t.Fatal("Expected server3, got nil")

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -2,6 +2,7 @@ package pool_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/OutOfStack/db/internal/pool"
 )
@@ -14,6 +15,7 @@ func TestMasterFirstSelector(t *testing.T) {
 			{Address: "standby1", Role: pool.RoleStandby},
 			{Address: "standby2", Role: pool.RoleStandby},
 		},
+		FailureTimeout: time.Hour, // Long timeout for tests
 	}
 
 	selector := pool.NewMasterFirstSelector(config)
@@ -68,6 +70,7 @@ func TestRoundRobinSelector(t *testing.T) {
 			{Address: "server2", Role: pool.RoleStandby},
 			{Address: "server3", Role: pool.RoleMaster},
 		},
+		FailureTimeout: time.Hour, // Long timeout for tests
 	}
 
 	selector := pool.NewRoundRobinSelector(config)
@@ -98,6 +101,7 @@ func TestRandomSelector(t *testing.T) {
 			{Address: "server2", Role: pool.RoleStandby},
 			{Address: "server3", Role: pool.RoleMaster},
 		},
+		FailureTimeout: time.Hour, // Long timeout for tests
 	}
 
 	selector := pool.NewRandomSelector(config)
@@ -172,6 +176,7 @@ func TestNewSelector(t *testing.T) {
 					{Address: "server1", Role: pool.RoleMaster},
 				},
 				SelectionStrategy: tt.strategy,
+				FailureTimeout:    time.Hour, // Long timeout for tests
 			}
 
 			selector := pool.NewSelector(config)

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -1,0 +1,197 @@
+package pool
+
+import (
+	"testing"
+)
+
+func TestMasterFirstSelector(t *testing.T) {
+	config := &PoolConfig{
+		Servers: []ServerConfig{
+			{Address: "master1", Role: RoleMaster},
+			{Address: "master2", Role: RoleMaster},
+			{Address: "standby1", Role: RoleStandby},
+			{Address: "standby2", Role: RoleStandby},
+		},
+	}
+
+	selector := NewMasterFirstSelector(config)
+
+	// First select should return a master
+	server := selector.Select()
+	if server == nil {
+		t.Fatal("Expected server, got nil")
+	}
+	if server.Role != RoleMaster {
+		t.Errorf("Expected master, got %s", server.Role)
+	}
+
+	// Mark all masters as failed
+	selector.MarkFailed("master1")
+	selector.MarkFailed("master2")
+
+	// Should fall back to standby
+	server = selector.Select()
+	if server == nil {
+		t.Fatal("Expected standby server, got nil")
+	}
+	if server.Role != RoleStandby {
+		t.Errorf("Expected standby, got %s", server.Role)
+	}
+
+	// Mark all standbys as failed
+	selector.MarkFailed("standby1")
+	selector.MarkFailed("standby2")
+
+	// Should return nil when all servers failed
+	server = selector.Select()
+	if server != nil {
+		t.Errorf("Expected nil when all servers failed, got %v", server)
+	}
+
+	// Reset should clear failures
+	selector.Reset()
+	server = selector.Select()
+	if server == nil {
+		t.Fatal("Expected server after reset, got nil")
+	}
+	if server.Role != RoleMaster {
+		t.Errorf("Expected master after reset, got %s", server.Role)
+	}
+}
+
+func TestRoundRobinSelector(t *testing.T) {
+	config := &PoolConfig{
+		Servers: []ServerConfig{
+			{Address: "server1", Role: RoleMaster},
+			{Address: "server2", Role: RoleStandby},
+			{Address: "server3", Role: RoleMaster},
+		},
+	}
+
+	selector := NewRoundRobinSelector(config)
+
+	// Track which servers we get
+	seen := make(map[string]int)
+	for i := 0; i < 6; i++ {
+		server := selector.Select()
+		if server == nil {
+			t.Fatal("Expected server, got nil")
+		}
+		seen[server.Address]++
+	}
+
+	// Each server should be selected twice in round-robin
+	for _, count := range seen {
+		if count != 2 {
+			t.Errorf("Expected each server to be selected 2 times, got %v", seen)
+			break
+		}
+	}
+}
+
+func TestRandomSelector(t *testing.T) {
+	config := &PoolConfig{
+		Servers: []ServerConfig{
+			{Address: "server1", Role: RoleMaster},
+			{Address: "server2", Role: RoleStandby},
+			{Address: "server3", Role: RoleMaster},
+		},
+	}
+
+	selector := NewRandomSelector(config)
+
+	// Select multiple times and ensure we get valid servers
+	for i := 0; i < 10; i++ {
+		server := selector.Select()
+		if server == nil {
+			t.Fatal("Expected server, got nil")
+		}
+		// Verify it's one of our configured servers
+		found := false
+		for _, s := range config.Servers {
+			if s.Address == server.Address {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Selected server %s not in config", server.Address)
+		}
+	}
+
+	// Mark all but one server as failed
+	selector.MarkFailed("server1")
+	selector.MarkFailed("server2")
+
+	// Should always return server3 now
+	for i := 0; i < 5; i++ {
+		server := selector.Select()
+		if server == nil {
+			t.Fatal("Expected server3, got nil")
+		}
+		if server.Address != "server3" {
+			t.Errorf("Expected server3, got %s", server.Address)
+		}
+	}
+}
+
+func TestNewSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy SelectionStrategy
+		wantType string
+	}{
+		{
+			name:     "master first strategy",
+			strategy: StrategyMasterFirst,
+			wantType: "*pool.MasterFirstSelector",
+		},
+		{
+			name:     "round robin strategy",
+			strategy: StrategyRoundRobin,
+			wantType: "*pool.RoundRobinSelector",
+		},
+		{
+			name:     "random strategy",
+			strategy: StrategyRandom,
+			wantType: "*pool.RandomSelector",
+		},
+		{
+			name:     "default to master first",
+			strategy: "invalid",
+			wantType: "*pool.MasterFirstSelector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &PoolConfig{
+				Servers: []ServerConfig{
+					{Address: "server1", Role: RoleMaster},
+				},
+				SelectionStrategy: tt.strategy,
+			}
+
+			selector := NewSelector(config)
+			if selector == nil {
+				t.Fatal("Expected selector, got nil")
+			}
+
+			// Type assertion to verify correct selector type
+			switch tt.wantType {
+			case "*pool.MasterFirstSelector":
+				if _, ok := selector.(*MasterFirstSelector); !ok {
+					t.Errorf("Expected MasterFirstSelector, got %T", selector)
+				}
+			case "*pool.RoundRobinSelector":
+				if _, ok := selector.(*RoundRobinSelector); !ok {
+					t.Errorf("Expected RoundRobinSelector, got %T", selector)
+				}
+			case "*pool.RandomSelector":
+				if _, ok := selector.(*RandomSelector); !ok {
+					t.Errorf("Expected RandomSelector, got %T", selector)
+				}
+			}
+		})
+	}
+}

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -1,27 +1,29 @@
-package pool
+package pool_test
 
 import (
 	"testing"
+
+	"github.com/OutOfStack/db/internal/pool"
 )
 
 func TestMasterFirstSelector(t *testing.T) {
-	config := &PoolConfig{
-		Servers: []ServerConfig{
-			{Address: "master1", Role: RoleMaster},
-			{Address: "master2", Role: RoleMaster},
-			{Address: "standby1", Role: RoleStandby},
-			{Address: "standby2", Role: RoleStandby},
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "master1", Role: pool.RoleMaster},
+			{Address: "master2", Role: pool.RoleMaster},
+			{Address: "standby1", Role: pool.RoleStandby},
+			{Address: "standby2", Role: pool.RoleStandby},
 		},
 	}
 
-	selector := NewMasterFirstSelector(config)
+	selector := pool.NewMasterFirstSelector(config)
 
 	// First select should return a master
 	server := selector.Select()
 	if server == nil {
 		t.Fatal("Expected server, got nil")
 	}
-	if server.Role != RoleMaster {
+	if server.Role != pool.RoleMaster {
 		t.Errorf("Expected master, got %s", server.Role)
 	}
 
@@ -34,7 +36,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	if server == nil {
 		t.Fatal("Expected standby server, got nil")
 	}
-	if server.Role != RoleStandby {
+	if server.Role != pool.RoleStandby {
 		t.Errorf("Expected standby, got %s", server.Role)
 	}
 
@@ -54,21 +56,21 @@ func TestMasterFirstSelector(t *testing.T) {
 	if server == nil {
 		t.Fatal("Expected server after reset, got nil")
 	}
-	if server.Role != RoleMaster {
+	if server.Role != pool.RoleMaster {
 		t.Errorf("Expected master after reset, got %s", server.Role)
 	}
 }
 
 func TestRoundRobinSelector(t *testing.T) {
-	config := &PoolConfig{
-		Servers: []ServerConfig{
-			{Address: "server1", Role: RoleMaster},
-			{Address: "server2", Role: RoleStandby},
-			{Address: "server3", Role: RoleMaster},
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "server1", Role: pool.RoleMaster},
+			{Address: "server2", Role: pool.RoleStandby},
+			{Address: "server3", Role: pool.RoleMaster},
 		},
 	}
 
-	selector := NewRoundRobinSelector(config)
+	selector := pool.NewRoundRobinSelector(config)
 
 	// Track which servers we get
 	seen := make(map[string]int)
@@ -90,15 +92,15 @@ func TestRoundRobinSelector(t *testing.T) {
 }
 
 func TestRandomSelector(t *testing.T) {
-	config := &PoolConfig{
-		Servers: []ServerConfig{
-			{Address: "server1", Role: RoleMaster},
-			{Address: "server2", Role: RoleStandby},
-			{Address: "server3", Role: RoleMaster},
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "server1", Role: pool.RoleMaster},
+			{Address: "server2", Role: pool.RoleStandby},
+			{Address: "server3", Role: pool.RoleMaster},
 		},
 	}
 
-	selector := NewRandomSelector(config)
+	selector := pool.NewRandomSelector(config)
 
 	// Select multiple times and ensure we get valid servers
 	for range 10 {
@@ -138,22 +140,22 @@ func TestRandomSelector(t *testing.T) {
 func TestNewSelector(t *testing.T) {
 	tests := []struct {
 		name     string
-		strategy SelectionStrategy
+		strategy pool.SelectionStrategy
 		wantType string
 	}{
 		{
 			name:     "master first strategy",
-			strategy: StrategyMasterFirst,
+			strategy: pool.StrategyMasterFirst,
 			wantType: "*pool.MasterFirstSelector",
 		},
 		{
 			name:     "round robin strategy",
-			strategy: StrategyRoundRobin,
+			strategy: pool.StrategyRoundRobin,
 			wantType: "*pool.RoundRobinSelector",
 		},
 		{
 			name:     "random strategy",
-			strategy: StrategyRandom,
+			strategy: pool.StrategyRandom,
 			wantType: "*pool.RandomSelector",
 		},
 		{
@@ -165,14 +167,14 @@ func TestNewSelector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := &PoolConfig{
-				Servers: []ServerConfig{
-					{Address: "server1", Role: RoleMaster},
+			config := &pool.PoolConfig{
+				Servers: []pool.ServerConfig{
+					{Address: "server1", Role: pool.RoleMaster},
 				},
 				SelectionStrategy: tt.strategy,
 			}
 
-			selector := NewSelector(config)
+			selector := pool.NewSelector(config)
 			if selector == nil {
 				t.Fatal("Expected selector, got nil")
 			}
@@ -180,15 +182,15 @@ func TestNewSelector(t *testing.T) {
 			// Type assertion to verify correct selector type
 			switch tt.wantType {
 			case "*pool.MasterFirstSelector":
-				if _, ok := selector.(*MasterFirstSelector); !ok {
+				if _, ok := selector.(*pool.MasterFirstSelector); !ok {
 					t.Errorf("Expected MasterFirstSelector, got %T", selector)
 				}
 			case "*pool.RoundRobinSelector":
-				if _, ok := selector.(*RoundRobinSelector); !ok {
+				if _, ok := selector.(*pool.RoundRobinSelector); !ok {
 					t.Errorf("Expected RoundRobinSelector, got %T", selector)
 				}
 			case "*pool.RandomSelector":
-				if _, ok := selector.(*RandomSelector); !ok {
+				if _, ok := selector.(*pool.RandomSelector); !ok {
 					t.Errorf("Expected RandomSelector, got %T", selector)
 				}
 			}


### PR DESCRIPTION
Implemented a connection pool system that allows the database client to connect to multiple servers with automatic failover support. This enables high availability by supporting master and standby server configurations.

Features:
- Pool configuration with server roles (master/standby)
- Multiple server selection strategies:
  * master_first: Prioritize master servers, fallback to standby
  * round_robin: Rotate through all servers
  * random: Random server selection
- Automatic failover when servers become unavailable
- Configurable retry logic with delays
- Connection pooling and management
- Backward compatible: single server mode still works when pool is disabled

New components:
- internal/pool: Pool management, server selection, and configuration
- internal/client: Unified client factory for pool and single connections
- internal/network/interface.go: Common Client interface

Configuration:
- Extended ClientConfig with pool settings
- Example configuration in example-pool-config.yaml
- Pool can be enabled/disabled via config