### PR TITLE
feat(protocol)!: replace text protocol with RESP2 framing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ db-cli
 requirements
 .claude/
 CLAUDE.MD
+AGENTS.md
+/docs/plans
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
     - makezero
     - mirror
     - misspell
+    - modernize
     - musttag
     - nakedret
     - nestif
@@ -94,6 +95,8 @@ linters:
     - whitespace
     - zerologlint
   settings:
+    exhaustive:
+      default-signifies-exhaustive: true
     goconst:
       min-len: 3
       min-occurrences: 2

--- a/client/client.go
+++ b/client/client.go
@@ -13,16 +13,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/OutOfStack/db/internal/network"
 	"github.com/OutOfStack/db/internal/pool"
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
 const (
-	respOK       = "OK"
-	respNotFound = "not found"
+	respOK = "OK"
 
 	// maxTableNameLen mirrors the server-side parser limit so invalid
 	// table names are rejected before reaching the wire
@@ -32,7 +32,7 @@ const (
 // transport is the minimal connection interface the client needs.
 // Satisfied by *network.TCPClient and *pool.Client
 type transport interface {
-	Send(data []byte) ([]byte, error)
+	Send(cmd string, args []string) (protocol.Reply, error)
 	Close() error
 }
 
@@ -53,7 +53,7 @@ func New(opts ...Option) (*Client, error) {
 
 	netOpts := []network.TCPClientOption{
 		network.WithClientIdleTimeout(o.idleTimeout),
-		network.WithClientBufferSize(o.maxMessageSizeKB * 1024),
+		network.WithClientMaxMessageSize(o.maxMessageSizeKB * 1024),
 	}
 
 	if len(o.servers) > 0 {
@@ -88,37 +88,44 @@ func (c *Client) Set(ctx context.Context, table, key, value string) error {
 		return err
 	}
 
-	resp, err := c.send(ctx, "SET "+table+" "+key+" "+value)
+	resp, err := c.send(ctx, "SET", []string{table, key, value})
 	if err != nil {
 		return err
 	}
-	if resp != respOK {
-		return &ServerError{Msg: resp}
+	switch resp.Kind {
+	case protocol.ReplySimpleString:
+		if resp.Value == respOK {
+			return nil
+		}
+		return &ServerError{Msg: replyText(resp)}
+	case protocol.ReplyError:
+		return &ServerError{Msg: resp.Value}
+	default:
+		return &ServerError{Msg: replyText(resp)}
 	}
-	return nil
 }
 
 // Get returns the value stored under key in table.
 // Returns ErrNotFound if the key does not exist.
-//
-// Limitation: the current text protocol does not mark error responses, so a
-// stored value literally equal to "not found" is indistinguishable from a
-// missing key. Client-side validation rules out all other known server
-// errors for well-formed calls; a future protocol revision with framed
-// responses will remove the ambiguity entirely
 func (c *Client) Get(ctx context.Context, table, key string) (string, error) {
 	if err := validateArgs(table, key); err != nil {
 		return "", err
 	}
 
-	resp, err := c.send(ctx, "GET "+table+" "+key)
+	resp, err := c.send(ctx, "GET", []string{table, key})
 	if err != nil {
 		return "", err
 	}
-	if resp == respNotFound {
+	switch resp.Kind {
+	case protocol.ReplyBulkString, protocol.ReplySimpleString:
+		return resp.Value, nil
+	case protocol.ReplyNull:
 		return "", ErrNotFound
+	case protocol.ReplyError:
+		return "", &ServerError{Msg: resp.Value}
+	default:
+		return "", &ServerError{Msg: replyText(resp)}
 	}
-	return resp, nil
 }
 
 // Del deletes key from table.
@@ -128,34 +135,41 @@ func (c *Client) Del(ctx context.Context, table, key string) error {
 		return err
 	}
 
-	resp, err := c.send(ctx, "DEL "+table+" "+key)
+	resp, err := c.send(ctx, "DEL", []string{table, key})
 	if err != nil {
 		return err
 	}
-	switch resp {
-	case respOK:
-		return nil
-	case respNotFound:
+	switch resp.Kind {
+	case protocol.ReplySimpleString:
+		if resp.Value == respOK {
+			return nil
+		}
+		return &ServerError{Msg: replyText(resp)}
+	case protocol.ReplyNull:
 		return ErrNotFound
+	case protocol.ReplyError:
+		return &ServerError{Msg: resp.Value}
 	default:
-		return &ServerError{Msg: resp}
+		return &ServerError{Msg: replyText(resp)}
 	}
 }
 
 // Raw sends a raw command line to the server and returns the response text
 // as is, without error mapping. It gives access to commands that have no
-// typed wrapper yet
+// typed wrapper yet.
 func (c *Client) Raw(ctx context.Context, command string) (string, error) {
-	command = strings.TrimSpace(command)
-	if command == "" {
+	parts, err := splitCommandLine(command)
+	if err != nil {
+		return "", err
+	}
+	if len(parts) == 0 {
 		return "", errors.New("empty command")
 	}
-	// the protocol is line-oriented: embedded newlines would smuggle extra
-	// commands into the payload and desynchronize the connection
-	if strings.ContainsAny(command, "\r\n") {
-		return "", errors.New("command cannot contain newline characters")
+	resp, err := c.send(ctx, parts[0], parts[1:])
+	if err != nil {
+		return "", err
 	}
-	return c.send(ctx, command)
+	return replyText(resp), nil
 }
 
 // Close closes the client connection(s)
@@ -163,36 +177,130 @@ func (c *Client) Close() error {
 	return c.transport.Close()
 }
 
-// send sends a command line to the server and returns the trimmed response
-func (c *Client) send(ctx context.Context, command string) (string, error) {
+// send sends a command to the server and returns a typed response.
+func (c *Client) send(ctx context.Context, cmd string, args []string) (protocol.Reply, error) {
 	// the current transport cannot honor cancellation mid-call,
 	// so check the context before sending
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return protocol.Reply{}, err
 	}
 
-	resp, err := c.transport.Send([]byte(command + "\n"))
+	resp, err := c.transport.Send(cmd, args)
 	if err != nil {
-		return "", fmt.Errorf("failed to send command: %w", err)
+		return protocol.Reply{}, fmt.Errorf("failed to send command: %w", err)
 	}
-	return strings.TrimSpace(string(resp)), nil
+	return resp, nil
 }
 
-// validateArgs checks that the table name and remaining arguments can be
-// carried by the whitespace-delimited text protocol
+func replyText(reply protocol.Reply) string {
+	switch reply.Kind {
+	case protocol.ReplySimpleString, protocol.ReplyBulkString, protocol.ReplyError:
+		return reply.Value
+	case protocol.ReplyNull:
+		return "not found"
+	case protocol.ReplyInteger:
+		return strconv.FormatInt(reply.Integer, 10)
+	case protocol.ReplyArray:
+		values := make([]string, 0, len(reply.Array))
+		for _, item := range reply.Array {
+			values = append(values, replyText(item))
+		}
+		return strings.Join(values, "\n")
+	default:
+		return ""
+	}
+}
+
+// validateArgs checks command arguments that are still constrained by database
+// semantics. RESP framing itself can carry whitespace, newlines, and NUL bytes.
 func validateArgs(table string, args ...string) error {
+	if table == "" {
+		return errors.New("table cannot be empty")
+	}
 	if len(table) > maxTableNameLen {
 		return fmt.Errorf("table name exceeds %d characters", maxTableNameLen)
 	}
-	for _, arg := range append([]string{table}, args...) {
-		if arg == "" {
-			return errors.New("argument cannot be empty")
-		}
-		if strings.ContainsFunc(arg, unicode.IsSpace) {
-			return fmt.Errorf("argument %q cannot contain whitespace", arg)
-		}
+	if len(args) > 0 && args[0] == "" {
+		return errors.New("key cannot be empty")
 	}
 	return nil
+}
+
+func splitCommandLine(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, nil
+	}
+
+	var parts []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	inToken := false
+
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(unescape(r))
+			escaped = false
+			inToken = true
+			continue
+		}
+
+		if r == '\\' {
+			escaped = true
+			inToken = true
+			continue
+		}
+
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+			inToken = true
+			continue
+		}
+
+		switch r {
+		case '\'', '"':
+			quote = r
+			inToken = true
+		case ' ', '\t', '\r', '\n':
+			if inToken {
+				parts = append(parts, current.String())
+				current.Reset()
+				inToken = false
+			}
+		default:
+			current.WriteRune(r)
+			inToken = true
+		}
+	}
+
+	if escaped {
+		return nil, errors.New("unfinished escape sequence")
+	}
+	if quote != 0 {
+		return nil, errors.New("unterminated quoted string")
+	}
+	if inToken {
+		parts = append(parts, current.String())
+	}
+	return parts, nil
+}
+
+func unescape(r rune) rune {
+	switch r {
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	default:
+		return r
+	}
 }
 
 // toPoolServers converts public Server values to pool config entries

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,26 +3,33 @@ package client_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/OutOfStack/db/client"
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
-// fakeTransport records sent data and returns a canned response
+type sentCommand struct {
+	cmd  string
+	args []string
+}
+
+// fakeTransport records sent commands and returns a canned response
 type fakeTransport struct {
-	resp   string
+	resp   protocol.Reply
 	err    error
-	sent   []string
+	sent   []sentCommand
 	closed bool
 }
 
-func (f *fakeTransport) Send(data []byte) ([]byte, error) {
-	f.sent = append(f.sent, string(data))
+func (f *fakeTransport) Send(cmd string, args []string) (protocol.Reply, error) {
+	f.sent = append(f.sent, sentCommand{cmd: cmd, args: append([]string(nil), args...)})
 	if f.err != nil {
-		return nil, f.err
+		return protocol.Reply{}, f.err
 	}
-	return []byte(f.resp), nil
+	return f.resp, nil
 }
 
 func (f *fakeTransport) Close() error {
@@ -35,15 +42,15 @@ func TestClient_Set(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		resp      string
+		resp      protocol.Reply
 		sendErr   error
-		wantSent  string
 		wantErr   bool
 		wantSrvEr bool
 	}{
-		{"ok", "OK", nil, "SET users name vlad\n", false, false},
-		{"server error", "table name too long", nil, "SET users name vlad\n", true, true},
-		{"transport error", "", errors.New("conn refused"), "SET users name vlad\n", true, false},
+		{"ok", protocol.SimpleString("OK"), nil, false, false},
+		{"server error", protocol.Error("table name too long"), nil, true, true},
+		{"unexpected response", protocol.BulkString("weird"), nil, true, true},
+		{"transport error", protocol.Reply{}, errors.New("conn refused"), true, false},
 	}
 
 	for _, tt := range tests {
@@ -61,8 +68,9 @@ func TestClient_Set(t *testing.T) {
 			if errors.As(err, &srvErr) != tt.wantSrvEr {
 				t.Errorf("Set() ServerError = %v, want %v", err, tt.wantSrvEr)
 			}
-			if len(ft.sent) != 1 || ft.sent[0] != tt.wantSent {
-				t.Errorf("sent = %q, want %q", ft.sent, tt.wantSent)
+			wantSent := []sentCommand{{cmd: "SET", args: []string{"users", "name", "vlad"}}}
+			if !reflect.DeepEqual(ft.sent, wantSent) {
+				t.Errorf("sent = %#v, want %#v", ft.sent, wantSent)
 			}
 		})
 	}
@@ -73,13 +81,14 @@ func TestClient_Get(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		resp    string
+		resp    protocol.Reply
 		want    string
 		wantErr error
 	}{
-		{"value", "vlad", "vlad", nil},
-		{"value with trailing newline", "vlad\n", "vlad", nil},
-		{"not found", "not found", "", client.ErrNotFound},
+		{"value", protocol.BulkString("vlad"), "vlad", nil},
+		{"value with trailing newline", protocol.BulkString("vlad\n"), "vlad\n", nil},
+		{"not found", protocol.NullBulkString(), "", client.ErrNotFound},
+		{"server error", protocol.Error("bad"), "", nil},
 	}
 
 	for _, tt := range tests {
@@ -89,6 +98,12 @@ func TestClient_Get(t *testing.T) {
 			c := client.NewWithTransport(&fakeTransport{resp: tt.resp})
 
 			got, err := c.Get(t.Context(), "users", "name")
+			if tt.resp.Kind == protocol.ReplyError {
+				if _, ok := errors.AsType[*client.ServerError](err); !ok {
+					t.Fatalf("Get() error = %v, want ServerError", err)
+				}
+				return
+			}
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("Get() error = %v, want %v", err, tt.wantErr)
 			}
@@ -104,13 +119,14 @@ func TestClient_Del(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		resp      string
+		resp      protocol.Reply
 		wantErr   error
 		wantSrvEr bool
 	}{
-		{"ok", "OK", nil, false},
-		{"not found", "not found", client.ErrNotFound, false},
-		{"server error", "some error", nil, true},
+		{"ok", protocol.SimpleString("OK"), nil, false},
+		{"not found", protocol.NullBulkString(), client.ErrNotFound, false},
+		{"server error", protocol.Error("some error"), nil, true},
+		{"unexpected response", protocol.BulkString("some error"), nil, true},
 	}
 
 	for _, tt := range tests {
@@ -140,40 +156,49 @@ func TestClient_Del(t *testing.T) {
 func TestClient_Raw(t *testing.T) {
 	t.Parallel()
 
-	ft := &fakeTransport{resp: "not found\n"}
+	ft := &fakeTransport{resp: protocol.NullBulkString()}
 	c := client.NewWithTransport(ft)
 
 	// Raw passes the response through without error mapping
-	got, err := c.Raw(t.Context(), "GET users missing")
+	got, err := c.Raw(t.Context(), `GET users "missing key"`)
 	if err != nil {
 		t.Fatalf("Raw() error = %v", err)
 	}
 	if got != "not found" {
 		t.Errorf("Raw() = %q, want %q", got, "not found")
 	}
-	if ft.sent[0] != "GET users missing\n" {
-		t.Errorf("sent = %q, want %q", ft.sent[0], "GET users missing\n")
+	wantSent := []sentCommand{{cmd: "GET", args: []string{"users", "missing key"}}}
+	if !reflect.DeepEqual(ft.sent, wantSent) {
+		t.Errorf("sent = %#v, want %#v", ft.sent, wantSent)
+	}
+
+	ft.resp = protocol.BulkString("hello\nworld")
+	got, err = c.Raw(t.Context(), `GET users hello\nworld`)
+	if err != nil {
+		t.Fatalf("Raw() with escape error = %v", err)
+	}
+	if got != "hello\nworld" {
+		t.Errorf("Raw() escaped response = %q, want newline value", got)
 	}
 
 	if _, err = c.Raw(t.Context(), "   "); err == nil {
 		t.Error("Raw() with empty command should fail")
 	}
-	if _, err = c.Raw(t.Context(), "SET t k v\nDEL t k"); err == nil {
-		t.Error("Raw() with embedded newline should fail")
+	if _, err = c.Raw(t.Context(), `SET t k "unterminated`); err == nil {
+		t.Error("Raw() with unterminated quote should fail")
 	}
-	// trailing newlines are trimmed, only embedded ones are rejected
-	if _, err = c.Raw(t.Context(), "GET t\rk"); err == nil {
-		t.Error("Raw() with embedded carriage return should fail")
+	if _, err = c.Raw(t.Context(), `SET t k trailing\`); err == nil {
+		t.Error("Raw() with unfinished escape should fail")
 	}
-	if len(ft.sent) != 1 {
-		t.Errorf("rejected commands must not reach the transport, sent: %q", ft.sent)
+	if len(ft.sent) != 2 {
+		t.Errorf("rejected commands must not reach the transport, sent: %#v", ft.sent)
 	}
 }
 
 func TestClient_ArgValidation(t *testing.T) {
 	t.Parallel()
 
-	ft := &fakeTransport{resp: "OK"}
+	ft := &fakeTransport{resp: protocol.SimpleString("OK")}
 	c := client.NewWithTransport(ft)
 
 	tests := []struct {
@@ -182,10 +207,6 @@ func TestClient_ArgValidation(t *testing.T) {
 	}{
 		{"empty table", func() error { return c.Set(t.Context(), "", "k", "v") }},
 		{"empty key", func() error { _, err := c.Get(t.Context(), "t", ""); return err }},
-		{"key with space", func() error { return c.Del(t.Context(), "t", "a b") }},
-		{"value with space", func() error { return c.Set(t.Context(), "t", "k", "a b") }},
-		{"value with tab", func() error { return c.Set(t.Context(), "t", "k", "a\tb") }},
-		{"value with newline", func() error { return c.Set(t.Context(), "t", "k", "a\nb") }},
 		{"table too long", func() error { return c.Set(t.Context(), strings.Repeat("t", 129), "k", "v") }},
 	}
 
@@ -195,14 +216,31 @@ func TestClient_ArgValidation(t *testing.T) {
 		}
 	}
 	if len(ft.sent) != 0 {
-		t.Errorf("invalid arguments must not reach the transport, sent: %q", ft.sent)
+		t.Errorf("invalid arguments must not reach the transport, sent: %#v", ft.sent)
+	}
+}
+
+func TestClient_AllowsFramedValues(t *testing.T) {
+	t.Parallel()
+
+	ft := &fakeTransport{resp: protocol.SimpleString("OK")}
+	c := client.NewWithTransport(ft)
+
+	value := "a b\nc\x00"
+	if err := c.Set(t.Context(), "t", "k", value); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	wantSent := []sentCommand{{cmd: "SET", args: []string{"t", "k", value}}}
+	if !reflect.DeepEqual(ft.sent, wantSent) {
+		t.Errorf("sent = %#v, want %#v", ft.sent, wantSent)
 	}
 }
 
 func TestClient_ContextCanceled(t *testing.T) {
 	t.Parallel()
 
-	ft := &fakeTransport{resp: "OK"}
+	ft := &fakeTransport{resp: protocol.SimpleString("OK")}
 	c := client.NewWithTransport(ft)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -212,7 +250,7 @@ func TestClient_ContextCanceled(t *testing.T) {
 		t.Errorf("Set() error = %v, want context.Canceled", err)
 	}
 	if len(ft.sent) != 0 {
-		t.Errorf("canceled context must not reach the transport, sent: %q", ft.sent)
+		t.Errorf("canceled context must not reach the transport, sent: %#v", ft.sent)
 	}
 }
 

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -1,10 +1,12 @@
 package client_test
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,27 +15,28 @@ import (
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/network"
 	"github.com/OutOfStack/db/internal/parser"
+	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
 )
 
 // startServer starts an in-process database server on an ephemeral port
 // and returns its address
-func startServer(t *testing.T) string {
+func startServer(t *testing.T, opts ...network.TCPServerOption) string {
 	t.Helper()
 
-	addr, _ := startStoppableServer(t)
+	addr, _ := startStoppableServer(t, opts...)
 	return addr
 }
 
 // startStoppableServer starts an in-process database server on an ephemeral
 // port and returns its address and a stop function. The stop function blocks
 // until the server no longer accepts new connections
-func startStoppableServer(t *testing.T) (addr string, stop func()) {
+func startStoppableServer(t *testing.T, opts ...network.TCPServerOption) (addr string, stop func()) {
 	t.Helper()
 
 	logger := slog.New(slog.DiscardHandler)
 
-	srv, err := network.NewTCPServer("127.0.0.1:0", logger)
+	srv, err := network.NewTCPServer("127.0.0.1:0", logger, opts...)
 	if err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
@@ -43,12 +46,22 @@ func startStoppableServer(t *testing.T) (addr string, stop func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go srv.Start(ctx, func(ctx context.Context, req []byte) []byte {
-		res, rErr := comp.HandleRequest(ctx, string(req))
+	go srv.Start(ctx, func(ctx context.Context, cmd string, args []string) protocol.Reply {
+		res, rErr := comp.HandleRequest(ctx, cmd, args)
 		if rErr != nil {
-			return []byte(rErr.Error())
+			if errors.Is(rErr, storage.ErrNotFound) {
+				return protocol.NullBulkString()
+			}
+			return protocol.Error(rErr.Error())
 		}
-		return []byte(res)
+		switch strings.ToUpper(cmd) {
+		case "GET":
+			return protocol.BulkString(res)
+		case "SET", "DEL":
+			return protocol.SimpleString(res)
+		default:
+			return protocol.BulkString(res)
+		}
 	})
 
 	addr = srv.Addr().String()
@@ -112,6 +125,18 @@ func TestClient_RoundTrip(t *testing.T) {
 	if err = c.Del(ctx, "users", "name"); !errors.Is(err, client.ErrNotFound) {
 		t.Errorf("Del() of missing key error = %v, want ErrNotFound", err)
 	}
+
+	framedValue := "hello world\nwith\x00bytes"
+	if err = c.Set(ctx, "users", "framed", framedValue); err != nil {
+		t.Fatalf("Set() framed value error = %v", err)
+	}
+	got, err = c.Get(ctx, "users", "framed")
+	if err != nil {
+		t.Fatalf("Get() framed value error = %v", err)
+	}
+	if got != framedValue {
+		t.Errorf("Get() framed value = %q, want %q", got, framedValue)
+	}
 }
 
 func TestClient_Raw_RoundTrip(t *testing.T) {
@@ -142,6 +167,132 @@ func TestClient_Raw_RoundTrip(t *testing.T) {
 	}
 	if resp != "GET requires 2 arguments: GET <table> <key>" {
 		t.Errorf("Raw(GET) = %q, want arity error text", resp)
+	}
+
+	resp, err = c.Raw(ctx, `SET users quoted "vlad has spaces"`)
+	if err != nil {
+		t.Fatalf("Raw(quoted SET) error = %v", err)
+	}
+	if resp != "OK" {
+		t.Errorf("Raw(quoted SET) = %q, want OK", resp)
+	}
+	got, err := c.Get(ctx, "users", "quoted")
+	if err != nil {
+		t.Fatalf("Get(quoted) error = %v", err)
+	}
+	if got != "vlad has spaces" {
+		t.Errorf("Get(quoted) = %q, want quoted value", got)
+	}
+}
+
+func TestClient_PipelinedCommands(t *testing.T) {
+	t.Parallel()
+
+	addr := startServer(t)
+
+	dialer := &net.Dialer{}
+	conn, err := dialer.DialContext(t.Context(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	if err = protocol.WriteCommand(conn, "SET", []string{"users", "name", "vlad"}); err != nil {
+		t.Fatalf("WriteCommand(SET) error = %v", err)
+	}
+	if err = protocol.WriteCommand(conn, "GET", []string{"users", "name"}); err != nil {
+		t.Fatalf("WriteCommand(GET) error = %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	reply, err := protocol.ReadReply(reader, 1024)
+	if err != nil {
+		t.Fatalf("ReadReply(SET) error = %v", err)
+	}
+	if reply.Kind != protocol.ReplySimpleString || reply.Value != "OK" {
+		t.Fatalf("SET reply = %#v, want +OK", reply)
+	}
+	reply, err = protocol.ReadReply(reader, 1024)
+	if err != nil {
+		t.Fatalf("ReadReply(GET) error = %v", err)
+	}
+	if reply.Kind != protocol.ReplyBulkString || reply.Value != "vlad" {
+		t.Fatalf("GET reply = %#v, want bulk vlad", reply)
+	}
+}
+
+func TestClient_MessageSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	const serverLimit = 1024
+	addr := startServer(t, network.WithServerMaxMessageSize(serverLimit))
+
+	c, err := client.New(client.WithAddress(addr))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer c.Close()
+
+	ctx := t.Context()
+
+	// large-but-legal request near the limit round-trips
+	// (frame overhead for SET users big <value> is ~40 bytes)
+	nearLimit := strings.Repeat("x", serverLimit-64)
+	if err = c.Set(ctx, "users", "big", nearLimit); err != nil {
+		t.Fatalf("Set() near limit error = %v", err)
+	}
+	got, err := c.Get(ctx, "users", "big")
+	if err != nil || got != nearLimit {
+		t.Fatalf("Get() near limit error = %v, value match = %v", err, got == nearLimit)
+	}
+
+	// request over the limit gets a clean -ERR, not a broken connection
+	err = c.Set(ctx, "users", "big", strings.Repeat("x", serverLimit*2))
+	if srvErr, ok := errors.AsType[*client.ServerError](err); !ok || !strings.Contains(srvErr.Msg, "message size exceeds limit") {
+		t.Fatalf("Set() over limit error = %v, want ServerError about size limit", err)
+	}
+
+	// the client stays usable afterwards
+	if err = c.Set(ctx, "users", "after", "ok"); err != nil {
+		t.Fatalf("Set() after rejected request error = %v", err)
+	}
+	if got, err = c.Get(ctx, "users", "after"); err != nil || got != "ok" {
+		t.Errorf("Get() after rejected request = %q, %v; want %q, nil", got, err, "ok")
+	}
+}
+
+func TestClient_OversizedReplyDoesNotDesyncConnection(t *testing.T) {
+	t.Parallel()
+
+	// server accepts large values, but the client only accepts 1KB replies
+	addr := startServer(t, network.WithServerMaxMessageSize(8192))
+
+	c, err := client.New(client.WithAddress(addr), client.WithMaxMessageSize(1))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer c.Close()
+
+	ctx := t.Context()
+
+	big := strings.Repeat("x", 3000)
+	if err = c.Set(ctx, "users", "big", big); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// the reply exceeds the client's limit and must fail...
+	if _, err = c.Get(ctx, "users", "big"); err == nil || !strings.Contains(err.Error(), "message size exceeds limit") {
+		t.Fatalf("Get() oversized reply error = %v, want size limit error", err)
+	}
+
+	// ...without leaving the rejected reply's bytes on the connection:
+	// subsequent commands must see their own replies
+	if err = c.Set(ctx, "users", "small", "v"); err != nil {
+		t.Fatalf("Set() after oversized reply error = %v", err)
+	}
+	got, err := c.Get(ctx, "users", "small")
+	if err != nil || got != "v" {
+		t.Errorf("Get() after oversized reply = %q, %v; want %q, nil", got, err, "v")
 	}
 }
 

--- a/cmd/db-cli/main.go
+++ b/cmd/db-cli/main.go
@@ -53,6 +53,7 @@ func main() {
 	}
 	fmt.Println("Available commands:")
 	fmt.Println("  SET table key value")
+	fmt.Println("  SET table key \"value with spaces\"")
 	fmt.Println("  GET table key")
 	fmt.Println("  DEL table key")
 	fmt.Println("Type 'exit' to quit")

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"log"
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/OutOfStack/db/internal/compute"
@@ -14,6 +16,7 @@ import (
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/network"
 	"github.com/OutOfStack/db/internal/parser"
+	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
 )
 
@@ -59,7 +62,7 @@ func main() {
 
 	srv, err := network.NewTCPServer(cfg.Network.Address, logger,
 		network.WithServerIdleTimeout(cfg.Network.IdleTimeout),
-		network.WithServerBufferSize(cfg.Network.MaxMessageSizeKB*1024),
+		network.WithServerMaxMessageSize(cfg.Network.MaxMessageSizeKB*1024),
 		network.WithServerMaxConnections(cfg.Network.MaxConnections))
 	if err != nil {
 		logger.Error("Failed to create server", "error", err)
@@ -71,12 +74,22 @@ func main() {
 
 	logger.Info("Server started", "address", cfg.Network.Address)
 
-	go srv.Start(ctx, func(ctx context.Context, req []byte) []byte {
-		res, rErr := comp.HandleRequest(ctx, string(req))
+	go srv.Start(ctx, func(ctx context.Context, cmd string, args []string) protocol.Reply {
+		res, rErr := comp.HandleRequest(ctx, cmd, args)
 		if rErr != nil {
-			return []byte(rErr.Error())
+			if errors.Is(rErr, storage.ErrNotFound) {
+				return protocol.NullBulkString()
+			}
+			return protocol.Error(rErr.Error())
 		}
-		return []byte(res)
+		switch strings.ToUpper(cmd) {
+		case "GET":
+			return protocol.BulkString(res)
+		case "SET", "DEL":
+			return protocol.SimpleString(res)
+		default:
+			return protocol.BulkString(res)
+		}
 	})
 
 	sigChan := make(chan os.Signal, 1)

--- a/internal/compute/compute.go
+++ b/internal/compute/compute.go
@@ -15,7 +15,7 @@ type Storage interface {
 
 // Parser is an interface for a parser
 type Parser interface {
-	Parse(input string) (string, []string, error)
+	Parse(cmd string, args []string) (string, []string, error)
 }
 
 // Compute represents compute layer
@@ -30,9 +30,9 @@ func New(parser Parser, storage Storage, logger *slog.Logger) *Compute {
 	return &Compute{parser: parser, storage: storage, logger: logger}
 }
 
-// HandleRequest processes the input request string and returns the result or an error
-func (c *Compute) HandleRequest(ctx context.Context, input string) (string, error) {
-	cmd, args, err := c.parser.Parse(input)
+// HandleRequest validates and executes a decoded request.
+func (c *Compute) HandleRequest(ctx context.Context, cmd string, args []string) (string, error) {
+	cmd, args, err := c.parser.Parse(cmd, args)
 	if err != nil {
 		c.logger.Error("Parse error", "error", err)
 		return "", err

--- a/internal/compute/compute_test.go
+++ b/internal/compute/compute_test.go
@@ -21,12 +21,11 @@ func TestHandleRequest_Success(t *testing.T) {
 	mockParser := mocks.NewMockParser(ctrl)
 	mockStorage := mocks.NewMockStorage(ctrl)
 
-	input := "echo hello"
 	cmd := "echo"
 	args := []string{"hello"}
 	result := "hello"
 
-	mockParser.EXPECT().Parse(input).Return(cmd, args, nil)
+	mockParser.EXPECT().Parse(cmd, args).Return(cmd, args, nil)
 	mockStorage.EXPECT().Execute(gomock.Any(), cmd, args).Return(result, nil)
 
 	var logBuf bytes.Buffer
@@ -35,7 +34,7 @@ func TestHandleRequest_Success(t *testing.T) {
 	c := compute.New(mockParser, mockStorage, logger)
 	ctx := t.Context()
 
-	res, err := c.HandleRequest(ctx, input)
+	res, err := c.HandleRequest(ctx, cmd, args)
 	require.NoError(t, err)
 	require.Equal(t, result, res)
 }
@@ -49,10 +48,11 @@ func TestHandleRequest_ParserError(t *testing.T) {
 	mockParser := mocks.NewMockParser(ctrl)
 	mockStorage := mocks.NewMockStorage(ctrl)
 
-	input := "bad input"
+	cmd := "bad"
+	args := []string{"input"}
 	parseErr := errors.New("parse failed")
 
-	mockParser.EXPECT().Parse(input).Return("", nil, parseErr)
+	mockParser.EXPECT().Parse(cmd, args).Return("", nil, parseErr)
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
@@ -60,7 +60,7 @@ func TestHandleRequest_ParserError(t *testing.T) {
 	c := compute.New(mockParser, mockStorage, logger)
 	ctx := t.Context()
 
-	res, err := c.HandleRequest(ctx, input)
+	res, err := c.HandleRequest(ctx, cmd, args)
 	require.Error(t, err)
 	require.Empty(t, res)
 	require.Contains(t, err.Error(), "parse failed")
@@ -75,12 +75,11 @@ func TestHandleRequest_StorageError(t *testing.T) {
 	mockParser := mocks.NewMockParser(ctrl)
 	mockStorage := mocks.NewMockStorage(ctrl)
 
-	input := "echo hello"
 	cmd := "echo"
 	args := []string{"hello"}
 	storageErr := errors.New("storage failed")
 
-	mockParser.EXPECT().Parse(input).Return(cmd, args, nil)
+	mockParser.EXPECT().Parse(cmd, args).Return(cmd, args, nil)
 	mockStorage.EXPECT().Execute(gomock.Any(), cmd, args).Return("", storageErr)
 
 	var logBuf bytes.Buffer
@@ -89,7 +88,7 @@ func TestHandleRequest_StorageError(t *testing.T) {
 	c := compute.New(mockParser, mockStorage, logger)
 	ctx := t.Context()
 
-	res, err := c.HandleRequest(ctx, input)
+	res, err := c.HandleRequest(ctx, cmd, args)
 	require.Error(t, err)
 	require.Empty(t, res)
 	require.Contains(t, err.Error(), "storage failed")

--- a/internal/compute/mocks/compute.go
+++ b/internal/compute/mocks/compute.go
@@ -80,9 +80,9 @@ func (m *MockParser) EXPECT() *MockParserMockRecorder {
 }
 
 // Parse mocks base method.
-func (m *MockParser) Parse(input string) (string, []string, error) {
+func (m *MockParser) Parse(cmd string, args []string) (string, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Parse", input)
+	ret := m.ctrl.Call(m, "Parse", cmd, args)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].([]string)
 	ret2, _ := ret[2].(error)
@@ -90,7 +90,7 @@ func (m *MockParser) Parse(input string) (string, []string, error) {
 }
 
 // Parse indicates an expected call of Parse.
-func (mr *MockParserMockRecorder) Parse(input any) *gomock.Call {
+func (mr *MockParserMockRecorder) Parse(cmd, args any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockParser)(nil).Parse), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockParser)(nil).Parse), cmd, args)
 }

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -9,15 +10,18 @@ import (
 	"net"
 	"strings"
 	"time"
+
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
 // TCPClient represents a TCP client connection
 type TCPClient struct {
 	conn    net.Conn
+	reader  *bufio.Reader
 	address string
 
-	idleTimeout time.Duration
-	bufferSize  int
+	idleTimeout    time.Duration
+	maxMessageSize int
 }
 
 // NewTCPClient creates a new TCP client connection
@@ -31,10 +35,11 @@ func NewTCPClient(address string, options ...TCPClientOption) (*TCPClient, error
 	}
 
 	client := &TCPClient{
-		conn:        conn,
-		address:     address,
-		bufferSize:  defaultBufferSize,
-		idleTimeout: defaultTimeout,
+		conn:           conn,
+		reader:         bufio.NewReader(conn),
+		address:        address,
+		maxMessageSize: defaultMaxMessageSize,
+		idleTimeout:    defaultTimeout,
 	}
 
 	for _, option := range options {
@@ -44,50 +49,61 @@ func NewTCPClient(address string, options ...TCPClientOption) (*TCPClient, error
 	return client, nil
 }
 
-// Send sends data to the server with automatic reconnection on connection failures
-func (tc *TCPClient) Send(data []byte) ([]byte, error) {
-	return tc.sendWithRetry(data, true)
+// Send sends a command to the server with automatic reconnection on connection failures
+func (tc *TCPClient) Send(cmd string, args []string) (protocol.Reply, error) {
+	return tc.sendWithRetry(cmd, args, true)
 }
 
 // sendWithRetry attempts to send data with optional retry on connection failure
-func (tc *TCPClient) sendWithRetry(data []byte, allowRetry bool) ([]byte, error) {
+func (tc *TCPClient) sendWithRetry(cmd string, args []string, allowRetry bool) (protocol.Reply, error) {
 	// set write deadline
 	if err := tc.conn.SetWriteDeadline(time.Now().Add(tc.idleTimeout)); err != nil {
-		return nil, fmt.Errorf("failed to set write deadline: %w", err)
+		return protocol.Reply{}, fmt.Errorf("failed to set write deadline: %w", err)
 	}
 
 	// send request
-	if _, err := tc.conn.Write(data); err != nil {
+	if err := protocol.WriteCommand(tc.conn, cmd, args); err != nil {
 		if allowRetry && tc.isConnectionError(err) {
 			if rErr := tc.reconnect(); rErr != nil {
-				return nil, fmt.Errorf("failed to reconnect: %w", rErr)
+				return protocol.Reply{}, fmt.Errorf("failed to reconnect: %w", rErr)
 			}
-			return tc.sendWithRetry(data, false)
+			return tc.sendWithRetry(cmd, args, false)
 		}
-		return nil, fmt.Errorf("failed to send data: %w", err)
+		return protocol.Reply{}, fmt.Errorf("failed to send data: %w", err)
 	}
 
 	// set read deadline
 	if err := tc.conn.SetReadDeadline(time.Now().Add(tc.idleTimeout)); err != nil {
-		return nil, fmt.Errorf("failed to set read deadline: %w", err)
+		return protocol.Reply{}, fmt.Errorf("failed to set read deadline: %w", err)
 	}
 
 	// read response
-	resp := make([]byte, tc.bufferSize)
-	n, err := tc.conn.Read(resp)
+	resp, err := protocol.ReadReply(tc.reader, tc.maxMessageSize)
 	if err != nil {
-		if allowRetry && tc.isConnectionError(err) {
-			if rErr := tc.reconnect(); rErr != nil {
-				return nil, fmt.Errorf("failed to reconnect: %w", rErr)
-			}
-			return tc.sendWithRetry(data, false)
-		}
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	} else if n == tc.bufferSize {
-		return nil, errors.New("response too large")
+		return tc.handleReadError(cmd, args, err, allowRetry)
 	}
 
-	return resp[:n], nil
+	return resp, nil
+}
+
+// handleReadError recovers from a failed reply read: connection errors are
+// retried once on a fresh connection; decode errors drop the connection
+// because unread reply bytes may remain on the wire and would otherwise be
+// read as the next command's reply
+func (tc *TCPClient) handleReadError(cmd string, args []string, err error, allowRetry bool) (protocol.Reply, error) {
+	if !tc.isConnectionError(err) {
+		// reconnect eagerly; if that fails the connection is still closed
+		// and the next Send re-dials via its own retry path
+		_ = tc.reconnect()
+		return protocol.Reply{}, fmt.Errorf("failed to read response: %w", err)
+	}
+	if allowRetry {
+		if rErr := tc.reconnect(); rErr != nil {
+			return protocol.Reply{}, fmt.Errorf("failed to reconnect: %w", rErr)
+		}
+		return tc.sendWithRetry(cmd, args, false)
+	}
+	return protocol.Reply{}, fmt.Errorf("failed to read response: %w", err)
 }
 
 // isConnectionError checks if the error indicates a broken connection
@@ -107,14 +123,12 @@ func (tc *TCPClient) isConnectionError(err error) bool {
 	}
 
 	// check for timeout errors
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
 		return true
 	}
 
 	// check for OpError with specific operations
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if opErr, ok := errors.AsType[*net.OpError](err); ok {
 		// check for connection-related operations
 		switch opErr.Op {
 		case "read", "write", "dial":
@@ -146,6 +160,7 @@ func (tc *TCPClient) reconnect() error {
 	}
 
 	tc.conn = conn
+	tc.reader = bufio.NewReader(conn)
 	return nil
 }
 

--- a/internal/network/interface.go
+++ b/internal/network/interface.go
@@ -1,9 +1,11 @@
 package network
 
+import "github.com/OutOfStack/db/internal/protocol"
+
 // Client represents a generic database client interface
 type Client interface {
-	// Send sends data to the database server and returns the response
-	Send(data []byte) ([]byte, error)
+	// Send sends a command to the database server and returns the response.
+	Send(cmd string, args []string) (protocol.Reply, error)
 	// Close closes the client connection
 	Close() error
 }

--- a/internal/network/options.go
+++ b/internal/network/options.go
@@ -12,11 +12,11 @@ func WithClientIdleTimeout(d time.Duration) TCPClientOption {
 	}
 }
 
-// WithClientBufferSize sets the read/write buffer size for a TCPClient.
-func WithClientBufferSize(size int) TCPClientOption {
+// WithClientMaxMessageSize sets the maximum decoded message size in bytes for a TCPClient.
+func WithClientMaxMessageSize(size int) TCPClientOption {
 	return func(c *TCPClient) {
 		if size > 0 {
-			c.bufferSize = size
+			c.maxMessageSize = size
 		}
 	}
 }
@@ -31,11 +31,11 @@ func WithServerIdleTimeout(d time.Duration) TCPServerOption {
 	}
 }
 
-// WithServerBufferSize sets the read/write buffer size for a TCPServer.
-func WithServerBufferSize(size int) TCPServerOption {
+// WithServerMaxMessageSize sets the maximum decoded message size in bytes for a TCPServer.
+func WithServerMaxMessageSize(size int) TCPServerOption {
 	return func(s *TCPServer) {
 		if size > 0 {
-			s.bufferSize = size
+			s.maxMessageSize = size
 		}
 	}
 }

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -9,15 +10,23 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
 const (
-	defaultBufferSize = 1024
-	defaultTimeout    = 1 * time.Minute
+	// defaultMaxMessageSize mirrors the 4KB config default (max_message_size)
+	defaultMaxMessageSize = 4096
+	defaultTimeout        = 1 * time.Minute
+
+	// errorDrainTimeout bounds draining of unread request bytes before closing
+	// a connection after a protocol error, so the error reply is not lost to a
+	// TCP reset caused by closing with pending input
+	errorDrainTimeout = 100 * time.Millisecond
 )
 
-// RequestHandler is a function that handles a client request
-type RequestHandler func(context.Context, []byte) []byte
+// RequestHandler is a function that handles a decoded client command.
+type RequestHandler func(context.Context, string, []string) protocol.Reply
 
 // TCPServer represents a TCP server that handles multiple client connections
 type TCPServer struct {
@@ -26,8 +35,8 @@ type TCPServer struct {
 	wg                  sync.WaitGroup
 	connectionSemaphore chan struct{}
 
-	idleTimeout time.Duration
-	bufferSize  int
+	idleTimeout    time.Duration
+	maxMessageSize int
 }
 
 // NewTCPServer creates a new Server instance with the given configuration and logger.
@@ -47,7 +56,7 @@ func NewTCPServer(address string, logger *slog.Logger, options ...TCPServerOptio
 		listener:            listener,
 		logger:              logger,
 		connectionSemaphore: make(chan struct{}, 100),
-		bufferSize:          defaultBufferSize,
+		maxMessageSize:      defaultMaxMessageSize,
 		idleTimeout:         defaultTimeout,
 	}
 
@@ -65,9 +74,7 @@ func (s *TCPServer) Addr() net.Addr {
 
 // Start begins accepting connections
 func (s *TCPServer) Start(ctx context.Context, handler RequestHandler) {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
+	s.wg.Go(func() {
 		for {
 			conn, err := s.listener.Accept()
 			if err != nil {
@@ -92,7 +99,7 @@ func (s *TCPServer) Start(ctx context.Context, handler RequestHandler) {
 				}
 			}
 		}
-	}()
+	})
 
 	<-ctx.Done()
 
@@ -115,7 +122,7 @@ func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler
 
 	s.logger.Info("Client connected", "address", conn.RemoteAddr())
 
-	buf := make([]byte, s.bufferSize)
+	reader := bufio.NewReader(conn)
 
 	for {
 		// set the read deadline
@@ -124,35 +131,36 @@ func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler
 			return
 		}
 
-		// read data from the connection
-		n, err := conn.Read(buf)
+		// read one full RESP command from the connection
+		cmd, args, err := protocol.ReadCommand(reader, s.maxMessageSize)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			// client disconnected (possibly mid-frame): close quietly
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				return
 			}
-			s.logger.Error("Error reading from connection", "error", err)
+			// idle timeout is a normal disconnect, not an error
+			if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+				s.logger.Info("Closing idle connection", "address", conn.RemoteAddr())
+				return
+			}
+			s.logger.Error("Error reading command from connection", "error", err)
+			if wErr := s.writeReply(conn, protocol.Error(err.Error())); wErr != nil {
+				s.logger.Error("Failed to send protocol error", "error", wErr)
+				return
+			}
+			// drain pending request bytes briefly: closing with unread input
+			// can trigger a TCP reset that discards the queued error reply
+			if dErr := conn.SetReadDeadline(time.Now().Add(errorDrainTimeout)); dErr == nil {
+				_, _ = io.Copy(io.Discard, reader)
+			}
 			return
 		}
 
-		if n > 0 {
-			if n == s.bufferSize {
-				s.logger.Warn("Request too large")
-				break
-			}
-
-			// process request
-			response := handler(ctx, buf[:n])
-
-			// set write deadline
-			if err = conn.SetWriteDeadline(time.Now().Add(s.idleTimeout)); err != nil {
-				s.logger.Error("Failed to set write deadline", "error", err)
-				return
-			}
-			// send response
-			if _, err = conn.Write(response); err != nil {
-				s.logger.Error("Failed to send response", "error", err)
-				return
-			}
+		// process request
+		response := handler(ctx, cmd, args)
+		if err = s.writeReply(conn, response); err != nil {
+			s.logger.Error("Failed to send response", "error", err)
+			return
 		}
 
 		// check for context cancellation
@@ -162,4 +170,14 @@ func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler
 		default:
 		}
 	}
+}
+
+func (s *TCPServer) writeReply(conn net.Conn, reply protocol.Reply) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(s.idleTimeout)); err != nil {
+		return fmt.Errorf("failed to set write deadline: %w", err)
+	}
+	if err := protocol.WriteReply(conn, reply); err != nil {
+		return fmt.Errorf("failed to write reply: %w", err)
+	}
+	return nil
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -16,15 +16,12 @@ func New() *Parser {
 	return &Parser{}
 }
 
-// Parse parses the input string and returns the command and arguments
-func (p *Parser) Parse(input string) (string, []string, error) {
-	fields := strings.Fields(input)
-	if len(fields) == 0 {
+// Parse validates a decoded command name and its arguments
+func (p *Parser) Parse(cmd string, args []string) (string, []string, error) {
+	cmd = strings.ToUpper(strings.TrimSpace(cmd))
+	if cmd == "" {
 		return "", nil, errors.New("empty input")
 	}
-
-	cmd := fields[0]
-	args := fields[1:]
 
 	switch cmd {
 	case "SET":
@@ -41,6 +38,9 @@ func (p *Parser) Parse(input string) (string, []string, error) {
 
 	if len(args[0]) > maxTableNameLen {
 		return "", nil, errors.New("table name too long")
+	}
+	if args[0] == "" || args[1] == "" {
+		return "", nil, errors.New("table and key cannot be empty")
 	}
 
 	return cmd, args, nil

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -11,40 +11,43 @@ func TestParse(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		input    string
+		cmd      string
+		args     []string
 		wantCmd  string
 		wantArgs []string
 		wantErr  bool
 	}{
-		{"SET users foo bar", "SET", []string{"users", "foo", "bar"}, false},
-		{"GET users foo", "GET", []string{"users", "foo"}, false},
-		{"DEL users foo", "DEL", []string{"users", "foo"}, false},
-		{"SET users foo", "", nil, true},
-		{"SET foo bar", "", nil, true},
-		{"GET foo", "", nil, true},
-		{"DEL foo", "", nil, true},
-		{"GET", "", nil, true},
-		{"SET " + strings.Repeat("t", 129) + " foo bar", "", nil, true},
-		{"UNKNOWN foo", "", nil, true},
-		{"", "", nil, true},
+		{"SET", []string{"users", "foo", "bar"}, "SET", []string{"users", "foo", "bar"}, false},
+		{"get", []string{"users", "foo"}, "GET", []string{"users", "foo"}, false},
+		{"DEL", []string{"users", "foo"}, "DEL", []string{"users", "foo"}, false},
+		{"SET", []string{"users", "foo"}, "", nil, true},
+		{"SET", []string{"foo", "bar"}, "", nil, true},
+		{"GET", []string{"foo"}, "", nil, true},
+		{"DEL", []string{"foo"}, "", nil, true},
+		{"GET", nil, "", nil, true},
+		{"SET", []string{strings.Repeat("t", 129), "foo", "bar"}, "", nil, true},
+		{"UNKNOWN", []string{"foo"}, "", nil, true},
+		{"", nil, "", nil, true},
+		{"GET", []string{"", "foo"}, "", nil, true},
+		{"GET", []string{"users", ""}, "", nil, true},
 	}
 
 	for _, tt := range tests {
 		p := parser.New()
-		cmd, args, err := p.Parse(tt.input)
+		cmd, args, err := p.Parse(tt.cmd, tt.args)
 		if (err != nil) != tt.wantErr {
-			t.Errorf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			t.Errorf("Parse(%q, %q) error = %v, wantErr %v", tt.cmd, tt.args, err, tt.wantErr)
 		}
 		if cmd != tt.wantCmd {
-			t.Errorf("Parse(%q) cmd = %q, want %q", tt.input, cmd, tt.wantCmd)
+			t.Errorf("Parse(%q, %q) cmd = %q, want %q", tt.cmd, tt.args, cmd, tt.wantCmd)
 		}
 		if len(args) != len(tt.wantArgs) {
-			t.Errorf("Parse(%q) args = %v, want %v", tt.input, args, tt.wantArgs)
+			t.Errorf("Parse(%q, %q) args = %v, want %v", tt.cmd, tt.args, args, tt.wantArgs)
 			continue
 		}
 		for i := range args {
 			if args[i] != tt.wantArgs[i] {
-				t.Errorf("Parse(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
+				t.Errorf("Parse(%q, %q) args[%d] = %q, want %q", tt.cmd, tt.args, i, args[i], tt.wantArgs[i])
 			}
 		}
 	}

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
 // syncedConnection wraps a TCPClient with a mutex to serialize Send() calls
@@ -16,10 +17,10 @@ type syncedConnection struct {
 }
 
 // Send serializes Send() calls to prevent concurrent access corruption
-func (sc *syncedConnection) Send(data []byte) ([]byte, error) {
+func (sc *syncedConnection) Send(cmd string, args []string) (protocol.Reply, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	return sc.client.Send(data)
+	return sc.client.Send(cmd, args)
 }
 
 // Close closes the underlying connection
@@ -52,8 +53,8 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	}, nil
 }
 
-// Send sends data using the pool, with automatic failover
-func (c *Client) Send(data []byte) ([]byte, error) {
+// Send sends a command using the pool, with automatic failover
+func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 	var lastErr error
 	attempts := 0
 	maxAttempts := c.config.MaxRetries + 1 // initial attempt + retries
@@ -66,7 +67,7 @@ func (c *Client) Send(data []byte) ([]byte, error) {
 			c.selector.Reset()
 			server = c.selector.Select()
 			if server == nil {
-				return nil, errors.New("no servers available in pool")
+				return protocol.Reply{}, errors.New("no servers available in pool")
 			}
 		}
 
@@ -83,7 +84,7 @@ func (c *Client) Send(data []byte) ([]byte, error) {
 		}
 
 		// Try to send
-		resp, err := conn.Send(data)
+		resp, err := conn.Send(cmd, args)
 		if err != nil {
 			// Connection failed, mark server as failed and retry
 			c.selector.MarkFailed(server.Address)
@@ -101,9 +102,9 @@ func (c *Client) Send(data []byte) ([]byte, error) {
 	}
 
 	if lastErr != nil {
-		return nil, fmt.Errorf("all servers failed after %d attempts: %w", attempts, lastErr)
+		return protocol.Reply{}, fmt.Errorf("all servers failed after %d attempts: %w", attempts, lastErr)
 	}
-	return nil, fmt.Errorf("all servers failed after %d attempts", attempts)
+	return protocol.Reply{}, fmt.Errorf("all servers failed after %d attempts", attempts)
 }
 
 // getConnection gets or creates a connection to the specified address

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -26,8 +26,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	server := selector.Select()
 	if server == nil {
 		t.Fatal("Expected server, got nil")
-	}
-	if server.Role != pool.RoleMaster {
+	} else if server.Role != pool.RoleMaster {
 		t.Errorf("Expected master, got %s", server.Role)
 	}
 
@@ -39,8 +38,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	server = selector.Select()
 	if server == nil {
 		t.Fatal("Expected standby server, got nil")
-	}
-	if server.Role != pool.RoleStandby {
+	} else if server.Role != pool.RoleStandby {
 		t.Errorf("Expected standby, got %s", server.Role)
 	}
 
@@ -59,8 +57,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	server = selector.Select()
 	if server == nil {
 		t.Fatal("Expected server after reset, got nil")
-	}
-	if server.Role != pool.RoleMaster {
+	} else if server.Role != pool.RoleMaster {
 		t.Errorf("Expected master after reset, got %s", server.Role)
 	}
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -1,0 +1,326 @@
+package protocol
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type ReplyKind int
+
+const (
+	ReplySimpleString ReplyKind = iota
+	ReplyBulkString
+	ReplyNull
+	ReplyError
+	ReplyInteger
+	ReplyArray
+)
+
+type Reply struct {
+	Kind    ReplyKind
+	Value   string
+	Integer int64
+	Array   []Reply
+}
+
+func SimpleString(value string) Reply {
+	return Reply{Kind: ReplySimpleString, Value: value}
+}
+
+func BulkString(value string) Reply {
+	return Reply{Kind: ReplyBulkString, Value: value}
+}
+
+func NullBulkString() Reply {
+	return Reply{Kind: ReplyNull}
+}
+
+func Error(value string) Reply {
+	return Reply{Kind: ReplyError, Value: value}
+}
+
+func Integer(value int64) Reply {
+	return Reply{Kind: ReplyInteger, Integer: value}
+}
+
+func Array(values []Reply) Reply {
+	return Reply{Kind: ReplyArray, Array: values}
+}
+
+func BulkStringArray(values []string) Reply {
+	replies := make([]Reply, 0, len(values))
+	for _, value := range values {
+		replies = append(replies, BulkString(value))
+	}
+	return Array(replies)
+}
+
+func WriteCommand(w io.Writer, cmd string, args []string) error {
+	if _, err := fmt.Fprintf(w, "*%d\r\n", len(args)+1); err != nil {
+		return err
+	}
+	if err := writeBulkString(w, cmd); err != nil {
+		return err
+	}
+	for _, arg := range args {
+		if err := writeBulkString(w, arg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ReadCommand(r *bufio.Reader, maxMessageSize int) (string, []string, error) {
+	var read int
+	line, err := readLine(r, maxMessageSize, &read)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(line) == 0 || line[0] != '*' {
+		return "", nil, errors.New("expected RESP array command")
+	}
+
+	count, err := parseLen(line[1:])
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid command array length: %w", err)
+	}
+	if count <= 0 {
+		return "", nil, errors.New("command array cannot be empty")
+	}
+	if err = checkArrayLen(count, maxMessageSize); err != nil {
+		return "", nil, err
+	}
+
+	parts := make([]string, 0, min(count, maxPreallocElems))
+	for range count {
+		value, rErr := readCommandBulkString(r, maxMessageSize, &read)
+		if rErr != nil {
+			return "", nil, rErr
+		}
+		parts = append(parts, value)
+	}
+
+	return parts[0], parts[1:], nil
+}
+
+func WriteReply(w io.Writer, reply Reply) error {
+	switch reply.Kind {
+	case ReplySimpleString:
+		_, err := fmt.Fprintf(w, "+%s\r\n", sanitizeLine(reply.Value))
+		return err
+	case ReplyBulkString:
+		return writeBulkString(w, reply.Value)
+	case ReplyNull:
+		_, err := io.WriteString(w, "$-1\r\n")
+		return err
+	case ReplyError:
+		value := sanitizeLine(reply.Value)
+		if value == "" {
+			value = "ERR"
+		} else if !strings.HasPrefix(value, "ERR ") {
+			value = "ERR " + value
+		}
+		_, err := fmt.Fprintf(w, "-%s\r\n", value)
+		return err
+	case ReplyInteger:
+		_, err := fmt.Fprintf(w, ":%d\r\n", reply.Integer)
+		return err
+	case ReplyArray:
+		if _, err := fmt.Fprintf(w, "*%d\r\n", len(reply.Array)); err != nil {
+			return err
+		}
+		for _, item := range reply.Array {
+			if err := WriteReply(w, item); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown reply kind: %d", reply.Kind)
+	}
+}
+
+func ReadReply(r *bufio.Reader, maxMessageSize int) (Reply, error) {
+	var read int
+	return readReply(r, maxMessageSize, &read)
+}
+
+func readReply(r *bufio.Reader, maxMessageSize int, read *int) (Reply, error) {
+	line, err := readLine(r, maxMessageSize, read)
+	if err != nil {
+		return Reply{}, err
+	}
+	if len(line) == 0 {
+		return Reply{}, errors.New("empty RESP reply")
+	}
+
+	switch line[0] {
+	case '+':
+		return SimpleString(line[1:]), nil
+	case '-':
+		value := line[1:]
+		value = strings.TrimPrefix(value, "ERR ")
+		return Error(value), nil
+	case ':':
+		value, pErr := strconv.ParseInt(line[1:], 10, 64)
+		if pErr != nil {
+			return Reply{}, fmt.Errorf("invalid integer reply: %w", pErr)
+		}
+		return Integer(value), nil
+	case '$':
+		value, null, rErr := readBulkStringBody(r, line[1:], maxMessageSize, read)
+		if rErr != nil {
+			return Reply{}, rErr
+		}
+		if null {
+			return NullBulkString(), nil
+		}
+		return BulkString(value), nil
+	case '*':
+		return readArrayReply(r, line[1:], maxMessageSize, read)
+	default:
+		return Reply{}, fmt.Errorf("unknown RESP reply prefix %q", line[0])
+	}
+}
+
+func readArrayReply(r *bufio.Reader, lenText string, maxMessageSize int, read *int) (Reply, error) {
+	count, err := parseLen(lenText)
+	if err != nil {
+		return Reply{}, fmt.Errorf("invalid array reply length: %w", err)
+	}
+	if count < 0 {
+		return NullBulkString(), nil
+	}
+	if err = checkArrayLen(count, maxMessageSize); err != nil {
+		return Reply{}, err
+	}
+	values := make([]Reply, 0, min(count, maxPreallocElems))
+	for range count {
+		value, rErr := readReply(r, maxMessageSize, read)
+		if rErr != nil {
+			return Reply{}, rErr
+		}
+		values = append(values, value)
+	}
+	return Array(values), nil
+}
+
+func writeBulkString(w io.Writer, value string) error {
+	if _, err := fmt.Fprintf(w, "$%d\r\n", len(value)); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, value); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\r\n")
+	return err
+}
+
+func readCommandBulkString(r *bufio.Reader, maxMessageSize int, read *int) (string, error) {
+	line, err := readLine(r, maxMessageSize, read)
+	if err != nil {
+		return "", err
+	}
+	if len(line) == 0 || line[0] != '$' {
+		return "", errors.New("command arguments must be bulk strings")
+	}
+
+	value, null, err := readBulkStringBody(r, line[1:], maxMessageSize, read)
+	if err != nil {
+		return "", err
+	}
+	if null {
+		return "", errors.New("command arguments cannot be null")
+	}
+	return value, nil
+}
+
+func readBulkStringBody(r *bufio.Reader, lenText string, maxMessageSize int, read *int) (string, bool, error) {
+	n, err := parseLen(lenText)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid bulk string length: %w", err)
+	}
+	if n == -1 {
+		return "", true, nil
+	}
+	if n < -1 {
+		return "", false, errors.New("invalid negative bulk string length")
+	}
+	if maxMessageSize > 0 && *read+n+2 > maxMessageSize {
+		return "", false, errors.New("message size exceeds limit")
+	}
+
+	buf := make([]byte, n+2)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", false, err
+	}
+	*read += len(buf)
+	if len(buf) < 2 || buf[len(buf)-2] != '\r' || buf[len(buf)-1] != '\n' {
+		return "", false, errors.New("bulk string missing CRLF terminator")
+	}
+
+	return string(buf[:n]), false, nil
+}
+
+func readLine(r *bufio.Reader, maxMessageSize int, read *int) (string, error) {
+	var out []byte
+	for {
+		part, err := r.ReadSlice('\n')
+		out = append(out, part...)
+		*read += len(part)
+		if maxMessageSize > 0 && *read > maxMessageSize {
+			return "", errors.New("message size exceeds limit")
+		}
+		if err == nil {
+			break
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return "", err
+	}
+
+	if len(out) < 2 || out[len(out)-2] != '\r' {
+		return "", errors.New("RESP line missing CRLF terminator")
+	}
+	return string(out[:len(out)-2]), nil
+}
+
+// minArrayElemSize is the smallest possible wire encoding of one array element (e.g. "+\r\n"), used to bound declared array lengths.
+// maxPreallocElems caps slice preallocation so a declared length cannot force a huge allocation before any element is read.
+const (
+	minArrayElemSize = 3
+	maxPreallocElems = 1024
+)
+
+// checkArrayLen rejects array lengths that could not possibly be encoded
+// within maxMessageSize, before any per-element allocation happens
+func checkArrayLen(count, maxMessageSize int) error {
+	if maxMessageSize > 0 && count > maxMessageSize/minArrayElemSize {
+		return errors.New("message size exceeds limit")
+	}
+	return nil
+}
+
+// sanitizeLine makes a value safe for line-based RESP types (simple strings and errors), which must not contain CR or LF
+func sanitizeLine(value string) string {
+	if !strings.ContainsAny(value, "\r\n") {
+		return value
+	}
+	return strings.NewReplacer("\r", " ", "\n", " ").Replace(value)
+}
+
+func parseLen(value string) (int, error) {
+	if value == "" {
+		return 0, errors.New("empty length")
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -250,7 +250,10 @@ func readBulkStringBody(r *bufio.Reader, lenText string, maxMessageSize int, rea
 	if n < -1 {
 		return "", false, errors.New("invalid negative bulk string length")
 	}
-	if maxMessageSize > 0 && *read+n+2 > maxMessageSize {
+	// overflow-safe size check: n is non-negative here, so compare against the
+	// remaining budget instead of computing *read+n+2, which can overflow for
+	// lengths near math.MaxInt and bypass the limit.
+	if maxMessageSize > 0 && n > maxMessageSize-*read-2 {
 		return "", false, errors.New("message size exceeds limit")
 	}
 

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -1,0 +1,224 @@
+package protocol_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/protocol"
+)
+
+func TestCommandRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	args := []string{"users", "name", "vlad has\nbytes\x00"}
+
+	if err := protocol.WriteCommand(&buf, "SET", args); err != nil {
+		t.Fatalf("WriteCommand() error = %v", err)
+	}
+
+	cmd, gotArgs, err := protocol.ReadCommand(bufio.NewReader(&buf), 1024)
+	if err != nil {
+		t.Fatalf("ReadCommand() error = %v", err)
+	}
+	if cmd != "SET" {
+		t.Errorf("cmd = %q, want SET", cmd)
+	}
+	if !reflect.DeepEqual(gotArgs, args) {
+		t.Errorf("args = %#v, want %#v", gotArgs, args)
+	}
+}
+
+func TestReadCommandRejectsMalformedFrames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"plain text", "GET users name\r\n"},
+		{"zero args", "*0\r\n"},
+		{"non bulk arg", "*1\r\n+GET\r\n"},
+		{"missing crlf", "*1\n$3\r\nGET\r\n"},
+		{"null command arg", "*1\r\n$-1\r\n"},
+		{"bad bulk terminator", "*1\r\n$3\r\nGET\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := protocol.ReadCommand(bufio.NewReader(bytes.NewBufferString(tt.input)), 1024)
+			if err == nil {
+				t.Fatal("ReadCommand() expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestReadCommandTruncatedFrame(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := protocol.ReadCommand(bufio.NewReader(bytes.NewBufferString("*2\r\n$3\r\nGET\r\n$5\r\nus")), 1024)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("ReadCommand() error = %v, want unexpected EOF", err)
+	}
+}
+
+func TestReadCommandSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := protocol.WriteCommand(&buf, "SET", []string{"t", "k", "0123456789"}); err != nil {
+		t.Fatalf("WriteCommand() error = %v", err)
+	}
+
+	_, _, err := protocol.ReadCommand(bufio.NewReader(&buf), 20)
+	if err == nil {
+		t.Fatal("ReadCommand() expected size error, got nil")
+	}
+}
+
+func TestReplyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []protocol.Reply{
+		protocol.SimpleString("OK"),
+		protocol.BulkString("vlad has\nbytes\x00"),
+		protocol.NullBulkString(),
+		protocol.Error("bad command"),
+		protocol.Integer(42),
+		protocol.BulkStringArray([]string{"users", "orders"}),
+	}
+
+	for _, want := range tests {
+		var buf bytes.Buffer
+		if err := protocol.WriteReply(&buf, want); err != nil {
+			t.Fatalf("WriteReply(%#v) error = %v", want, err)
+		}
+		got, err := protocol.ReadReply(bufio.NewReader(&buf), 1024)
+		if err != nil {
+			t.Fatalf("ReadReply(%#v) error = %v", want, err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("reply = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestReadReplyRejectsMalformedPrefix(t *testing.T) {
+	t.Parallel()
+
+	_, err := protocol.ReadReply(bufio.NewReader(bytes.NewBufferString("!wat\r\n")), 1024)
+	if err == nil {
+		t.Fatal("ReadReply() expected error, got nil")
+	}
+}
+
+func TestRejectsHugeArrayCount(t *testing.T) {
+	t.Parallel()
+
+	// declared counts that could never fit in the size limit must be rejected
+	// before any allocation happens (a naive prealloc panics or OOMs)
+	for _, input := range []string{
+		"*9223372036854775807\r\n",
+		"*1000000000\r\n$1\r\na\r\n",
+	} {
+		if _, _, err := protocol.ReadCommand(bufio.NewReader(bytes.NewBufferString(input)), 1024); err == nil {
+			t.Errorf("ReadCommand(%q) expected error, got nil", input)
+		}
+		if _, err := protocol.ReadReply(bufio.NewReader(bytes.NewBufferString(input)), 1024); err == nil {
+			t.Errorf("ReadReply(%q) expected error, got nil", input)
+		}
+	}
+}
+
+func TestWriteReplySanitizesCRLF(t *testing.T) {
+	t.Parallel()
+
+	// CR/LF in line-based replies must not break framing: a crafted error
+	// message must decode as exactly one reply, not smuggle in a second one
+	var buf bytes.Buffer
+	if err := protocol.WriteReply(&buf, protocol.Error("unknown command: FOO\r\n+OK")); err != nil {
+		t.Fatalf("WriteReply() error = %v", err)
+	}
+	reader := bufio.NewReader(&buf)
+	got, err := protocol.ReadReply(reader, 1024)
+	if err != nil {
+		t.Fatalf("ReadReply() error = %v", err)
+	}
+	if got.Kind != protocol.ReplyError || got.Value != "unknown command: FOO  +OK" {
+		t.Errorf("reply = %#v, want sanitized error", got)
+	}
+	if _, err = protocol.ReadReply(reader, 1024); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF after single reply, got %v", err)
+	}
+}
+
+func FuzzReadCommand(f *testing.F) {
+	f.Add([]byte("*3\r\n$3\r\nSET\r\n$1\r\nk\r\n$1\r\nv\r\n"))
+	f.Add([]byte("*9223372036854775807\r\n"))
+	f.Add([]byte("*1\r\n$-1\r\n"))
+	f.Add([]byte("GET users name\r\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cmd, args, err := protocol.ReadCommand(bufio.NewReader(bytes.NewReader(data)), 1024)
+		if err != nil {
+			return
+		}
+		// whatever decodes must re-encode and decode to the same command
+		var buf bytes.Buffer
+		if err = protocol.WriteCommand(&buf, cmd, args); err != nil {
+			t.Fatalf("WriteCommand(%q, %q) error = %v", cmd, args, err)
+		}
+		cmd2, args2, err := protocol.ReadCommand(bufio.NewReader(&buf), 1024)
+		if err != nil {
+			t.Fatalf("re-decode of %q %q error = %v", cmd, args, err)
+		}
+		if cmd2 != cmd || !reflect.DeepEqual(args2, args) {
+			t.Fatalf("round trip = %q %q, want %q %q", cmd2, args2, cmd, args)
+		}
+	})
+}
+
+func FuzzReadReply(f *testing.F) {
+	f.Add([]byte("+OK\r\n"))
+	f.Add([]byte("-ERR bad command\r\n"))
+	f.Add([]byte(":42\r\n"))
+	f.Add([]byte("$-1\r\n"))
+	f.Add([]byte("*2\r\n$5\r\nusers\r\n$6\r\norders\r\n"))
+	f.Add([]byte("*1000000000\r\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r1, err := protocol.ReadReply(bufio.NewReader(bytes.NewReader(data)), 1024)
+		if err != nil {
+			return
+		}
+		// the first encode may normalize (ERR prefix, CR/LF sanitization);
+		// after that, encode/decode must be a stable round trip
+		r2, err := rewrite(r1)
+		if err != nil {
+			t.Fatalf("first re-encode of %#v error = %v", r1, err)
+		}
+		r3, err := rewrite(r2)
+		if err != nil {
+			t.Fatalf("second re-encode of %#v error = %v", r2, err)
+		}
+		if !reflect.DeepEqual(r2, r3) {
+			t.Fatalf("round trip not stable: %#v != %#v", r2, r3)
+		}
+	})
+}
+
+// rewrite encodes a reply and decodes it back
+func rewrite(reply protocol.Reply) (protocol.Reply, error) {
+	var buf bytes.Buffer
+	if err := protocol.WriteReply(&buf, reply); err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.ReadReply(bufio.NewReader(&buf), 1<<20)
+}


### PR DESCRIPTION
Adopt RESP2 as the wire framing for requests and replies, replacing the "one TCP read = one whitespace-delimited command" protocol.

BREAKING CHANGE: wire protocol is now RESP2; old plain-text clients and servers are imcompatible.