### PR TITLE
feat(wal): add write-ahead logging and snapshots for durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ The server can be configured using a YAML file. Example configuration:
 ```yaml
 engine:
   type: "in_memory"
+wal:
+  enabled: true
+  data_dir: "data"
+  sync: "everysec"
+  segment_size: 64
+  snapshot_interval: 5m
 network:
   address: "127.0.0.1:3223"
   max_connections: 100
@@ -102,6 +108,11 @@ logging:
 #### Server Configuration Options
 
 - **engine.type**: Storage engine type (currently only "in_memory")
+- **wal.enabled**: Enable durable write-ahead logging (disabled by default)
+- **wal.data_dir**: Directory for WAL segments and snapshots
+- **wal.sync**: Fsync policy (`always`, `everysec`, or `no`)
+- **wal.segment_size**: WAL segment rollover size in MiB
+- **wal.snapshot_interval**: Interval between snapshots when data has changed
 - **network.address**: Server listening address
 - **network.max_connections**: Maximum concurrent client connections (enforced by server)
 - **network.max_message_size**: Maximum message size in KB
@@ -336,7 +347,8 @@ go build -o bin/db-cli ./cmd/db-cli
     ├── network/                 # TCP networking layer
     ├── parser/                  # Command parsing
     ├── pool/                    # Connection pooling and failover
-    └── storage/                 # Storage layer
+    ├── storage/                 # Storage layer
+    └── wal/                     # Write-ahead log and snapshots
 ```
 
 ## Development

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/OutOfStack/db/internal/compute"
 	"github.com/OutOfStack/db/internal/config"
@@ -17,6 +19,7 @@ import (
 	"github.com/OutOfStack/db/internal/parser"
 	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
+	"github.com/OutOfStack/db/internal/wal"
 )
 
 func main() {
@@ -26,12 +29,28 @@ func main() {
 
 	cfg, err := config.LoadServerConfig(configPath)
 	if err != nil {
-		log.Fatalf("Failed to load configuration: %v\n", err)
+		log.Printf("Failed to load configuration: %v\n", err)
+		return
 	}
+	logger, closeLog, err := newLogger(cfg.Logging)
+	if err != nil {
+		log.Printf("Failed to configure logging: %v\n", err)
+		return
+	}
+	defer func() {
+		if closeErr := closeLog(); closeErr != nil {
+			log.Printf("Failed to close log file: %v", closeErr)
+		}
+	}()
 
-	var logger *slog.Logger
+	if err = run(cfg, logger); err != nil {
+		logger.Error("Server stopped", "error", err)
+	}
+}
+
+func newLogger(cfg config.ServerLoggingConfig) (*slog.Logger, func() error, error) {
 	level := slog.LevelInfo
-	switch cfg.Logging.Level {
+	switch cfg.Level {
 	case "debug":
 		level = slog.LevelDebug
 	case "warn":
@@ -39,54 +58,186 @@ func main() {
 	case "error":
 		level = slog.LevelError
 	}
-
 	opts := &slog.HandlerOptions{Level: level}
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
-	if cfg.Logging.Output != "" {
-		file, fErr := os.OpenFile(cfg.Logging.Output, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
-		if fErr != nil {
-			logger.Error("Failed to open log file", "error", fErr)
-			os.Exit(1)
-		}
-		defer func() {
-			if fErr = file.Close(); fErr != nil {
-				logger.Error("Failed to close log file", "error", fErr)
-			}
-		}()
-		logger = slog.New(slog.NewJSONHandler(file, opts))
+	if cfg.Output == "" {
+		return slog.New(slog.NewJSONHandler(os.Stdout, opts)), func() error { return nil }, nil
+	}
+	file, err := os.OpenFile(cfg.Output, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, nil, err
+	}
+	return slog.New(slog.NewJSONHandler(file, opts)), file.Close, nil
+}
+
+func run(cfg *config.ServerConfig, logger *slog.Logger) error {
+	dbEngine, walWriter, snapshotLSN, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		return err
+	}
+	if walWriter != nil {
+		defer func() { _ = walWriter.Close() }() // the coordinated shutdown below reports the first close error
 	}
 
-	store := storage.New(engine.New())
+	var options []storage.Option
+	if walWriter != nil {
+		options = append(options, storage.WithWAL(walWriter))
+	}
+	store := storage.New(dbEngine, options...)
 	comp := compute.New(parser.New(), store, logger)
+	return serve(cfg, logger, comp, store, walWriter, snapshotLSN)
+}
 
+func recoverPersistence(
+	cfg *config.ServerConfig,
+	logger *slog.Logger,
+) (*engine.Engine, *wal.Writer, uint64, error) {
+	dbEngine := engine.New()
+	if !cfg.WAL.Enabled {
+		return dbEngine, nil, 0, nil
+	}
+
+	var entries []engine.Entry
+	snapshotLSN, err := wal.LoadLatestSnapshot(cfg.WAL.DataDir, func(table, key, value string) error {
+		entries = append(entries, engine.Entry{Table: table, Key: key, Value: value})
+		return nil
+	})
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("load snapshot: %w", err)
+	}
+	dbEngine.Load(context.Background(), entries)
+
+	lastLSN, err := wal.NewReader(cfg.WAL.DataDir, logger).Replay(snapshotLSN, func(record wal.Record) error {
+		return applyRecoveredRecord(dbEngine, record)
+	})
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("replay WAL: %w", err)
+	}
+	writer, err := wal.OpenWriter(wal.WriterConfig{
+		Dir:         cfg.WAL.DataDir,
+		Sync:        cfg.WAL.Sync,
+		SegmentSize: cfg.WAL.SegmentSizeMB << 20,
+	}, lastLSN)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("open WAL: %w", err)
+	}
+	logger.Info("Persistence recovered", "snapshot_lsn", snapshotLSN, "last_lsn", lastLSN)
+	return dbEngine, writer, snapshotLSN, nil
+}
+
+func applyRecoveredRecord(dbEngine *engine.Engine, record wal.Record) error {
+	switch record.Command {
+	case wal.CommandSet:
+		return dbEngine.Set(context.Background(), record.Args[0], record.Args[1], record.Args[2])
+	case wal.CommandDel:
+		err := dbEngine.Del(context.Background(), record.Args[0], record.Args[1])
+		if errors.Is(err, engine.ErrNotFound) {
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("unsupported WAL command %q", record.Command)
+	}
+}
+
+func serve(
+	cfg *config.ServerConfig,
+	logger *slog.Logger,
+	comp *compute.Compute,
+	store *storage.Storage,
+	walWriter *wal.Writer,
+	recoveredSnapshotLSN uint64,
+) error {
 	srv, err := network.NewTCPServer(cfg.Network.Address, logger,
 		network.WithServerIdleTimeout(cfg.Network.IdleTimeout),
 		network.WithServerMaxMessageSize(cfg.Network.MaxMessageSizeKB*1024),
 		network.WithServerMaxConnections(cfg.Network.MaxConnections))
 	if err != nil {
-		logger.Error("Failed to create server", "error", err)
-		return
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		srv.Start(ctx, requestHandler(comp))
+	}()
+	snapshotDone := startSnapshotLoop(ctx, cfg, logger, store, walWriter, recoveredSnapshotLSN)
 
 	logger.Info("Server started", "address", cfg.Network.Address)
-
-	go srv.Start(ctx, func(ctx context.Context, cmd string, args []string) protocol.Reply {
-		res, rErr := comp.HandleRequest(ctx, cmd, args)
-		if rErr != nil {
-			if errors.Is(rErr, storage.ErrNotFound) {
-				return protocol.NullBulkString()
-			}
-			return protocol.Error(rErr.Error())
-		}
-		return res
-	})
-
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 	<-sigChan
 
 	logger.Info("Shutting down server...")
+	cancel()
+	<-serverDone
+	<-snapshotDone
+	if walWriter != nil {
+		if err = walWriter.Close(); err != nil {
+			return fmt.Errorf("close WAL: %w", err)
+		}
+	}
+	return nil
+}
+
+func requestHandler(comp *compute.Compute) network.RequestHandler {
+	return func(ctx context.Context, cmd string, args []string) protocol.Reply {
+		result, err := comp.HandleRequest(ctx, cmd, args)
+		if err == nil {
+			return result
+		}
+		if errors.Is(err, storage.ErrNotFound) {
+			return protocol.NullBulkString()
+		}
+		return protocol.Error(err.Error())
+	}
+}
+
+func startSnapshotLoop(
+	ctx context.Context,
+	cfg *config.ServerConfig,
+	logger *slog.Logger,
+	store *storage.Storage,
+	writer *wal.Writer,
+	lastSnapshotLSN uint64,
+) <-chan struct{} {
+	done := make(chan struct{})
+	if writer == nil {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(cfg.WAL.SnapshotInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if writer.LastLSN() == lastSnapshotLSN {
+					continue
+				}
+				writtenLSN, err := createSnapshot(ctx, cfg.WAL.DataDir, store)
+				if err != nil {
+					logger.Error("Failed to write snapshot", "error", err)
+					continue
+				}
+				lastSnapshotLSN = writtenLSN
+				logger.Info("Snapshot written", "lsn", writtenLSN)
+			}
+		}
+	}()
+	return done
+}
+
+func createSnapshot(ctx context.Context, dir string, store *storage.Storage) (uint64, error) {
+	var writtenLSN uint64
+	err := store.Snapshot(ctx, func(ctx context.Context, lsn uint64, source storage.SnapshotSource) error {
+		writtenLSN = lsn
+		return wal.WriteSnapshot(ctx, dir, lsn, source)
+	})
+	return writtenLSN, err
 }

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -23,6 +23,12 @@ import (
 )
 
 func main() {
+	os.Exit(execute())
+}
+
+// execute runs the server and returns a process exit code. It is separate from
+// main so deferred cleanup (e.g. closing the log file) runs before os.Exit.
+func execute() int {
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "Path to configuration file")
 	flag.Parse()
@@ -30,12 +36,12 @@ func main() {
 	cfg, err := config.LoadServerConfig(configPath)
 	if err != nil {
 		log.Printf("Failed to load configuration: %v\n", err)
-		return
+		return 1
 	}
 	logger, closeLog, err := newLogger(cfg.Logging)
 	if err != nil {
 		log.Printf("Failed to configure logging: %v\n", err)
-		return
+		return 1
 	}
 	defer func() {
 		if closeErr := closeLog(); closeErr != nil {
@@ -45,7 +51,9 @@ func main() {
 
 	if err = run(cfg, logger); err != nil {
 		logger.Error("Server stopped", "error", err)
+		return 1
 	}
+	return 0
 }
 
 func newLogger(cfg config.ServerLoggingConfig) (*slog.Logger, func() error, error) {

--- a/config.server.example.yaml
+++ b/config.server.example.yaml
@@ -4,6 +4,14 @@
 engine:
   type: "in_memory"
 
+# WAL is disabled by default for backward compatibility.
+wal:
+  enabled: false
+  data_dir: "data"
+  sync: "everysec"          # always, everysec, or no
+  segment_size: 64          # MiB
+  snapshot_interval: 5m
+
 network:
   address: "127.0.0.1:3223"
   max_connections: 100

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ func LoadServerConfig(filename string) (*ServerConfig, error) {
 			return nil, err
 		}
 		if data != nil {
-			var fileCfg ServerConfig
+			fileCfg := *DefaultServerConfig()
 			if err = yaml.Unmarshal(data, &fileCfg); err != nil {
 				return nil, fmt.Errorf("failed to parse config file: %w", err)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/wal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,6 +37,12 @@ network:
 logging:
   level: "debug"
   output: "/tmp/test.log"
+wal:
+  enabled: true
+  data_dir: "test-data"
+  sync: "always"
+  segment_size: 8
+  snapshot_interval: 30s
 `
 		tmpFile, err := os.CreateTemp(".", "config_test_*.yaml")
 		require.NoError(t, err)
@@ -56,6 +63,11 @@ logging:
 		assert.Equal(t, "debug", cfg.Logging.Level)
 		assert.Equal(t, "/tmp/test.log", cfg.Logging.Output)
 		assert.Equal(t, "in_memory", cfg.Engine.Type)
+		assert.True(t, cfg.WAL.Enabled)
+		assert.Equal(t, "test-data", cfg.WAL.DataDir)
+		assert.Equal(t, wal.SyncAlways, cfg.WAL.Sync)
+		assert.Equal(t, int64(8), cfg.WAL.SegmentSizeMB)
+		assert.Equal(t, 30*time.Second, cfg.WAL.SnapshotInterval)
 	})
 
 	t.Run("returns error for invalid config values", func(t *testing.T) {
@@ -81,6 +93,32 @@ network:
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid config: maxConnections must be positive")
 	})
+}
+
+func TestServerWALConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		change func(*config.ServerConfig)
+		want   string
+	}{
+		{"missing data directory", func(cfg *config.ServerConfig) { cfg.WAL.DataDir = "" }, "wal dataDir"},
+		{"bad sync policy", func(cfg *config.ServerConfig) { cfg.WAL.Sync = "sometimes" }, "wal sync policy"},
+		{"bad segment size", func(cfg *config.ServerConfig) { cfg.WAL.SegmentSizeMB = 0 }, "wal segmentSize"},
+		{"bad snapshot interval", func(cfg *config.ServerConfig) { cfg.WAL.SnapshotInterval = 0 }, "wal snapshotInterval"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.DefaultServerConfig()
+			cfg.WAL.Enabled = true
+			test.change(cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.want)
+		})
+	}
 }
 
 func TestLoadServerConfig_EnvOverrides(t *testing.T) { //nolint:paralleltest // t.Setenv

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/wal"
 )
 
 // Environment variables that override server configuration values
@@ -23,8 +24,19 @@ const (
 // ServerConfig - configuration for the database server
 type ServerConfig struct {
 	Engine  ServerEngineConfig  `yaml:"engine"`
+	WAL     ServerWALConfig     `yaml:"wal"`
 	Network ServerNetworkConfig `yaml:"network"`
 	Logging ServerLoggingConfig `yaml:"logging"`
+}
+
+// ServerWALConfig controls durable write-ahead logging and snapshots.
+// SegmentSizeMB is measured in MiB.
+type ServerWALConfig struct {
+	Enabled          bool           `yaml:"enabled"`
+	DataDir          string         `yaml:"data_dir"`
+	Sync             wal.SyncPolicy `yaml:"sync"`
+	SegmentSizeMB    int64          `yaml:"segment_size"`
+	SnapshotInterval time.Duration  `yaml:"snapshot_interval"`
 }
 
 // ServerEngineConfig holds configuration for the database engine.
@@ -55,6 +67,13 @@ func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		Engine: ServerEngineConfig{
 			Type: engine.TypeInMemory,
+		},
+		WAL: ServerWALConfig{
+			Enabled:          false,
+			DataDir:          "data",
+			Sync:             wal.SyncEverySec,
+			SegmentSizeMB:    64,
+			SnapshotInterval: 5 * time.Minute,
 		},
 		Network: ServerNetworkConfig{
 			Address:          defaultAddress,
@@ -125,6 +144,23 @@ func (c *ServerConfig) Validate() error {
 
 	if c.Network.IdleTimeout <= 0 {
 		return errors.New("idleTimeout must be positive")
+	}
+
+	if c.WAL.Enabled {
+		if c.WAL.DataDir == "" {
+			return errors.New("wal dataDir cannot be empty")
+		}
+		switch c.WAL.Sync {
+		case wal.SyncAlways, wal.SyncEverySec, wal.SyncNo:
+		default:
+			return fmt.Errorf("unsupported wal sync policy: %s", c.WAL.Sync)
+		}
+		if c.WAL.SegmentSizeMB <= 0 {
+			return errors.New("wal segmentSize must be positive")
+		}
+		if c.WAL.SnapshotInterval <= 0 {
+			return errors.New("wal snapshotInterval must be positive")
+		}
 	}
 
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -23,6 +23,13 @@ type Engine struct {
 	mu    sync.RWMutex
 }
 
+// Entry is one value used by the recovery bulk-load path.
+type Entry struct {
+	Table string
+	Key   string
+	Value string
+}
+
 // Tables returns all table names in sorted order.
 func (e *Engine) Tables(_ context.Context) []string {
 	e.mu.RLock()
@@ -64,6 +71,36 @@ func New() *Engine {
 	return &Engine{
 		store: make(map[string]map[string]string),
 		mu:    sync.RWMutex{},
+	}
+}
+
+// Range calls fn for every stored value while holding a read lock. Iteration
+// stops when fn returns false.
+func (e *Engine) Range(fn func(table, key, value string) bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for table, values := range e.store {
+		for key, value := range values {
+			if !fn(table, key, value) {
+				return
+			}
+		}
+	}
+}
+
+// Load inserts a recovered set of entries without routing them through the WAL.
+func (e *Engine) Load(_ context.Context, entries []Entry) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, entry := range entries {
+		table := e.store[entry.Table]
+		if table == nil {
+			table = make(map[string]string)
+			e.store[entry.Table] = table
+		}
+		table[entry.Key] = entry.Value
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -41,6 +41,35 @@ func TestEngine_Introspection(t *testing.T) {
 	}
 }
 
+func TestEngine_LoadAndRange(t *testing.T) {
+	t.Parallel()
+	eng := engine.New()
+	eng.Load(t.Context(), []engine.Entry{
+		{Table: "users", Key: "a", Value: "one"},
+		{Table: "users", Key: "b", Value: "two"},
+		{Table: "orders", Key: "x", Value: "three"},
+	})
+
+	got := make(map[string]string)
+	eng.Range(func(table, key, value string) bool {
+		got[table+"/"+key] = value
+		return true
+	})
+	want := map[string]string{"users/a": "one", "users/b": "two", "orders/x": "three"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Range() = %v, want %v", got, want)
+	}
+
+	count := 0
+	eng.Range(func(string, string, string) bool {
+		count++
+		return false
+	})
+	if count != 1 {
+		t.Fatalf("early-stop Range() calls = %d, want 1", count)
+	}
+}
+
 func TestEngine_Set(t *testing.T) {
 	t.Parallel()
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -59,6 +59,26 @@ func BulkStringArray(values []string) Reply {
 	return Array(replies)
 }
 
+// CommandSize returns the exact number of bytes WriteCommand emits for cmd/args.
+// It lets callers reject an over-limit command before writing it, matching the
+// cumulative-byte limit ReadCommand enforces on the way back in.
+func CommandSize(cmd string, args []string) int {
+	size := 1 + intWidth(len(args)+1) + 2 // *<count>\r\n
+	size += bulkStringSize(cmd)
+	for _, arg := range args {
+		size += bulkStringSize(arg)
+	}
+	return size
+}
+
+func bulkStringSize(value string) int {
+	return 1 + intWidth(len(value)) + 2 + len(value) + 2 // $<len>\r\n<value>\r\n
+}
+
+func intWidth(n int) int {
+	return len(strconv.Itoa(n))
+}
+
 func WriteCommand(w io.Writer, cmd string, args []string) error {
 	if _, err := fmt.Fprintf(w, "*%d\r\n", len(args)+1); err != nil {
 		return err

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -33,6 +33,30 @@ func TestCommandRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCommandSizeMatchesWriteCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		cmd  string
+		args []string
+	}{
+		{"SET", []string{"users", "name", "vlad"}},
+		{"DEL", []string{"users", "name"}},
+		{"SET", []string{"t", "k", ""}},
+		{"SET", []string{"table", "key", "a value spanning multiple words and \r\n bytes"}},
+	}
+
+	for _, c := range cases {
+		var buf bytes.Buffer
+		if err := protocol.WriteCommand(&buf, c.cmd, c.args); err != nil {
+			t.Fatalf("WriteCommand() error = %v", err)
+		}
+		if got := protocol.CommandSize(c.cmd, c.args); got != buf.Len() {
+			t.Errorf("CommandSize(%q, %v) = %d, want %d", c.cmd, c.args, got, buf.Len())
+		}
+	}
+}
+
 func TestReadCommandRejectsMalformedFrames(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/mocks/storage.go
+++ b/internal/storage/mocks/storage.go
@@ -83,6 +83,18 @@ func (mr *MockEngineMockRecorder) Keys(ctx, table any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Keys", reflect.TypeOf((*MockEngine)(nil).Keys), ctx, table)
 }
 
+// Range mocks base method.
+func (m *MockEngine) Range(fn func(table, key, value string) bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Range", fn)
+}
+
+// Range indicates an expected call of Range.
+func (mr *MockEngineMockRecorder) Range(fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Range", reflect.TypeOf((*MockEngine)(nil).Range), fn)
+}
+
 // Set mocks base method.
 func (m *MockEngine) Set(ctx context.Context, table, key, value string) error {
 	m.ctrl.T.Helper()

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/protocol"
@@ -21,16 +22,124 @@ type Engine interface {
 	Tables(ctx context.Context) []string
 	TableExists(ctx context.Context, table string) bool
 	Keys(ctx context.Context, table string) []string
+	Range(fn func(table, key, value string) bool)
+}
+
+// WAL is the persistence stream used for mutating commands.
+type WAL interface {
+	Append(ctx context.Context, command string, args []string) (uint64, error)
+	LastLSN() uint64
+	Prune(ctx context.Context, uptoLSN uint64) error
+}
+
+// SnapshotSource is the read-only state exposed to snapshot writers.
+type SnapshotSource interface {
+	Range(fn func(table, key, value string) bool)
+}
+
+// Option configures Storage.
+type Option func(*Storage)
+
+// WithWAL enables write-ahead logging for mutations.
+func WithWAL(log WAL) Option {
+	return func(storage *Storage) { storage.wal = log }
 }
 
 // Storage implements a storage layer that provides a simple key-value store
 type Storage struct {
 	engine Engine
+	wal    WAL
+	// mu serializes snapshots (write lock) against mutations (read lock); many
+	// mutations may run concurrently so their WAL appends can be group-committed.
+	mu   sync.RWMutex
+	gate *applyGate
 }
 
 // New returns a new Storage instance
-func New(engine Engine) *Storage {
-	return &Storage{engine: engine}
+func New(engine Engine, options ...Option) *Storage {
+	storage := &Storage{engine: engine}
+	for _, option := range options {
+		option(storage)
+	}
+	if storage.wal != nil {
+		storage.gate = newApplyGate(storage.wal.LastLSN() + 1)
+	}
+	return storage
+}
+
+// applyGate applies engine mutations in strictly increasing LSN order. Concurrent
+// mutations append to the WAL in parallel (enabling group commit) but must land in
+// the engine in the same order the WAL assigned, so replay reproduces the state.
+type applyGate struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+	next uint64
+}
+
+func newApplyGate(next uint64) *applyGate {
+	gate := &applyGate{next: next}
+	gate.cond = sync.NewCond(&gate.mu)
+	return gate
+}
+
+// run waits until lsn is the next LSN to apply, runs fn, then releases the next
+// LSN. The gate always advances: the WAL record is already durable, so a benign
+// engine error (e.g. deleting a missing key) must not stall later mutations.
+func (g *applyGate) run(lsn uint64, fn func() error) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for lsn != g.next {
+		g.cond.Wait()
+	}
+	err := fn()
+	g.next++
+	g.cond.Broadcast()
+	return err
+}
+
+// Snapshot writes a state/LSN-consistent snapshot, then prunes incorporated WAL
+// segments. Mutations are paused only long enough to copy the state and capture
+// its LSN; the disk write and prune run without blocking mutations or reads.
+func (s *Storage) Snapshot(
+	ctx context.Context,
+	write func(context.Context, uint64, SnapshotSource) error,
+) error {
+	if s.wal == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	lsn := s.wal.LastLSN()
+	source := captureState(s.engine)
+	s.mu.Unlock()
+
+	if err := write(ctx, lsn, source); err != nil {
+		return err
+	}
+	return s.wal.Prune(ctx, lsn)
+}
+
+// snapshotEntry is one captured value; captured is a point-in-time copy of the
+// engine used so snapshot disk I/O happens without holding the mutation lock.
+type snapshotEntry struct{ table, key, value string }
+
+type captured []snapshotEntry
+
+func (c captured) Range(fn func(table, key, value string) bool) {
+	for _, entry := range c {
+		if !fn(entry.table, entry.key, entry.value) {
+			return
+		}
+	}
+}
+
+func captureState(source SnapshotSource) captured {
+	var entries captured
+	source.Range(func(table, key, value string) bool {
+		entries = append(entries, snapshotEntry{table: table, key: key, value: value})
+		return true
+	})
+	return entries
 }
 
 // Execute executes the given command with arguments and returns the result or an error
@@ -54,7 +163,8 @@ func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (proto
 }
 
 func (s *Storage) set(ctx context.Context, args []string) (protocol.Reply, error) {
-	if err := s.engine.Set(ctx, args[0], args[1], args[2]); err != nil {
+	apply := func() error { return s.engine.Set(ctx, args[0], args[1], args[2]) }
+	if err := s.mutate(ctx, "SET", args, apply); err != nil {
 		return protocol.Reply{}, err
 	}
 	return protocol.SimpleString("OK"), nil
@@ -72,13 +182,32 @@ func (s *Storage) get(ctx context.Context, args []string) (protocol.Reply, error
 }
 
 func (s *Storage) del(ctx context.Context, args []string) (protocol.Reply, error) {
-	if err := s.engine.Del(ctx, args[0], args[1]); err != nil {
+	apply := func() error { return s.engine.Del(ctx, args[0], args[1]) }
+	if err := s.mutate(ctx, "DEL", args, apply); err != nil {
 		if errors.Is(err, engine.ErrNotFound) {
 			return protocol.Reply{}, ErrNotFound
 		}
 		return protocol.Reply{}, err
 	}
 	return protocol.SimpleString("OK"), nil
+}
+
+// mutate durably logs a mutation, then applies it to the engine. When the WAL is
+// enabled, appends run concurrently (under the shared read lock) so the writer can
+// group-commit them, while the apply gate replays them into the engine in LSN order.
+func (s *Storage) mutate(ctx context.Context, command string, args []string, apply func() error) error {
+	if s.wal == nil {
+		return apply()
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	lsn, err := s.wal.Append(ctx, command, args)
+	if err != nil {
+		return err
+	}
+	return s.gate.run(lsn, apply)
 }
 
 func fmtBool(value bool) string {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,9 +1,14 @@
 package storage_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
 	mocks "github.com/OutOfStack/db/internal/storage/mocks"
@@ -18,6 +23,121 @@ func newStorageWithMock(t *testing.T) (*storage.Storage, *mocks.MockEngine) {
 	t.Helper()
 	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
 	return storage.New(mockEngine), mockEngine
+}
+
+type fakeWAL struct {
+	append func(context.Context, string, []string) (uint64, error)
+	last   uint64
+	pruned uint64
+}
+
+func (f *fakeWAL) Append(ctx context.Context, command string, args []string) (uint64, error) {
+	return f.append(ctx, command, args)
+}
+
+func (f *fakeWAL) LastLSN() uint64 { return f.last }
+
+func (f *fakeWAL) Prune(_ context.Context, uptoLSN uint64) error {
+	f.pruned = uptoLSN
+	return nil
+}
+
+func TestStorage_WALBeforeMutation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	appended := false
+	log := &fakeWAL{append: func(_ context.Context, command string, args []string) (uint64, error) {
+		assert.Equal(t, "SET", command)
+		assert.Equal(t, []string{"t", "k", "v"}, args)
+		appended = true
+		return 1, nil
+	}}
+	mockEngine.EXPECT().Set(ctx, "t", "k", "v").DoAndReturn(func(context.Context, string, string, string) error {
+		assert.True(t, appended, "engine mutation happened before WAL append")
+		return nil
+	})
+
+	result, err := storage.New(mockEngine, storage.WithWAL(log)).Execute(ctx, "SET", []string{"t", "k", "v"})
+	require.NoError(t, err)
+	assert.Equal(t, protocol.SimpleString("OK"), result)
+}
+
+func TestStorage_WALFailurePreventsMutation(t *testing.T) {
+	t.Parallel()
+	expectedErr := errors.New("disk full")
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	log := &fakeWAL{append: func(context.Context, string, []string) (uint64, error) { return 0, expectedErr }}
+
+	result, err := storage.New(mockEngine, storage.WithWAL(log)).Execute(t.Context(), "DEL", []string{"t", "k"})
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, result)
+}
+
+// TestStorage_ConcurrentMutationsApplyInLSNOrder verifies that when many
+// mutations append concurrently (so the WAL can group-commit them), they still
+// land in the engine in LSN order: the surviving value is the highest-LSN write.
+func TestStorage_ConcurrentMutationsApplyInLSNOrder(t *testing.T) {
+	t.Parallel()
+	eng := engine.New()
+
+	var mu sync.Mutex
+	var lsn uint64
+	valueByLSN := make(map[uint64]string)
+	log := &fakeWAL{append: func(_ context.Context, _ string, args []string) (uint64, error) {
+		mu.Lock()
+		lsn++
+		assigned := lsn
+		valueByLSN[assigned] = args[2]
+		mu.Unlock()
+		// Jitter so appends return out of order relative to their LSNs; the apply
+		// gate must still serialize the engine writes by LSN.
+		time.Sleep(time.Duration(assigned%3) * time.Millisecond)
+		return assigned, nil
+	}}
+	store := storage.New(eng, storage.WithWAL(log))
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.Execute(context.Background(), "SET", []string{"t", "k", fmt.Sprintf("v%d", i)})
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	want := valueByLSN[lsn]
+	mu.Unlock()
+	got, err := eng.Get(context.Background(), "t", "k")
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "engine must reflect the highest-LSN write")
+}
+
+func TestStorage_SnapshotUsesMatchingLSNAndPrunes(t *testing.T) {
+	t.Parallel()
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	log := &fakeWAL{last: 17, append: func(context.Context, string, []string) (uint64, error) { return 0, nil }}
+	mockEngine.EXPECT().Range(gomock.Any()).Do(func(fn func(string, string, string) bool) {
+		fn("t", "k", "v")
+	})
+	store := storage.New(mockEngine, storage.WithWAL(log))
+
+	err := store.Snapshot(t.Context(), func(_ context.Context, lsn uint64, source storage.SnapshotSource) error {
+		assert.Equal(t, uint64(17), lsn)
+		source.Range(func(table, key, value string) bool {
+			assert.Equal(t, "t", table)
+			assert.Equal(t, "k", key)
+			assert.Equal(t, "v", value)
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(17), log.pruned)
 }
 
 func TestStorage_Execute(t *testing.T) {

--- a/internal/wal/files.go
+++ b/internal/wal/files.go
@@ -1,0 +1,59 @@
+package wal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	walPrefix      = "wal-"
+	walSuffix      = ".log"
+	snapshotPrefix = "snapshot-"
+	snapshotSuffix = ".db"
+)
+
+type numberedFile struct {
+	path   string
+	number uint64
+}
+
+func walFilename(firstLSN uint64) string {
+	return fmt.Sprintf("%s%020d%s", walPrefix, firstLSN, walSuffix)
+}
+
+func snapshotFilename(lsn uint64) string {
+	return fmt.Sprintf("%s%020d%s", snapshotPrefix, lsn, snapshotSuffix)
+}
+
+func listNumberedFiles(dir, prefix, suffix string) ([]numberedFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	files := make([]numberedFile, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		text := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+		number, parseErr := strconv.ParseUint(text, 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		files = append(files, numberedFile{path: filepath.Join(dir, name), number: number})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].number < files[j].number })
+	return files, nil
+}

--- a/internal/wal/reader.go
+++ b/internal/wal/reader.go
@@ -1,0 +1,116 @@
+package wal
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// Reader replays ordered WAL segments from a directory.
+type Reader struct {
+	dir    string
+	logger *slog.Logger
+}
+
+// NewReader creates a WAL reader. A nil logger discards recovery warnings.
+func NewReader(dir string, logger *slog.Logger) *Reader {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &Reader{dir: dir, logger: logger}
+}
+
+// Replay applies records newer than afterLSN and returns the last valid LSN.
+// A partial or checksum-invalid record in the final segment is truncated as a
+// crash tail; the same damage in an earlier segment is a startup error.
+func (r *Reader) Replay(afterLSN uint64, apply func(Record) error) (uint64, error) {
+	segments, err := listNumberedFiles(r.dir, walPrefix, walSuffix)
+	if err != nil {
+		return afterLSN, fmt.Errorf("list WAL segments: %w", err)
+	}
+
+	lastSeen := uint64(0)
+	lastApplied := afterLSN
+	for index, segment := range segments {
+		isLast := index == len(segments)-1
+		segmentLast, replayErr := r.replaySegment(segment, isLast, afterLSN, lastSeen, lastApplied, apply)
+		if replayErr != nil {
+			return lastApplied, replayErr
+		}
+		lastSeen = segmentLast.seen
+		lastApplied = segmentLast.applied
+	}
+	return lastApplied, nil
+}
+
+type replayPosition struct {
+	seen    uint64
+	applied uint64
+}
+
+func (r *Reader) replaySegment( //nolint:gocyclo // recovery deliberately keeps corruption decisions beside file-position handling
+	segment numberedFile,
+	isLast bool,
+	afterLSN uint64,
+	lastSeen uint64,
+	lastApplied uint64,
+	apply func(Record) error,
+) (replayPosition, error) {
+	file, err := os.Open(segment.path)
+	if err != nil {
+		return replayPosition{}, fmt.Errorf("open WAL segment %s: %w", segment.path, err)
+	}
+	reader := bufio.NewReader(file)
+	position := replayPosition{seen: lastSeen, applied: lastApplied}
+
+	for {
+		offset, seekErr := file.Seek(0, io.SeekCurrent)
+		if seekErr != nil {
+			_ = file.Close()
+			return position, fmt.Errorf("find WAL offset: %w", seekErr)
+		}
+		offset -= int64(reader.Buffered())
+
+		record, readErr := readRecord(reader)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			_ = file.Close()
+			if isLast && (errors.Is(readErr, ErrPartialRecord) || errors.Is(readErr, ErrChecksum)) {
+				if truncateErr := os.Truncate(segment.path, offset); truncateErr != nil {
+					return position, fmt.Errorf("truncate damaged WAL tail: %w", truncateErr)
+				}
+				r.logger.Warn("Truncated damaged WAL tail", "segment", segment.path, "offset", offset, "error", readErr)
+				return position, nil
+			}
+			return position, fmt.Errorf("corrupt WAL segment %s at offset %d: %w", segment.path, offset, readErr)
+		}
+
+		if position.seen != 0 && record.LSN != position.seen+1 {
+			_ = file.Close()
+			return position, fmt.Errorf("non-contiguous WAL LSN: got %d after %d", record.LSN, position.seen)
+		}
+		position.seen = record.LSN
+		if record.LSN <= afterLSN {
+			continue
+		}
+		if position.applied == afterLSN && record.LSN != afterLSN+1 {
+			_ = file.Close()
+			return position, fmt.Errorf("WAL starts at LSN %d after snapshot LSN %d", record.LSN, afterLSN)
+		}
+		if err = apply(record); err != nil {
+			_ = file.Close()
+			return position, fmt.Errorf("apply WAL record %d: %w", record.LSN, err)
+		}
+		position.applied = record.LSN
+	}
+
+	if err = file.Close(); err != nil {
+		return position, fmt.Errorf("close WAL segment: %w", err)
+	}
+	return position, nil
+}

--- a/internal/wal/record.go
+++ b/internal/wal/record.go
@@ -1,0 +1,109 @@
+package wal
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+
+	"github.com/OutOfStack/db/internal/protocol"
+)
+
+const (
+	checksumSize  = 4
+	lsnSize       = 8
+	maxRecordSize = 64 << 20
+
+	// CommandSet and CommandDel are the mutating operations accepted by the WAL.
+	CommandSet = "SET"
+	CommandDel = "DEL"
+)
+
+var (
+	// ErrChecksum is returned when a WAL record does not match its checksum.
+	ErrChecksum = errors.New("wal checksum mismatch")
+	// ErrPartialRecord is returned when the end of a record is missing.
+	ErrPartialRecord = errors.New("partial wal record")
+)
+
+// Record is one mutation stored in the write-ahead log.
+type Record struct {
+	LSN     uint64
+	Command string
+	Args    []string
+}
+
+func encodeRecord(record Record) ([]byte, error) {
+	var body bytes.Buffer
+	if err := binary.Write(&body, binary.BigEndian, record.LSN); err != nil {
+		return nil, fmt.Errorf("encode LSN: %w", err)
+	}
+	if err := protocol.WriteCommand(&body, record.Command, record.Args); err != nil {
+		return nil, fmt.Errorf("encode command: %w", err)
+	}
+
+	encoded := body.Bytes()
+	checksum := crc32.ChecksumIEEE(encoded)
+	result := make([]byte, 0, len(encoded)+checksumSize)
+	result = append(result, encoded...)
+	result = binary.BigEndian.AppendUint32(result, checksum)
+	return result, nil
+}
+
+func readRecord(reader *bufio.Reader) (Record, error) {
+	lsnBytes := make([]byte, lsnSize)
+	n, err := io.ReadFull(reader, lsnBytes)
+	if err != nil {
+		if errors.Is(err, io.EOF) && n == 0 {
+			return Record{}, io.EOF
+		}
+		return Record{}, fmt.Errorf("%w: read LSN: %w", ErrPartialRecord, err)
+	}
+
+	command, args, err := protocol.ReadCommand(reader, maxRecordSize)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return Record{}, fmt.Errorf("%w: read command: %w", ErrPartialRecord, err)
+		}
+		return Record{}, fmt.Errorf("decode command: %w", err)
+	}
+
+	checksumBytes := make([]byte, checksumSize)
+	if _, err = io.ReadFull(reader, checksumBytes); err != nil {
+		return Record{}, fmt.Errorf("%w: read checksum: %w", ErrPartialRecord, err)
+	}
+
+	record := Record{LSN: binary.BigEndian.Uint64(lsnBytes), Command: command, Args: args}
+	encoded, err := encodeRecord(record)
+	if err != nil {
+		return Record{}, err
+	}
+	want := binary.BigEndian.Uint32(checksumBytes)
+	got := binary.BigEndian.Uint32(encoded[len(encoded)-checksumSize:])
+	if got != want {
+		return Record{}, fmt.Errorf("%w: got %08x, want %08x", ErrChecksum, got, want)
+	}
+	if err = validateRecord(record); err != nil {
+		return Record{}, err
+	}
+	return record, nil
+}
+
+func validateRecord(record Record) error {
+	switch record.Command {
+	case CommandSet:
+		if len(record.Args) != 3 {
+			return fmt.Errorf("invalid SET WAL record: got %d arguments", len(record.Args))
+		}
+	case CommandDel:
+		if len(record.Args) != 2 {
+			return fmt.Errorf("invalid DEL WAL record: got %d arguments", len(record.Args))
+		}
+	default:
+		return fmt.Errorf("invalid WAL record command %q", record.Command)
+	}
+	return nil
+}

--- a/internal/wal/snapshot.go
+++ b/internal/wal/snapshot.go
@@ -1,0 +1,125 @@
+package wal
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/OutOfStack/db/internal/protocol"
+)
+
+// SnapshotSource exposes a stable iteration of the in-memory state.
+type SnapshotSource interface {
+	Range(fn func(table, key, value string) bool)
+}
+
+// WriteSnapshot atomically writes the full state as protocol-encoded SET commands.
+func WriteSnapshot(ctx context.Context, dir string, lsn uint64, source SnapshotSource) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create snapshot directory: %w", err)
+	}
+	name := snapshotFilename(lsn)
+	temporary, err := os.CreateTemp(dir, name+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create snapshot: %w", err)
+	}
+	temporaryName := temporary.Name()
+	defer func() { _ = os.Remove(temporaryName) }()
+
+	if err = writeSnapshotRecords(ctx, temporary, source); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err = temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync snapshot: %w", err)
+	}
+	if err = temporary.Close(); err != nil {
+		return fmt.Errorf("close snapshot: %w", err)
+	}
+	target := filepath.Join(dir, name)
+	if err = os.Rename(temporaryName, target); err != nil {
+		return fmt.Errorf("publish snapshot: %w", err)
+	}
+	if err = syncDirectory(dir); err != nil {
+		return fmt.Errorf("sync snapshot directory: %w", err)
+	}
+
+	return removeOldSnapshots(dir, lsn)
+}
+
+func writeSnapshotRecords(ctx context.Context, file io.Writer, source SnapshotSource) error {
+	var writeErr error
+	source.Range(func(table, key, value string) bool {
+		if ctx.Err() != nil {
+			writeErr = ctx.Err()
+			return false
+		}
+		if err := protocol.WriteCommand(file, CommandSet, []string{table, key, value}); err != nil {
+			writeErr = err
+			return false
+		}
+		return true
+	})
+	if writeErr != nil {
+		return fmt.Errorf("write snapshot: %w", writeErr)
+	}
+	return nil
+}
+
+func removeOldSnapshots(dir string, lsn uint64) error {
+	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	if err != nil {
+		return fmt.Errorf("list old snapshots: %w", err)
+	}
+	for _, snapshot := range snapshots {
+		if snapshot.number < lsn {
+			if err = os.Remove(snapshot.path); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove old snapshot: %w", err)
+			}
+		}
+	}
+	if err = syncDirectory(dir); err != nil {
+		return fmt.Errorf("sync snapshot cleanup: %w", err)
+	}
+	return nil
+}
+
+// LoadLatestSnapshot loads the newest complete snapshot and returns its LSN.
+func LoadLatestSnapshot(dir string, apply func(table, key, value string) error) (uint64, error) {
+	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	if err != nil {
+		return 0, fmt.Errorf("list snapshots: %w", err)
+	}
+	if len(snapshots) == 0 {
+		return 0, nil
+	}
+	latest := snapshots[len(snapshots)-1]
+	file, err := os.Open(latest.path)
+	if err != nil {
+		return 0, fmt.Errorf("open snapshot: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+	for {
+		command, args, readErr := protocol.ReadCommand(reader, maxRecordSize)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return 0, fmt.Errorf("read snapshot %s: %w", latest.path, readErr)
+		}
+		if command != CommandSet || len(args) != 3 {
+			return 0, fmt.Errorf("invalid snapshot record %q with %d arguments", command, len(args))
+		}
+		if err = apply(args[0], args[1], args[2]); err != nil {
+			return 0, fmt.Errorf("apply snapshot: %w", err)
+		}
+	}
+	return latest.number, nil
+}

--- a/internal/wal/syncdir_unix.go
+++ b/internal/wal/syncdir_unix.go
@@ -5,6 +5,7 @@ package wal
 import "os"
 
 func syncDirectory(path string) error {
+	// #nosec G304 -- path is the operator-configured WAL directory
 	directory, err := os.Open(path)
 	if err != nil {
 		return err

--- a/internal/wal/syncdir_unix.go
+++ b/internal/wal/syncdir_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package wal
+
+import "os"
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}

--- a/internal/wal/syncdir_windows.go
+++ b/internal/wal/syncdir_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package wal
+
+// Go's portable os API cannot open a Windows directory with the flags needed
+// by FlushFileBuffers. NTFS journals rename/create metadata; file contents are
+// still explicitly synced before publication.
+func syncDirectory(string) error { return nil }

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -1,0 +1,307 @@
+package wal_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+func TestRecordRoundTripAndChecksum(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := wal.Record{LSN: 1, Command: wal.CommandSet, Args: []string{"users", "name", "value\nwith\x00bytes"}}
+	if _, err = writer.Append(t.Context(), want.Command, want.Args); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = writer.Append(t.Context(), wal.CommandSet, []string{"users", "second", "value"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var got wal.Record
+	_, err = wal.NewReader(dir, nil).Replay(0, func(record wal.Record) error {
+		if record.LSN == want.LSN {
+			got = record
+		}
+		return nil
+	})
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("Replay() record = %#v, %v; want %#v, nil", got, err, want)
+	}
+
+	segments := walSegmentFiles(t, dir)
+	data, err := os.ReadFile(segments[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)-1] ^= 0xff
+	if err = os.WriteFile(segments[0], data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { return nil })
+	if !errors.Is(err, wal.ErrChecksum) {
+		t.Fatalf("Replay() error = %v, want ErrChecksum", err)
+	}
+}
+
+func walSegmentFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	segments, err := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(segments)
+	if len(segments) == 0 {
+		t.Fatal("no WAL segments found")
+	}
+	return segments
+}
+
+func TestWriterRotatesAndReaderReplays(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	for index := range 3 {
+		lsn, appendErr := writer.Append(t.Context(), wal.CommandSet, []string{"t", string(rune('a' + index)), "v"})
+		if appendErr != nil {
+			t.Fatalf("Append() error = %v", appendErr)
+		}
+		if lsn != uint64(index+1) {
+			t.Fatalf("Append() LSN = %d, want %d", lsn, index+1)
+		}
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	segments := walSegmentFiles(t, dir)
+	if len(segments) != 3 {
+		t.Fatalf("segments = %d, want 3", len(segments))
+	}
+
+	var records []wal.Record
+	lastLSN, err := wal.NewReader(dir, nil).Replay(0, func(record wal.Record) error {
+		records = append(records, record)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if lastLSN != 3 || len(records) != 3 {
+		t.Fatalf("Replay() = LSN %d, %d records; want 3, 3", lastLSN, len(records))
+	}
+}
+
+func TestReaderTruncatesPartialLastSegment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1 << 20}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	for _, key := range []string{"a", "b"} {
+		if _, err = writer.Append(t.Context(), wal.CommandSet, []string{"t", key, "v"}); err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	segments := walSegmentFiles(t, dir)
+	before, err := os.Stat(segments[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(segments[0], os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = file.Write([]byte{0, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err = file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int
+	lastLSN, err := wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { count++; return nil })
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	after, err := os.Stat(segments[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastLSN != 2 || count != 2 || after.Size() != before.Size() {
+		t.Fatalf("recovery = LSN %d, count %d, size %d; want 2, 2, %d", lastLSN, count, after.Size(), before.Size())
+	}
+}
+
+func TestReaderRejectsCorruptionInEarlierSegment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"a", "b"} {
+		if _, err = writer.Append(t.Context(), wal.CommandSet, []string{"t", key, "v"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	segments := walSegmentFiles(t, dir)
+	data, err := os.ReadFile(segments[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)-1] ^= 0xff
+	if err = os.WriteFile(segments[0], data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { return nil })
+	if !errors.Is(err, wal.ErrChecksum) {
+		t.Fatalf("Replay() error = %v, want checksum error", err)
+	}
+}
+
+func TestSnapshotAndWALTailRecoveryEquivalence(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	want := newTestState()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 128}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apply := func(command string, args []string) {
+		if command == wal.CommandSet {
+			want.set(args[0], args[1], args[2])
+		} else {
+			want.del(args[0], args[1])
+		}
+	}
+	appendMutation := func(command string, args []string) {
+		t.Helper()
+		if _, appendErr := writer.Append(t.Context(), command, args); appendErr != nil {
+			t.Fatal(appendErr)
+		}
+		apply(command, args)
+	}
+
+	appendMutation(wal.CommandSet, []string{"users", "a", "one"})
+	appendMutation(wal.CommandSet, []string{"users", "b", "two"})
+	snapshotLSN := writer.LastLSN()
+	if err = wal.WriteSnapshot(t.Context(), dir, snapshotLSN, want); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Prune(t.Context(), snapshotLSN); err != nil {
+		t.Fatal(err)
+	}
+	appendMutation(wal.CommandSet, []string{"orders", "x", "three"})
+	appendMutation(wal.CommandDel, []string{"users", "a"})
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := newTestState()
+	loadedLSN, err := wal.LoadLatestSnapshot(dir, func(table, key, value string) error {
+		got.set(table, key, value)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lastLSN, err := wal.NewReader(dir, nil).Replay(loadedLSN, func(record wal.Record) error {
+		if record.Command == wal.CommandSet {
+			got.set(record.Args[0], record.Args[1], record.Args[2])
+		} else {
+			got.del(record.Args[0], record.Args[1])
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastLSN != 4 || !reflect.DeepEqual(got.values, want.values) {
+		t.Fatalf("recovered LSN/state = %d/%v, want 4/%v", lastLSN, got.values, want.values)
+	}
+}
+
+type testState struct{ values map[string]map[string]string }
+
+func newTestState() *testState { return &testState{values: make(map[string]map[string]string)} }
+
+func (s *testState) set(table, key, value string) {
+	if s.values[table] == nil {
+		s.values[table] = make(map[string]string)
+	}
+	s.values[table][key] = value
+}
+
+func (s *testState) del(table, key string) {
+	delete(s.values[table], key)
+	if len(s.values[table]) == 0 {
+		delete(s.values, table)
+	}
+}
+
+func (s *testState) Range(fn func(table, key, value string) bool) {
+	for table, values := range s.values {
+		for key, value := range values {
+			if !fn(table, key, value) {
+				return
+			}
+		}
+	}
+}
+
+func BenchmarkAppendSyncPolicies(b *testing.B) {
+	for _, policy := range []wal.SyncPolicy{wal.SyncAlways, wal.SyncEverySec, wal.SyncNo} {
+		b.Run(string(policy), func(b *testing.B) {
+			dir := b.TempDir()
+			writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: policy, SegmentSize: 64 << 20}, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for range b.N {
+				if _, err = writer.Append(context.Background(), wal.CommandSet, []string{"t", "k", "value"}); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			if err = writer.Close(); err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSnapshotIgnoresTemporaryFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "snapshot-999.db.tmp"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lsn, err := wal.LoadLatestSnapshot(dir, func(string, string, string) error { return nil })
+	if err != nil || lsn != 0 {
+		t.Fatalf("LoadLatestSnapshot() = %d, %v; want 0, nil", lsn, err)
+	}
+}

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -1,0 +1,436 @@
+package wal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SyncPolicy controls when appended WAL records are fsynced.
+type SyncPolicy string
+
+const (
+	SyncAlways   SyncPolicy = "always"
+	SyncEverySec SyncPolicy = "everysec"
+	SyncNo       SyncPolicy = "no"
+)
+
+// ErrClosed is returned when an operation is attempted after shutdown starts.
+var ErrClosed = errors.New("wal writer is closed")
+
+// WriterConfig configures the segmented WAL writer.
+type WriterConfig struct {
+	Dir         string
+	Sync        SyncPolicy
+	SegmentSize int64
+}
+
+type requestKind uint8
+
+const (
+	requestAppend requestKind = iota
+	requestPrune
+	requestClose
+)
+
+type writerRequest struct {
+	kind    requestKind
+	command string
+	args    []string
+	uptoLSN uint64
+	result  chan writerResult
+}
+
+type writerResult struct {
+	lsn uint64
+	err error
+}
+
+// Writer serializes WAL appends through one goroutine.
+type Writer struct {
+	config WriterConfig
+	file   *os.File
+	size   int64
+
+	requests  chan writerRequest
+	done      chan struct{}
+	closing   atomic.Bool
+	lastLSN   atomic.Uint64
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// OpenWriter opens a writer after recovery. lastLSN must be the last LSN
+// returned by snapshot loading plus WAL replay.
+func OpenWriter(config WriterConfig, lastLSN uint64) (*Writer, error) {
+	if config.Dir == "" {
+		return nil, errors.New("WAL directory cannot be empty")
+	}
+	if config.SegmentSize <= 0 {
+		return nil, errors.New("WAL segment size must be positive")
+	}
+	switch config.Sync {
+	case SyncAlways, SyncEverySec, SyncNo:
+	default:
+		return nil, fmt.Errorf("invalid WAL sync policy %q", config.Sync)
+	}
+	if err := os.MkdirAll(config.Dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create WAL directory: %w", err)
+	}
+	segments, err := listNumberedFiles(config.Dir, walPrefix, walSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("list WAL segments: %w", err)
+	}
+	var file *os.File
+	var size int64
+	if len(segments) > 0 {
+		last := segments[len(segments)-1]
+		file, err = os.OpenFile(last.path, os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			return nil, fmt.Errorf("open WAL segment: %w", err)
+		}
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("stat WAL segment: %w", statErr)
+		}
+		size = info.Size()
+	}
+
+	writer := &Writer{
+		config:   config,
+		file:     file,
+		size:     size,
+		requests: make(chan writerRequest, 256),
+		done:     make(chan struct{}),
+	}
+	writer.lastLSN.Store(lastLSN)
+	go writer.run()
+	return writer, nil
+}
+
+// Append writes one mutation and waits until it satisfies the configured sync policy.
+func (w *Writer) Append(ctx context.Context, command string, args []string) (uint64, error) {
+	if w.closing.Load() {
+		return 0, ErrClosed
+	}
+	if err := validateRecord(Record{Command: command, Args: args}); err != nil {
+		return 0, err
+	}
+	result := make(chan writerResult, 1)
+	request := writerRequest{kind: requestAppend, command: command, args: append([]string(nil), args...), result: result}
+	select {
+	case w.requests <- request:
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-w.done:
+		return 0, ErrClosed
+	}
+	// Once the request is enqueued the writer will assign it a durable LSN, so we
+	// must wait for that outcome rather than abandoning it on ctx cancellation:
+	// an orphaned LSN would stall the caller's in-order apply of later records.
+	select {
+	case response := <-result:
+		return response.lsn, response.err
+	case <-w.done:
+		select {
+		case response := <-result:
+			return response.lsn, response.err
+		default:
+			return 0, ErrClosed
+		}
+	}
+}
+
+// LastLSN returns the most recently written LSN.
+func (w *Writer) LastLSN() uint64 { return w.lastLSN.Load() }
+
+// Prune removes segments whose records are all represented by a snapshot.
+func (w *Writer) Prune(ctx context.Context, uptoLSN uint64) error {
+	return w.control(ctx, writerRequest{kind: requestPrune, uptoLSN: uptoLSN})
+}
+
+// Close flushes, fsyncs, and closes the WAL. It is safe to call more than once.
+func (w *Writer) Close() error {
+	w.closeOnce.Do(func() {
+		w.closing.Store(true)
+		result := make(chan writerResult, 1)
+		select {
+		case w.requests <- writerRequest{kind: requestClose, result: result}:
+			response := <-result
+			w.closeErr = response.err
+		case <-w.done:
+		}
+	})
+	<-w.done
+	return w.closeErr
+}
+
+func (w *Writer) control(ctx context.Context, request writerRequest) error {
+	if w.closing.Load() {
+		return ErrClosed
+	}
+	request.result = make(chan writerResult, 1)
+	select {
+	case w.requests <- request:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return ErrClosed
+	}
+	select {
+	case response := <-request.result:
+		return response.err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return ErrClosed
+	}
+}
+
+func (w *Writer) run() {
+	defer close(w.done)
+	state := writerState{file: w.file, size: w.size}
+
+	var ticker *time.Ticker
+	var tick <-chan time.Time
+	if w.config.Sync == SyncEverySec {
+		ticker = time.NewTicker(time.Second)
+		tick = ticker.C
+		defer ticker.Stop()
+	}
+
+	for {
+		select {
+		case <-tick:
+			w.syncEverySecond(&state)
+		case request := <-w.requests:
+			if request.kind == requestAppend {
+				batch, control := w.collectAppendBatch(request)
+				w.handleBatch(batch, &state)
+				if control != nil && w.handleControl(*control, &state) {
+					return
+				}
+				continue
+			}
+			if w.handleControl(request, &state) {
+				return
+			}
+		}
+	}
+}
+
+type writerState struct {
+	file        *os.File
+	size        int64
+	terminalErr error
+}
+
+func (w *Writer) syncEverySecond(state *writerState) {
+	if state.terminalErr != nil || state.file == nil {
+		return
+	}
+	if err := state.file.Sync(); err != nil {
+		state.terminalErr = fmt.Errorf("sync WAL: %w", err)
+	}
+}
+
+func (w *Writer) collectAppendBatch(first writerRequest) ([]writerRequest, *writerRequest) {
+	batch := []writerRequest{first}
+	for {
+		select {
+		case next := <-w.requests:
+			if next.kind != requestAppend {
+				return batch, &next
+			}
+			batch = append(batch, next)
+		default:
+			return batch, nil
+		}
+	}
+}
+
+func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
+	results := make([]writerResult, len(batch))
+	for index, request := range batch {
+		if state.terminalErr != nil {
+			results[index].err = state.terminalErr
+			continue
+		}
+		lsn, err := w.appendOne(request, state)
+		if err != nil {
+			state.terminalErr = fmt.Errorf("append WAL record: %w", err)
+			results[index].err = state.terminalErr
+			continue
+		}
+		results[index].lsn = lsn
+	}
+
+	if state.terminalErr == nil && w.config.Sync == SyncAlways && state.file != nil {
+		if err := state.file.Sync(); err != nil {
+			state.terminalErr = fmt.Errorf("sync WAL: %w", err)
+		}
+	}
+	if state.terminalErr != nil {
+		for index := range results {
+			results[index].err = state.terminalErr
+		}
+	}
+	for index, request := range batch {
+		request.result <- results[index]
+	}
+}
+
+func (w *Writer) appendOne(request writerRequest, state *writerState) (uint64, error) {
+	lsn := w.lastLSN.Load() + 1
+	record, err := encodeRecord(Record{LSN: lsn, Command: request.command, Args: request.args})
+	if err != nil {
+		return 0, err
+	}
+	if err = w.ensureSegment(state, lsn, int64(len(record))); err != nil {
+		return 0, err
+	}
+	written, err := state.file.Write(record)
+	state.size += int64(written)
+	if err != nil {
+		return 0, err
+	}
+	if written != len(record) {
+		return 0, io.ErrShortWrite
+	}
+	w.lastLSN.Store(lsn)
+	return lsn, nil
+}
+
+func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64) error {
+	if state.file != nil && (state.size == 0 || state.size+recordSize <= w.config.SegmentSize) {
+		return nil
+	}
+	if err := w.closeForRotation(state); err != nil {
+		return err
+	}
+	path := filepath.Join(w.config.Dir, walFilename(lsn))
+	// #nosec G304 -- path is constrained to the configured directory and a generated numeric filename.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if w.config.Sync != SyncNo {
+		if err = syncDirectory(w.config.Dir); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("sync WAL directory: %w", err)
+		}
+	}
+	state.file = file
+	state.size = 0
+	return nil
+}
+
+func (w *Writer) closeForRotation(state *writerState) error {
+	if state.file == nil {
+		return nil
+	}
+	// Sync the segment being closed for any durable policy. Under SyncAlways a
+	// batch that overflows into a new segment would otherwise close the old
+	// segment with its final records unsynced, even though they were acked.
+	if w.config.Sync != SyncNo {
+		if err := state.file.Sync(); err != nil {
+			return err
+		}
+	}
+	return state.file.Close()
+}
+
+func (w *Writer) handleControl(request writerRequest, state *writerState) bool {
+	switch request.kind {
+	case requestPrune:
+		err := state.terminalErr
+		if err == nil {
+			err = w.prune(state, request.uptoLSN)
+		}
+		request.result <- writerResult{err: err}
+		return false
+	case requestClose:
+		err := state.terminalErr
+		if state.file != nil {
+			if syncErr := state.file.Sync(); err == nil && syncErr != nil {
+				err = fmt.Errorf("sync WAL during close: %w", syncErr)
+			}
+			if closeErr := state.file.Close(); err == nil && closeErr != nil {
+				err = fmt.Errorf("close WAL: %w", closeErr)
+			}
+		}
+		if syncErr := w.syncAllSegments(); err == nil && syncErr != nil {
+			err = syncErr
+		}
+		request.result <- writerResult{err: err}
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *Writer) syncAllSegments() error {
+	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	if err != nil {
+		return fmt.Errorf("list WAL segments during close: %w", err)
+	}
+	for _, segment := range segments {
+		file, openErr := os.OpenFile(segment.path, os.O_RDWR, 0o600)
+		if openErr != nil {
+			return fmt.Errorf("open WAL segment during close: %w", openErr)
+		}
+		syncErr := file.Sync()
+		closeErr := file.Close()
+		if syncErr != nil {
+			return fmt.Errorf("sync WAL segment during close: %w", syncErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close WAL segment during close: %w", closeErr)
+		}
+	}
+	return nil
+}
+
+func (w *Writer) prune(state *writerState, uptoLSN uint64) error {
+	if state.file != nil {
+		if err := state.file.Sync(); err != nil {
+			return fmt.Errorf("sync WAL before prune: %w", err)
+		}
+	}
+	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	if err != nil {
+		return fmt.Errorf("list WAL segments for prune: %w", err)
+	}
+	if w.lastLSN.Load() <= uptoLSN {
+		if state.file != nil {
+			if err = state.file.Close(); err != nil {
+				return fmt.Errorf("close WAL before prune: %w", err)
+			}
+			state.file = nil
+			state.size = 0
+		}
+		for _, segment := range segments {
+			if err = os.Remove(segment.path); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove WAL segment: %w", err)
+			}
+		}
+		return syncDirectory(w.config.Dir)
+	}
+
+	for index := 0; index+1 < len(segments); index++ {
+		if segments[index+1].number > uptoLSN+1 {
+			break
+		}
+		if err = os.Remove(segments[index].path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove WAL segment: %w", err)
+		}
+	}
+	return syncDirectory(w.config.Dir)
+}

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/OutOfStack/db/internal/protocol"
 )
 
 // SyncPolicy controls when appended WAL records are fsynced.
@@ -122,6 +124,12 @@ func (w *Writer) Append(ctx context.Context, command string, args []string) (uin
 	}
 	if err := validateRecord(Record{Command: command, Args: args}); err != nil {
 		return 0, err
+	}
+	// Reject records the recovery reader could not decode (its RESP limit is
+	// maxRecordSize). The network layer's max message size is configurable and
+	// may exceed this, so guard here rather than persisting an unreadable record.
+	if size := protocol.CommandSize(command, args); size > maxRecordSize {
+		return 0, fmt.Errorf("WAL record size %d exceeds maximum %d bytes", size, maxRecordSize)
 	}
 	result := make(chan writerResult, 1)
 	request := writerRequest{kind: requestAppend, command: command, args: append([]string(nil), args...), result: result}
@@ -258,6 +266,7 @@ func (w *Writer) collectAppendBatch(first writerRequest) ([]writerRequest, *writ
 
 func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
 	results := make([]writerResult, len(batch))
+	wrote := false
 	for index, request := range batch {
 		if state.terminalErr != nil {
 			results[index].err = state.terminalErr
@@ -270,16 +279,21 @@ func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
 			continue
 		}
 		results[index].lsn = lsn
+		wrote = true
 	}
 
-	if state.terminalErr == nil && w.config.Sync == SyncAlways && state.file != nil {
+	// Sync whatever was written even when a later append in the batch failed:
+	// the earlier records are already on disk and will replay on restart, so
+	// their callers must be acked, not failed. Only a sync failure leaves those
+	// records non-durable, and only then do we fail the callers we would ack.
+	if wrote && w.config.Sync == SyncAlways && state.file != nil {
 		if err := state.file.Sync(); err != nil {
 			state.terminalErr = fmt.Errorf("sync WAL: %w", err)
-		}
-	}
-	if state.terminalErr != nil {
-		for index := range results {
-			results[index].err = state.terminalErr
+			for index := range results {
+				if results[index].err == nil {
+					results[index].err = state.terminalErr
+				}
+			}
 		}
 	}
 	for index, request := range batch {
@@ -315,6 +329,11 @@ func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64)
 	if err := w.closeForRotation(state); err != nil {
 		return err
 	}
+	// The previous segment is closed and durably synced. Drop the handle so a
+	// failed open below cannot leave a stale, closed file that later code syncs
+	// (which would wrongly fail callers whose records are already durable).
+	state.file = nil
+	state.size = 0
 	path := filepath.Join(w.config.Dir, walFilename(lsn))
 	// #nosec G304 -- path is constrained to the configured directory and a generated numeric filename.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)


### PR DESCRIPTION
Add an optional WAL + snapshot persistence layer (disabled by default) so data survives restarts. Mutations are appended to a segmented, checksummed log before being applied to the engine; periodic snapshots let the log be pruned. On startup the server loads the latest snapshot, replays the WAL, and truncates a damaged crash tail.