### PR TITLE
feat(replication): add master/standby WAL replication with manual failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 *.dylib
 bin/
 .DS_Store
-db
-db-cli
+/db
+/db-cli
 
 # Test binary, built with `go test -c`
 *.test

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -380,7 +380,7 @@ func TestClient_Pool_Failover(t *testing.T) {
 
 	ctx := t.Context()
 
-	// master serves while alive
+	// master serves writes and reads while alive
 	if err = c.Set(ctx, "t", "key", "master-value"); err != nil {
 		t.Fatalf("Set() error = %v", err)
 	}
@@ -389,21 +389,44 @@ func TestClient_Pool_Failover(t *testing.T) {
 		t.Fatalf("Get() = %q, %v; want %q, nil", got, err, "master-value")
 	}
 
+	// Seed the standby directly (these in-process servers do not replicate) so a
+	// read that fails over to it returns an observably different value.
+	standby, err := client.New(client.WithAddress(standbyAddr))
+	if err != nil {
+		t.Fatalf("standby client New() error = %v", err)
+	}
+	defer standby.Close()
+	if err = standby.Set(ctx, "t", "key", "standby-value"); err != nil {
+		t.Fatalf("seed standby Set() error = %v", err)
+	}
+
 	stopMaster()
 
-	// after master death every operation must keep succeeding via the standby.
-	// The master's established connection may absorb at most one more request
-	// before it closes, so send two before asserting state
-	if err = c.Set(ctx, "t", "key", "standby-value"); err != nil {
-		t.Fatalf("Set() after master stop error = %v", err)
-	}
-	if err = c.Set(ctx, "t", "key", "standby-value"); err != nil {
-		t.Fatalf("second Set() after master stop error = %v", err)
+	// Reads fail over to the standby. The master's established connection may
+	// absorb at most one more request before it closes, so retry until failover.
+	if err = eventually(func() bool {
+		v, gErr := c.Get(ctx, "t", "key")
+		return gErr == nil && v == "standby-value"
+	}); err != nil {
+		t.Errorf("Get() did not fail over to standby: %v", err)
 	}
 
-	// servers do not replicate, so getting the new value proves the standby serves now
-	got, err = c.Get(ctx, "t", "key")
-	if err != nil || got != "standby-value" {
-		t.Errorf("Get() after failover = %q, %v; want %q, nil", got, err, "standby-value")
+	// Writes route only to masters, so with the master down they must fail rather
+	// than silently land on the read-only standby.
+	if err = eventually(func() bool {
+		return c.Set(ctx, "t", "key", "new-value") != nil
+	}); err != nil {
+		t.Errorf("Set() after master stop unexpectedly succeeded (writes must not hit standbys)")
 	}
+}
+
+// eventually retries cond for a short while, returning nil once it holds.
+func eventually(cond func() bool) error {
+	for range 50 {
+		if cond() {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return errors.New("condition not met within timeout")
 }

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -90,9 +90,24 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 	if walWriter != nil {
 		options = append(options, storage.WithWAL(walWriter))
 	}
+	// A standby starts read-only: client writes are rejected until PROMOTE, while
+	// replication applies the master's log directly to the engine.
+	if cfg.Replication.Role == config.RoleStandby {
+		options = append(options, storage.WithReadOnly(true))
+	}
 	store := storage.New(dbEngine, options...)
-	comp := compute.New(parser.New(), store, logger)
-	return serve(cfg, logger, comp, store, walWriter, snapshotLSN)
+
+	repl, err := setupReplication(cfg, logger, store, walWriter)
+	if err != nil {
+		return err
+	}
+
+	var computeOptions []compute.Option
+	if repl != nil {
+		computeOptions = append(computeOptions, compute.WithAdmin(repl.admin))
+	}
+	comp := compute.New(parser.New(), store, logger, computeOptions...)
+	return serve(cfg, logger, comp, store, walWriter, repl, snapshotLSN)
 }
 
 func recoverPersistence(
@@ -153,6 +168,7 @@ func serve(
 	comp *compute.Compute,
 	store *storage.Storage,
 	walWriter *wal.Writer,
+	repl *replicationRuntime,
 	recoveredSnapshotLSN uint64,
 ) error {
 	srv, err := network.NewTCPServer(cfg.Network.Address, logger,
@@ -170,9 +186,13 @@ func serve(
 		defer close(serverDone)
 		srv.Start(ctx, requestHandler(comp))
 	}()
+	// Snapshots run for every role: a standby applies replicated records through
+	// the storage layer under the same lock a snapshot takes, so its snapshots
+	// are consistent, and this keeps a promoted node's WAL bounded.
 	snapshotDone := startSnapshotLoop(ctx, cfg, logger, store, walWriter, recoveredSnapshotLSN)
+	replDone := startReplication(ctx, logger, repl)
 
-	logger.Info("Server started", "address", cfg.Network.Address)
+	logger.Info("Server started", "address", cfg.Network.Address, "role", roleName(cfg.Replication.Role))
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
@@ -180,6 +200,8 @@ func serve(
 
 	logger.Info("Shutting down server...")
 	cancel()
+	stopReplication(logger, repl)
+	<-replDone
 	<-serverDone
 	<-snapshotDone
 	if walWriter != nil {
@@ -199,8 +221,18 @@ func requestHandler(comp *compute.Compute) network.RequestHandler {
 		if errors.Is(err, storage.ErrNotFound) {
 			return protocol.NullBulkString()
 		}
+		if errors.Is(err, storage.ErrReadOnly) {
+			return protocol.Error("readonly")
+		}
 		return protocol.Error(err.Error())
 	}
+}
+
+func roleName(role string) string {
+	if role == config.RoleStandalone {
+		return "standalone"
+	}
+	return role
 }
 
 func startSnapshotLoop(

--- a/cmd/db/main_test.go
+++ b/cmd/db/main_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/replication"
+	"github.com/OutOfStack/db/internal/storage"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+// freeAddr returns a currently-free localhost address for a replication listener.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve address: %v", err)
+	}
+	addr := listener.Addr().String()
+	_ = listener.Close()
+	return addr
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	for range 200 {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestPromoteServesReplication promotes a standby and verifies it both accepts
+// writes and serves replication to a downstream standby.
+func TestPromoteServesReplication(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultServerConfig()
+	cfg.WAL.Enabled = true
+	cfg.WAL.DataDir = t.TempDir()
+	cfg.WAL.Sync = wal.SyncAlways
+	cfg.WAL.SegmentSizeMB = 1
+	cfg.Replication.Role = config.RoleStandby
+	cfg.Replication.MasterAddress = "127.0.0.1:1" // unreachable; loop just retries
+	cfg.Replication.ListenAddress = freeAddr(t)
+	cfg.Replication.ReconnectBackoff = time.Hour
+	logger := slog.New(slog.DiscardHandler)
+
+	dbEngine, writer, _, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		t.Fatalf("recoverPersistence() error = %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+	store := storage.New(dbEngine, storage.WithWAL(writer), storage.WithReadOnly(true))
+	repl, err := setupReplication(cfg, logger, store, writer)
+	if err != nil {
+		t.Fatalf("setupReplication() error = %v", err)
+	}
+	repl.standby.Start(t.Context())
+	defer stopReplication(logger, repl)
+
+	if _, err = store.Execute(t.Context(), "SET", []string{"t", "k", "v"}); !errors.Is(err, storage.ErrReadOnly) {
+		t.Fatalf("SET on standby error = %v, want ErrReadOnly", err)
+	}
+	if _, err = repl.admin.Promote(t.Context()); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	if store.ReadOnly() {
+		t.Fatal("store still read-only after promotion")
+	}
+	if _, err = store.Execute(t.Context(), "SET", []string{"t", "k", "v1"}); err != nil {
+		t.Fatalf("SET after promotion error = %v", err)
+	}
+
+	// A downstream standby can be re-aimed at the promoted node and replicates.
+	downstreamDir := t.TempDir()
+	dsEngine := engine.New()
+	dsWriter, err := wal.OpenWriter(wal.WriterConfig{Dir: downstreamDir, Sync: wal.SyncAlways, SegmentSize: 1 << 20}, 0)
+	if err != nil {
+		t.Fatalf("downstream OpenWriter() error = %v", err)
+	}
+	defer func() { _ = dsWriter.Close() }()
+	dsStore := storage.New(dsEngine, storage.WithWAL(dsWriter))
+	ds := replication.NewStandby(cfg.Replication.ListenAddress, dsStore, downstreamDir, 0, 10*time.Millisecond, logger)
+	ds.Start(t.Context())
+	defer ds.Stop()
+
+	waitFor(t, "downstream standby to replicate from promoted node", func() bool {
+		v, gErr := dsEngine.Get(context.Background(), "t", "k")
+		return gErr == nil && v == "v1"
+	})
+}
+
+func TestRecoverPersistenceSnapshotAndWALTail(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultServerConfig()
+	cfg.WAL.Enabled = true
+	cfg.WAL.DataDir = t.TempDir()
+	cfg.WAL.Sync = wal.SyncAlways
+	cfg.WAL.SegmentSizeMB = 1
+	cfg.WAL.SnapshotInterval = time.Minute
+	logger := slog.New(slog.DiscardHandler)
+
+	dbEngine, writer, _, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		t.Fatalf("initial recoverPersistence() error = %v", err)
+	}
+	store := storage.New(dbEngine, storage.WithWAL(writer))
+	if _, err = store.Execute(t.Context(), "SET", []string{"users", "a", "one"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = createSnapshot(t.Context(), cfg.WAL.DataDir, store); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.Execute(t.Context(), "SET", []string{"users", "b", "two"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.Execute(t.Context(), "DEL", []string{"users", "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, recoveredWriter, snapshotLSN, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		t.Fatalf("recoverPersistence() error = %v", err)
+	}
+	defer func() { _ = recoveredWriter.Close() }()
+	if snapshotLSN != 1 {
+		t.Fatalf("snapshot LSN = %d, want 1", snapshotLSN)
+	}
+	if _, err = recovered.Get(t.Context(), "users", "a"); !errors.Is(err, engine.ErrNotFound) {
+		t.Fatalf("deleted key error = %v, want ErrNotFound", err)
+	}
+	value, err := recovered.Get(t.Context(), "users", "b")
+	if err != nil || value != "two" {
+		t.Fatalf("recovered value = %q, %v; want two, nil", value, err)
+	}
+}

--- a/cmd/db/replication.go
+++ b/cmd/db/replication.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"sync"
+
+	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/replication"
+	"github.com/OutOfStack/db/internal/storage"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+// replicationRuntime bundles the replication components for a server, exactly
+// one of master/standby is non-nil (both nil for a standalone server).
+type replicationRuntime struct {
+	master  *replication.Master
+	standby *replication.Standby
+	admin   *replicationAdmin
+}
+
+// setupReplication builds the replication runtime for the configured role. It
+// returns nil for a standalone server. Replication requires the WAL, which the
+// config validation guarantees is enabled for master/standby roles.
+func setupReplication(
+	cfg *config.ServerConfig,
+	logger *slog.Logger,
+	store *storage.Storage,
+	writer *wal.Writer,
+) (*replicationRuntime, error) {
+	switch cfg.Replication.Role {
+	case config.RoleStandalone:
+		return nil, nil //nolint:nilnil // standalone has no replication runtime
+	case config.RoleMaster:
+		master, err := replication.NewMaster(cfg.Replication.ListenAddress, writer, cfg.WAL.DataDir, logger)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("Replication master listening", "address", master.Addr().String())
+		return &replicationRuntime{
+			master: master,
+			admin:  &replicationAdmin{store: store, writer: writer, logger: logger, role: config.RoleMaster},
+		}, nil
+	case config.RoleStandby:
+		standby := replication.NewStandby(
+			cfg.Replication.MasterAddress, store, cfg.WAL.DataDir,
+			writer.LastLSN(), cfg.Replication.ReconnectBackoff, logger)
+		return &replicationRuntime{
+			standby: standby,
+			admin: &replicationAdmin{
+				store:      store,
+				writer:     writer,
+				standby:    standby,
+				logger:     logger,
+				dir:        cfg.WAL.DataDir,
+				listenAddr: cfg.Replication.ListenAddress,
+				role:       config.RoleStandby,
+			},
+		}, nil
+	default:
+		return nil, errors.New("unsupported replication role: " + cfg.Replication.Role)
+	}
+}
+
+// startReplication launches replication background work. The returned channel
+// closes when a master stops accepting connections; for a standby the loop is
+// owned by the standby and drained by stopReplication.
+func startReplication(ctx context.Context, _ *slog.Logger, repl *replicationRuntime) <-chan struct{} {
+	done := make(chan struct{})
+	if repl == nil {
+		close(done)
+		return done
+	}
+	switch {
+	case repl.master != nil:
+		go func() {
+			defer close(done)
+			repl.master.Serve(ctx)
+		}()
+	case repl.standby != nil:
+		repl.standby.Start(ctx)
+		close(done)
+	default:
+		close(done)
+	}
+	return done
+}
+
+// stopReplication tears down replication during shutdown.
+func stopReplication(logger *slog.Logger, repl *replicationRuntime) {
+	if repl == nil {
+		return
+	}
+	if repl.master != nil {
+		if err := repl.master.Close(); err != nil {
+			logger.Error("Failed to close replication master", "error", err)
+		}
+	}
+	if repl.standby != nil {
+		repl.standby.Stop()
+	}
+	if repl.admin != nil {
+		repl.admin.close() // stops a master started by promotion, if any
+	}
+}
+
+// replicationAdmin implements compute.Admin, handling PROMOTE and REPLICATION
+// STATUS. Its role changes from standby to master on promotion.
+type replicationAdmin struct {
+	store      *storage.Storage
+	writer     *wal.Writer
+	standby    *replication.Standby // nil when started as master
+	logger     *slog.Logger
+	dir        string
+	listenAddr string // when set, promotion serves replication here
+
+	mu             sync.Mutex
+	role           string
+	promoted       *replication.Master
+	promotedCancel context.CancelFunc
+}
+
+// Promote flips a standby to master: it stops replication, lifts read-only mode
+// so the server accepts writes, and — when a listen address is configured —
+// starts serving replication so other standbys can be re-aimed here. Demoting
+// the old master remains an operator action.
+func (a *replicationAdmin) Promote(_ context.Context) (protocol.Reply, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.role == config.RoleMaster {
+		return protocol.Reply{}, errors.New("server is already master")
+	}
+	if a.standby != nil {
+		a.standby.Stop()
+	}
+	a.store.Promote()
+	a.role = config.RoleMaster
+	a.logger.Info("Promoted standby to master", "applied_lsn", a.writer.LastLSN())
+
+	if a.listenAddr != "" {
+		// The promoted master outlives this request, so it runs on its own
+		// lifetime context rather than the request context.
+		if err := a.startMasterLocked(); err != nil { //nolint:contextcheck // intentional: master uses its own lifetime context
+			// Writes are already enabled; log rather than fail the promotion.
+			a.logger.Error("Promoted master could not serve replication", "error", err)
+		}
+	}
+	return protocol.SimpleString("OK"), nil
+}
+
+// startMasterLocked starts a replication listener for the promoted node. The
+// caller holds a.mu.
+func (a *replicationAdmin) startMasterLocked() error {
+	master, err := replication.NewMaster(a.listenAddr, a.writer, a.dir, a.logger)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	a.promoted = master
+	a.promotedCancel = cancel
+	go master.Serve(ctx)
+	a.logger.Info("Promoted master serving replication", "address", master.Addr().String())
+	return nil
+}
+
+// close stops a replication listener started by promotion. It is called during
+// server shutdown.
+func (a *replicationAdmin) close() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.promotedCancel != nil {
+		a.promotedCancel()
+	}
+	if a.promoted != nil {
+		if err := a.promoted.Close(); err != nil {
+			a.logger.Error("Failed to close promoted replication master", "error", err)
+		}
+	}
+}
+
+// Status returns role, applied LSN, lag, and connection state as a flat
+// key/value array reply.
+func (a *replicationAdmin) Status(_ context.Context) (protocol.Reply, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var applied, lag uint64
+	connected := true
+	if a.role == config.RoleStandby && a.standby != nil {
+		applied = a.standby.AppliedLSN()
+		lag = a.standby.Lag()
+		connected = a.standby.Connected()
+	} else {
+		applied = a.writer.LastLSN()
+	}
+
+	values := []string{
+		"role", roleName(a.role),
+		"applied_lsn", strconv.FormatUint(applied, 10),
+		"lag", strconv.FormatUint(lag, 10),
+		"connected", strconv.FormatBool(connected),
+	}
+	return protocol.BulkStringArray(values), nil
+}

--- a/config.server.example.yaml
+++ b/config.server.example.yaml
@@ -12,6 +12,18 @@ wal:
   segment_size: 64          # MiB
   snapshot_interval: 5m
 
+# Replication ships the WAL from a master to standbys (asynchronous). It requires
+# wal.enabled. Leave role empty for a standalone server.
+replication:
+  role: ""                        # "", "master", or "standby"
+  # master: address standbys connect to for the WAL stream.
+  # standby (optional): if set, PROMOTE starts serving replication here so other
+  # standbys can be re-aimed at the promoted node.
+  listen_address: ""              # e.g. "127.0.0.1:3224"
+  # standby: the master's listen_address to replicate from.
+  master_address: ""              # e.g. "127.0.0.1:3224"
+  reconnect_backoff: 1s           # standby: pause between reconnect attempts
+
 network:
   address: "127.0.0.1:3223"
   max_connections: 100

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -1,18 +1,28 @@
 # Example commands for the Simple DB service
+# Keys are scoped by table: SET <table> <key> <value>
 
 # Basic operations
-SET user_name John
-GET user_name
+SET users name John
+GET users name
 
 # Delete and verify
-DEL user_name
-GET user_name
+DEL users name
+GET users name
 
 # Special characters
-SET path/to/file.txt /home/user/documents/file.txt
-GET path/to/file.txt
+SET files path/to/file.txt /home/user/documents/file.txt
+GET files path/to/file.txt
+
+# Introspection
+TABLES                 # list all tables
+EXISTS users           # does the table exist
+KEYS users             # list keys in a table
+
+# Replication (master/standby)
+REPLICATION STATUS     # role, applied LSN, lag, connection state
+PROMOTE                # promote a standby to master
 
 # Invalid commands
-SET invalid_key  # Missing value
-GET invalid_key invalid_value  # Too many args
-UNKNOWN invalid_command  # Unknown command
+SET users name         # Missing value
+GET users name extra   # Too many args
+UNKNOWN foo            # Unknown command

--- a/internal/compute/compute.go
+++ b/internal/compute/compute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 
 	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
@@ -19,16 +20,36 @@ type Parser interface {
 	Parse(cmd string, args []string) (string, []string, error)
 }
 
+// Admin handles replication control-plane commands that live above the storage
+// layer and are never written to the WAL.
+type Admin interface {
+	Promote(ctx context.Context) (protocol.Reply, error)
+	Status(ctx context.Context) (protocol.Reply, error)
+}
+
 // Compute represents compute layer
 type Compute struct {
 	parser  Parser
 	storage Storage
+	admin   Admin
 	logger  *slog.Logger
 }
 
+// Option configures a Compute.
+type Option func(*Compute)
+
+// WithAdmin wires a replication admin handler for PROMOTE and REPLICATION STATUS.
+func WithAdmin(admin Admin) Option {
+	return func(c *Compute) { c.admin = admin }
+}
+
 // New creates a new Compute with the given parser, storage, and logger
-func New(parser Parser, storage Storage, logger *slog.Logger) *Compute {
-	return &Compute{parser: parser, storage: storage, logger: logger}
+func New(parser Parser, storage Storage, logger *slog.Logger, options ...Option) *Compute {
+	c := &Compute{parser: parser, storage: storage, logger: logger}
+	for _, option := range options {
+		option(c)
+	}
+	return c
 }
 
 // HandleRequest validates and executes a decoded request.
@@ -41,6 +62,10 @@ func (c *Compute) HandleRequest(ctx context.Context, cmd string, args []string) 
 
 	c.logger.Info("Parsed command", "cmd", cmd, "args", args)
 
+	if reply, handled, adminErr := c.handleAdmin(ctx, cmd, args); handled {
+		return reply, adminErr
+	}
+
 	result, err := c.storage.Execute(ctx, cmd, args)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
@@ -52,4 +77,28 @@ func (c *Compute) HandleRequest(ctx context.Context, cmd string, args []string) 
 	}
 
 	return result, nil
+}
+
+// handleAdmin dispatches replication control commands. handled is true when cmd
+// is such a command, in which case the caller returns reply/err directly.
+func (c *Compute) handleAdmin(ctx context.Context, cmd string, args []string) (protocol.Reply, bool, error) {
+	switch cmd {
+	case "PROMOTE":
+		if c.admin == nil {
+			return protocol.Reply{}, true, errors.New("replication not enabled")
+		}
+		reply, err := c.admin.Promote(ctx)
+		return reply, true, err
+	case "REPLICATION":
+		if len(args) != 1 || !strings.EqualFold(args[0], "STATUS") {
+			return protocol.Reply{}, true, errors.New("usage: REPLICATION STATUS")
+		}
+		if c.admin == nil {
+			return protocol.Reply{}, true, errors.New("replication not enabled")
+		}
+		reply, err := c.admin.Status(ctx)
+		return reply, true, err
+	default:
+		return protocol.Reply{}, false, nil
+	}
 }

--- a/internal/compute/compute_test.go
+++ b/internal/compute/compute_test.go
@@ -2,12 +2,14 @@ package compute_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
 
 	"github.com/OutOfStack/db/internal/compute"
 	mocks "github.com/OutOfStack/db/internal/compute/mocks"
+	"github.com/OutOfStack/db/internal/parser"
 	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -93,4 +95,56 @@ func TestHandleRequest_StorageError(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, res)
 	require.Contains(t, err.Error(), "storage failed")
+}
+
+type fakeAdmin struct {
+	promoted   bool
+	statusCall bool
+}
+
+func (f *fakeAdmin) Promote(context.Context) (protocol.Reply, error) {
+	f.promoted = true
+	return protocol.SimpleString("OK"), nil
+}
+
+func (f *fakeAdmin) Status(context.Context) (protocol.Reply, error) {
+	f.statusCall = true
+	return protocol.BulkStringArray([]string{"role", "master"}), nil
+}
+
+func TestHandleRequest_AdminRouting(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Storage must never see admin commands.
+	mockStorage := mocks.NewMockStorage(ctrl)
+	admin := &fakeAdmin{}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	c := compute.New(parser.New(), mockStorage, logger, compute.WithAdmin(admin))
+	ctx := t.Context()
+
+	res, err := c.HandleRequest(ctx, "PROMOTE", nil)
+	require.NoError(t, err)
+	require.Equal(t, "OK", res.Value)
+	require.True(t, admin.promoted)
+
+	res, err = c.HandleRequest(ctx, "REPLICATION", []string{"STATUS"})
+	require.NoError(t, err)
+	require.Equal(t, protocol.ReplyArray, res.Kind)
+	require.True(t, admin.statusCall)
+}
+
+func TestHandleRequest_AdminDisabled(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStorage := mocks.NewMockStorage(ctrl)
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	c := compute.New(parser.New(), mockStorage, logger)
+
+	_, err := c.HandleRequest(t.Context(), "PROMOTE", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "replication not enabled")
 }

--- a/internal/compute/mocks/compute.go
+++ b/internal/compute/mocks/compute.go
@@ -95,3 +95,57 @@ func (mr *MockParserMockRecorder) Parse(cmd, args any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockParser)(nil).Parse), cmd, args)
 }
+
+// MockAdmin is a mock of Admin interface.
+type MockAdmin struct {
+	ctrl     *gomock.Controller
+	recorder *MockAdminMockRecorder
+	isgomock struct{}
+}
+
+// MockAdminMockRecorder is the mock recorder for MockAdmin.
+type MockAdminMockRecorder struct {
+	mock *MockAdmin
+}
+
+// NewMockAdmin creates a new mock instance.
+func NewMockAdmin(ctrl *gomock.Controller) *MockAdmin {
+	mock := &MockAdmin{ctrl: ctrl}
+	mock.recorder = &MockAdminMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAdmin) EXPECT() *MockAdminMockRecorder {
+	return m.recorder
+}
+
+// Promote mocks base method.
+func (m *MockAdmin) Promote(ctx context.Context) (protocol.Reply, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Promote", ctx)
+	ret0, _ := ret[0].(protocol.Reply)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Promote indicates an expected call of Promote.
+func (mr *MockAdminMockRecorder) Promote(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Promote", reflect.TypeOf((*MockAdmin)(nil).Promote), ctx)
+}
+
+// Status mocks base method.
+func (m *MockAdmin) Status(ctx context.Context) (protocol.Reply, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Status", ctx)
+	ret0, _ := ret[0].(protocol.Reply)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Status indicates an expected call of Status.
+func (mr *MockAdminMockRecorder) Status(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockAdmin)(nil).Status), ctx)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -121,6 +121,54 @@ func TestServerWALConfigValidation(t *testing.T) {
 	}
 }
 
+func TestServerReplicationConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		change func(*config.ServerConfig)
+		want   string
+	}{
+		{"master needs listen address", func(cfg *config.ServerConfig) {
+			cfg.Replication.Role = config.RoleMaster
+		}, "listen_address"},
+		{"standby needs master address", func(cfg *config.ServerConfig) {
+			cfg.Replication.Role = config.RoleStandby
+			cfg.Replication.ReconnectBackoff = time.Second
+		}, "master_address"},
+		{"unknown role", func(cfg *config.ServerConfig) {
+			cfg.Replication.Role = "arbiter"
+		}, "replication role"},
+		{"replication requires wal", func(cfg *config.ServerConfig) {
+			cfg.WAL.Enabled = false
+			cfg.Replication.Role = config.RoleMaster
+			cfg.Replication.ListenAddress = "127.0.0.1:3224"
+		}, "requires wal"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.DefaultServerConfig()
+			cfg.WAL.Enabled = true
+			cfg.WAL.DataDir = "data"
+			test.change(cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+func TestServerReplicationConfigValid(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultServerConfig()
+	cfg.WAL.Enabled = true
+	cfg.Replication.Role = config.RoleStandby
+	cfg.Replication.MasterAddress = "127.0.0.1:3224"
+	cfg.Replication.ReconnectBackoff = time.Second
+	require.NoError(t, cfg.Validate())
+}
+
 func TestLoadServerConfig_EnvOverrides(t *testing.T) { //nolint:paralleltest // t.Setenv
 	t.Run("env overrides defaults", func(t *testing.T) {
 		t.Setenv("DB_ADDRESS", "0.0.0.0:9999")

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -21,12 +21,31 @@ const (
 	envLogOutput      = "DB_LOG_OUTPUT"
 )
 
+// Replication roles.
+const (
+	RoleStandalone = ""
+	RoleMaster     = "master"
+	RoleStandby    = "standby"
+)
+
 // ServerConfig - configuration for the database server
 type ServerConfig struct {
-	Engine  ServerEngineConfig  `yaml:"engine"`
-	WAL     ServerWALConfig     `yaml:"wal"`
-	Network ServerNetworkConfig `yaml:"network"`
-	Logging ServerLoggingConfig `yaml:"logging"`
+	Engine      ServerEngineConfig      `yaml:"engine"`
+	WAL         ServerWALConfig         `yaml:"wal"`
+	Replication ServerReplicationConfig `yaml:"replication"`
+	Network     ServerNetworkConfig     `yaml:"network"`
+	Logging     ServerLoggingConfig     `yaml:"logging"`
+}
+
+// ServerReplicationConfig controls master/standby log shipping. Role is
+// "master", "standby", or empty (standalone). A master streams its WAL to
+// standbys that connect to ListenAddress; a standby connects to MasterAddress.
+// Replication requires WAL persistence to be enabled.
+type ServerReplicationConfig struct {
+	Role             string        `yaml:"role"`
+	ListenAddress    string        `yaml:"listen_address"`
+	MasterAddress    string        `yaml:"master_address"`
+	ReconnectBackoff time.Duration `yaml:"reconnect_backoff"`
 }
 
 // ServerWALConfig controls durable write-ahead logging and snapshots.
@@ -74,6 +93,10 @@ func DefaultServerConfig() *ServerConfig {
 			Sync:             wal.SyncEverySec,
 			SegmentSizeMB:    64,
 			SnapshotInterval: 5 * time.Minute,
+		},
+		Replication: ServerReplicationConfig{
+			Role:             RoleStandalone,
+			ReconnectBackoff: time.Second,
 		},
 		Network: ServerNetworkConfig{
 			Address:          defaultAddress,
@@ -163,5 +186,31 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	return c.Replication.validate(c.WAL.Enabled)
+}
+
+// validate checks replication settings. Replication requires WAL persistence,
+// since the WAL is the replication stream.
+func (r *ServerReplicationConfig) validate(walEnabled bool) error {
+	switch r.Role {
+	case RoleStandalone:
+		return nil
+	case RoleMaster:
+		if r.ListenAddress == "" {
+			return errors.New("replication master requires listen_address")
+		}
+	case RoleStandby:
+		if r.MasterAddress == "" {
+			return errors.New("replication standby requires master_address")
+		}
+		if r.ReconnectBackoff <= 0 {
+			return errors.New("replication reconnect_backoff must be positive")
+		}
+	default:
+		return fmt.Errorf("unsupported replication role: %s", r.Role)
+	}
+	if !walEnabled {
+		return errors.New("replication requires wal.enabled")
+	}
 	return nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -102,7 +102,21 @@ func (e *Engine) Reset() {
 func (e *Engine) Load(_ context.Context, entries []Entry) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	e.load(entries)
+}
 
+// Replace atomically swaps all stored data for entries under a single lock, so a
+// concurrent reader never observes the empty intermediate state that separate
+// Reset + Load calls would expose. Used by snapshot resync on a serving standby.
+func (e *Engine) Replace(entries []Entry) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.store = make(map[string]map[string]string)
+	e.load(entries)
+}
+
+// load inserts entries into the current store. The caller holds e.mu.
+func (e *Engine) load(entries []Entry) {
 	for _, entry := range entries {
 		table := e.store[entry.Table]
 		if table == nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -89,6 +89,15 @@ func (e *Engine) Range(fn func(table, key, value string) bool) {
 	}
 }
 
+// Reset removes all stored data. A standby calls it during snapshot resync,
+// before loading the master's snapshot, since the snapshot fully replaces the
+// standby's superseded state.
+func (e *Engine) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.store = make(map[string]map[string]string)
+}
+
 // Load inserts a recovered set of entries without routing them through the WAL.
 func (e *Engine) Load(_ context.Context, entries []Entry) {
 	e.mu.Lock()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -9,7 +9,10 @@ import (
 // maxTableNameLen is the maximum allowed length of a table name
 const maxTableNameLen = 128
 
-const commandTables = "TABLES"
+const (
+	commandTables  = "TABLES"
+	commandPromote = "PROMOTE"
+)
 
 // Parser implements a parser for a simple key-value store
 type Parser struct{}
@@ -17,7 +20,10 @@ type Parser struct{}
 type commandSpec struct {
 	args     int
 	readOnly bool
-	usage    string
+	// admin marks a control-plane command (e.g. replication management) whose
+	// arguments are not table-scoped and so skip table/key validation.
+	admin bool
+	usage string
 }
 
 // commands is the central command registry used for validation and future
@@ -29,6 +35,8 @@ var commands = map[string]commandSpec{ //nolint:gochecknoglobals // a single reg
 	commandTables: {args: 0, readOnly: true, usage: commandTables},
 	"EXISTS":      {args: 1, readOnly: true, usage: "EXISTS <table>"},
 	"KEYS":        {args: 1, readOnly: true, usage: "KEYS <table>"},
+	commandPromote: {args: 0, readOnly: false, admin: true, usage: commandPromote},
+	"REPLICATION": {args: 1, readOnly: true, admin: true, usage: "REPLICATION STATUS"},
 }
 
 // New creates a new Parser instance.
@@ -51,7 +59,7 @@ func (p *Parser) Parse(cmd string, args []string) (string, []string, error) {
 		return "", nil, fmt.Errorf("%s requires %d arguments: %s", cmd, spec.args, spec.usage)
 	}
 
-	if spec.args == 0 {
+	if spec.args == 0 || spec.admin {
 		return cmd, args, nil
 	}
 	if len(args[0]) > maxTableNameLen {

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -3,12 +3,18 @@ package pool
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/OutOfStack/db/internal/network"
 	"github.com/OutOfStack/db/internal/protocol"
 )
+
+// readOnlyReply is the error value a standby returns for a mutating command
+// (wire "-ERR readonly", decoded with the "ERR " prefix stripped). It signals
+// that the selected server is not actually a writable master.
+const readOnlyReply = "readonly"
 
 // syncedConnection wraps a TCPClient with a mutex to serialize Send() calls
 type syncedConnection struct {
@@ -53,22 +59,20 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	}, nil
 }
 
-// Send sends a command using the pool, with automatic failover
+// Send sends a command using the pool, with automatic failover. Writes (SET,
+// DEL) route to a master; reads follow the configured strategy. A standby that
+// replies "ERR readonly" to a write marks the routing stale, so the pool fails
+// that server over and retries against another master.
 func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
+	write := isWriteCommand(cmd)
 	var lastErr error
 	attempts := 0
 	maxAttempts := c.config.MaxRetries + 1 // initial attempt + retries
 
 	for attempts < maxAttempts {
-		// Select a server
-		server := c.selector.Select()
+		server := c.selectServer(write)
 		if server == nil {
-			// No servers available, reset and try one more time
-			c.selector.Reset()
-			server = c.selector.Select()
-			if server == nil {
-				return protocol.Reply{}, errors.New("no servers available in pool")
-			}
+			return protocol.Reply{}, noServersError(write)
 		}
 
 		// Get or create connection
@@ -97,6 +101,18 @@ func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 			continue
 		}
 
+		// A write that reached a read-only server means our master routing is
+		// stale (the server was demoted); fail it over and retry elsewhere.
+		if write && isReadOnlyReply(resp) {
+			c.selector.MarkFailed(server.Address)
+			lastErr = fmt.Errorf("server %s is read-only", server.Address)
+			attempts++
+			if attempts < maxAttempts {
+				time.Sleep(c.config.RetryDelay)
+			}
+			continue
+		}
+
 		// Success!
 		return resp, nil
 	}
@@ -105,6 +121,46 @@ func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 		return protocol.Reply{}, fmt.Errorf("all servers failed after %d attempts: %w", attempts, lastErr)
 	}
 	return protocol.Reply{}, fmt.Errorf("all servers failed after %d attempts", attempts)
+}
+
+// selectServer picks a server for the command, resetting the selector once if
+// all candidates are currently marked failed.
+func (c *Client) selectServer(write bool) *ServerConfig {
+	server := c.pick(write)
+	if server == nil {
+		c.selector.Reset()
+		server = c.pick(write)
+	}
+	return server
+}
+
+func (c *Client) pick(write bool) *ServerConfig {
+	if write {
+		return c.selector.SelectWrite()
+	}
+	return c.selector.SelectRead()
+}
+
+func noServersError(write bool) error {
+	if write {
+		return errors.New("no master servers available in pool")
+	}
+	return errors.New("no servers available in pool")
+}
+
+// isWriteCommand reports whether cmd mutates state and must route to a master.
+func isWriteCommand(cmd string) bool {
+	switch strings.ToUpper(strings.TrimSpace(cmd)) {
+	case "SET", "DEL":
+		return true
+	default:
+		return false
+	}
+}
+
+// isReadOnlyReply reports whether resp is a standby's "ERR readonly" response.
+func isReadOnlyReply(resp protocol.Reply) bool {
+	return resp.Kind == protocol.ReplyError && strings.EqualFold(resp.Value, readOnlyReply)
 }
 
 // getConnection gets or creates a connection to the specified address

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -1,0 +1,131 @@
+package pool_test
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/pool"
+	"github.com/OutOfStack/db/internal/protocol"
+)
+
+// startHandler runs an in-process server with a custom handler on an ephemeral
+// port and returns its address.
+func startHandler(t *testing.T, handler network.RequestHandler) string {
+	t.Helper()
+	srv, err := network.NewTCPServer("127.0.0.1:0", slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewTCPServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go srv.Start(ctx, handler)
+	return srv.Addr().String()
+}
+
+func okHandler(hits *atomic.Int32) network.RequestHandler {
+	return func(_ context.Context, _ string, _ []string) protocol.Reply {
+		hits.Add(1)
+		return protocol.SimpleString("OK")
+	}
+}
+
+func newPool(t *testing.T, servers []pool.ServerConfig, strategy pool.SelectionStrategy) *pool.Client {
+	t.Helper()
+	client, err := pool.NewClient(&pool.PoolConfig{
+		Enabled:           true,
+		Servers:           servers,
+		SelectionStrategy: strategy,
+		MaxRetries:        3,
+		RetryDelay:        5 * time.Millisecond,
+		FailureTimeout:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// TestSelectWrite_OnlyMasters verifies every strategy's SelectWrite returns a
+// master, never a standby.
+func TestSelectWrite_OnlyMasters(t *testing.T) {
+	t.Parallel()
+	config := &pool.PoolConfig{
+		Servers: []pool.ServerConfig{
+			{Address: "m1", Role: pool.RoleMaster},
+			{Address: "s1", Role: pool.RoleStandby},
+			{Address: "s2", Role: pool.RoleStandby},
+		},
+		FailureTimeout: time.Hour,
+	}
+	for _, strategy := range []pool.SelectionStrategy{pool.StrategyMasterFirst, pool.StrategyRoundRobin, pool.StrategyRandom} {
+		config.SelectionStrategy = strategy
+		selector := pool.NewSelector(config)
+		for range 20 {
+			server := selector.SelectWrite()
+			if server == nil {
+				t.Fatalf("%s: SelectWrite returned nil", strategy)
+			}
+			if server.Role != pool.RoleMaster {
+				t.Fatalf("%s: SelectWrite returned %s (role %s), want a master", strategy, server.Address, server.Role)
+			}
+		}
+	}
+}
+
+// TestClient_WritesSkipStandbys verifies writes route only to masters while
+// reads may use standbys.
+func TestClient_WritesSkipStandbys(t *testing.T) {
+	t.Parallel()
+	var masterHits, standbyHits atomic.Int32
+	masterAddr := startHandler(t, okHandler(&masterHits))
+	standbyAddr := startHandler(t, okHandler(&standbyHits))
+
+	client := newPool(t, []pool.ServerConfig{
+		{Address: masterAddr, Role: pool.RoleMaster},
+		{Address: standbyAddr, Role: pool.RoleStandby},
+	}, pool.StrategyMasterFirst)
+
+	for range 5 {
+		if _, err := client.Send("SET", []string{"t", "k", "v"}); err != nil {
+			t.Fatalf("Send SET: %v", err)
+		}
+	}
+	if standbyHits.Load() != 0 {
+		t.Errorf("standby received %d writes, want 0", standbyHits.Load())
+	}
+	if masterHits.Load() != 5 {
+		t.Errorf("master received %d writes, want 5", masterHits.Load())
+	}
+}
+
+// TestClient_ReadOnlyFailover verifies an "ERR readonly" reply to a write marks
+// the server stale and reroutes to another master.
+func TestClient_ReadOnlyFailover(t *testing.T) {
+	t.Parallel()
+	var goodHits atomic.Int32
+	readOnlyAddr := startHandler(t, func(_ context.Context, _ string, _ []string) protocol.Reply {
+		return protocol.Error("readonly")
+	})
+	goodAddr := startHandler(t, okHandler(&goodHits))
+
+	client := newPool(t, []pool.ServerConfig{
+		{Address: readOnlyAddr, Role: pool.RoleMaster},
+		{Address: goodAddr, Role: pool.RoleMaster},
+	}, pool.StrategyMasterFirst)
+
+	resp, err := client.Send("SET", []string{"t", "k", "v"})
+	if err != nil {
+		t.Fatalf("Send SET: %v", err)
+	}
+	if resp.Kind != protocol.ReplySimpleString || resp.Value != "OK" {
+		t.Fatalf("reply = %+v, want +OK", resp)
+	}
+	if goodHits.Load() == 0 {
+		t.Error("write never reached the writable master after readonly failover")
+	}
+}

--- a/internal/pool/selector.go
+++ b/internal/pool/selector.go
@@ -8,8 +8,14 @@ import (
 
 // ServerSelector is responsible for selecting servers from the pool
 type ServerSelector interface {
-	// Select returns the next server to use, or nil if no servers available
+	// Select returns the next server to use, or nil if no servers available.
+	// It is equivalent to SelectRead and kept for backward compatibility.
 	Select() *ServerConfig
+	// SelectRead returns the next server for a read, following the strategy.
+	SelectRead() *ServerConfig
+	// SelectWrite returns the next master for a write, or nil if none available.
+	// Standbys are never returned: writes must reach a master.
+	SelectWrite() *ServerConfig
 	// MarkFailed marks a server as failed
 	MarkFailed(address string)
 	// Reset resets the selector state
@@ -38,18 +44,15 @@ func NewMasterFirstSelector(config *PoolConfig) *MasterFirstSelector {
 }
 
 // Select picks the next available server (master first, then standby)
-func (s *MasterFirstSelector) Select() *ServerConfig {
+func (s *MasterFirstSelector) Select() *ServerConfig { return s.SelectRead() }
+
+// SelectRead picks the next available server (master first, then standby)
+func (s *MasterFirstSelector) SelectRead() *ServerConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Try masters first
-	for i := range len(s.masters) {
-		idx := (s.currentMaster + i) % len(s.masters)
-		server := &s.masters[idx]
-		if !s.isFailed(server.Address) {
-			s.currentMaster = (idx + 1) % len(s.masters)
-			return server
-		}
+	if server := s.selectMasterLocked(); server != nil {
+		return server
 	}
 
 	// Fall back to standbys
@@ -62,6 +65,25 @@ func (s *MasterFirstSelector) Select() *ServerConfig {
 		}
 	}
 
+	return nil
+}
+
+// SelectWrite picks the next available master, or nil when none are available.
+func (s *MasterFirstSelector) SelectWrite() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.selectMasterLocked()
+}
+
+func (s *MasterFirstSelector) selectMasterLocked() *ServerConfig {
+	for i := range len(s.masters) {
+		idx := (s.currentMaster + i) % len(s.masters)
+		server := &s.masters[idx]
+		if !s.isFailed(server.Address) {
+			s.currentMaster = (idx + 1) % len(s.masters)
+			return server
+		}
+	}
 	return nil
 }
 
@@ -100,7 +122,9 @@ func (s *MasterFirstSelector) isFailed(address string) bool {
 type RoundRobinSelector struct {
 	mu             sync.RWMutex
 	servers        []ServerConfig
+	masters        []ServerConfig
 	current        int
+	currentMaster  int
 	failedServers  map[string]time.Time
 	failureTimeout time.Duration
 }
@@ -109,29 +133,40 @@ type RoundRobinSelector struct {
 func NewRoundRobinSelector(config *PoolConfig) *RoundRobinSelector {
 	return &RoundRobinSelector{
 		servers:        config.Servers,
+		masters:        config.GetMasters(),
 		failedServers:  make(map[string]time.Time),
 		failureTimeout: config.FailureTimeout,
 	}
 }
 
 // Select picks the next server in round-robin order
-func (s *RoundRobinSelector) Select() *ServerConfig {
+func (s *RoundRobinSelector) Select() *ServerConfig { return s.SelectRead() }
+
+// SelectRead picks the next server in round-robin order across all servers
+func (s *RoundRobinSelector) SelectRead() *ServerConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return rotate(s.servers, &s.current, s.isFailed)
+}
 
-	if len(s.servers) == 0 {
-		return nil
-	}
+// SelectWrite picks the next master in round-robin order
+func (s *RoundRobinSelector) SelectWrite() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return rotate(s.masters, &s.currentMaster, s.isFailed)
+}
 
-	for i := range len(s.servers) {
-		idx := (s.current + i) % len(s.servers)
-		server := &s.servers[idx]
-		if !s.isFailed(server.Address) {
-			s.current = (idx + 1) % len(s.servers)
+// rotate returns the next non-failed server from servers starting at *cursor,
+// advancing the cursor past the chosen server.
+func rotate(servers []ServerConfig, cursor *int, isFailed func(string) bool) *ServerConfig {
+	for i := range servers {
+		idx := (*cursor + i) % len(servers)
+		server := &servers[idx]
+		if !isFailed(server.Address) {
+			*cursor = (idx + 1) % len(servers)
 			return server
 		}
 	}
-
 	return nil
 }
 
@@ -169,6 +204,7 @@ func (s *RoundRobinSelector) isFailed(address string) bool {
 type RandomSelector struct {
 	mu             sync.RWMutex
 	servers        []ServerConfig
+	masters        []ServerConfig
 	failedServers  map[string]time.Time
 	failureTimeout time.Duration
 }
@@ -177,35 +213,42 @@ type RandomSelector struct {
 func NewRandomSelector(config *PoolConfig) *RandomSelector {
 	return &RandomSelector{
 		servers:        config.Servers,
+		masters:        config.GetMasters(),
 		failedServers:  make(map[string]time.Time),
 		failureTimeout: config.FailureTimeout,
 	}
 }
 
 // Select picks a random available server
-func (s *RandomSelector) Select() *ServerConfig {
+func (s *RandomSelector) Select() *ServerConfig { return s.SelectRead() }
+
+// SelectRead picks a random available server across all servers
+func (s *RandomSelector) SelectRead() *ServerConfig {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.pickRandom(s.servers)
+}
 
-	if len(s.servers) == 0 {
-		return nil
-	}
+// SelectWrite picks a random available master
+func (s *RandomSelector) SelectWrite() *ServerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pickRandom(s.masters)
+}
 
-	// Get available servers
+func (s *RandomSelector) pickRandom(servers []ServerConfig) *ServerConfig {
 	available := []int{}
-	for i := range s.servers {
-		if !s.isFailed(s.servers[i].Address) {
+	for i := range servers {
+		if !s.isFailed(servers[i].Address) {
 			available = append(available, i)
 		}
 	}
-
 	if len(available) == 0 {
 		return nil
 	}
-
 	//nolint:gosec // Non-cryptographic random is sufficient for server selection
 	idx := available[rand.IntN(len(available))]
-	return &s.servers[idx]
+	return &servers[idx]
 }
 
 // MarkFailed marks a server as failed

--- a/internal/replication/master.go
+++ b/internal/replication/master.go
@@ -1,0 +1,230 @@
+package replication
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+// defaultHeartbeatInterval is how often the master emits a heartbeat frame to an
+// otherwise-idle standby so it can keep its lag estimate current.
+const defaultHeartbeatInterval = time.Second
+
+// Master streams the WAL to connecting standbys. It combines historical segment
+// files on disk with a live fan-out from the WAL writer, so a standby resumes
+// from any LSN: a fresh or lagging standby catches up from segments (or a
+// snapshot when its position was already truncated), then tails live commits.
+type Master struct {
+	writer   *wal.Writer
+	dir      string
+	listener net.Listener
+	logger   *slog.Logger
+
+	heartbeatInterval time.Duration
+	wg                sync.WaitGroup
+}
+
+// NewMaster starts listening for standby connections on listenAddr. writer and
+// dir are the server's live WAL writer and its data directory.
+func NewMaster(listenAddr string, writer *wal.Writer, dir string, logger *slog.Logger) (*Master, error) {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(context.Background(), "tcp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("start replication listener: %w", err)
+	}
+	return &Master{
+		writer:            writer,
+		dir:               dir,
+		listener:          listener,
+		logger:            logger,
+		heartbeatInterval: defaultHeartbeatInterval,
+	}, nil
+}
+
+// Addr returns the address the master is listening on for standbys.
+func (m *Master) Addr() net.Addr { return m.listener.Addr() }
+
+// Serve accepts standby connections until ctx is cancelled or Close is called.
+func (m *Master) Serve(ctx context.Context) {
+	for {
+		conn, err := m.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			m.logger.Error("Replication accept failed", "error", err)
+			continue
+		}
+		m.wg.Go(func() {
+			m.handleConn(ctx, conn)
+		})
+	}
+}
+
+// Close stops accepting connections and waits for in-flight streams to end.
+func (m *Master) Close() error {
+	err := m.listener.Close()
+	m.wg.Wait()
+	return err
+}
+
+func (m *Master) handleConn(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	// Close the connection when the server shuts down so a blocked stream unblocks.
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stop()
+
+	reader := bufio.NewReader(conn)
+	requestedLSN, err := readHandshake(reader)
+	if err != nil {
+		m.logger.Warn("Replication handshake failed", "remote", conn.RemoteAddr(), "error", err)
+		return
+	}
+	m.logger.Info("Standby connected", "remote", conn.RemoteAddr(), "from_lsn", requestedLSN)
+
+	writer := bufio.NewWriter(conn)
+	if err = m.stream(ctx, writer, requestedLSN); err != nil && !errors.Is(err, context.Canceled) {
+		m.logger.Info("Replication stream ended", "remote", conn.RemoteAddr(), "error", err)
+	}
+}
+
+func (m *Master) stream(ctx context.Context, w *bufio.Writer, requestedLSN uint64) error {
+	sub, unsub := m.writer.Subscribe()
+	defer unsub()
+
+	nextLSN := requestedLSN + 1
+	oldest, err := wal.OldestRecordLSN(m.dir, m.writer.LastLSN()+1)
+	if err != nil {
+		return err
+	}
+	if nextLSN < oldest {
+		snapLSN, serr := m.sendSnapshot(w)
+		if serr != nil {
+			return serr
+		}
+		if snapLSN+1 > nextLSN {
+			nextLSN = snapLSN + 1
+		}
+	}
+
+	ticker := time.NewTicker(m.heartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		if err = m.streamDisk(w, &nextLSN); err != nil {
+			return err
+		}
+		if err = w.Flush(); err != nil {
+			return err
+		}
+		gap, cErr := m.consumeLive(ctx, w, sub, ticker, &nextLSN)
+		if cErr != nil {
+			return cErr
+		}
+		if !gap {
+			return nil
+		}
+	}
+}
+
+// consumeLive streams live records until a gap is detected (a record was dropped
+// from the buffered fan-out), the context ends, or a write fails. A returned
+// gap==true tells the caller to re-scan disk segments to recover the missed
+// records before resuming the live tail.
+func (m *Master) consumeLive(
+	ctx context.Context,
+	w *bufio.Writer,
+	sub <-chan wal.Record,
+	ticker *time.Ticker,
+	nextLSN *uint64,
+) (bool, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-ticker.C:
+			if err := writeHeartbeatFrame(w, m.writer.LastLSN()); err != nil {
+				return false, err
+			}
+			if err := w.Flush(); err != nil {
+				return false, err
+			}
+			// A record can be dropped from the buffered fan-out during a burst; if
+			// the burst then stops, no later record arrives to reveal the gap. The
+			// heartbeat is our backstop: whenever the committed tail is ahead of
+			// what we have shipped, recover the missing records from disk.
+			if m.writer.LastLSN() >= *nextLSN {
+				return true, nil
+			}
+		case record, ok := <-sub:
+			if !ok {
+				return false, nil
+			}
+			if record.LSN < *nextLSN {
+				continue // already sent from disk
+			}
+			if record.LSN > *nextLSN {
+				return true, nil // gap: recover from disk
+			}
+			if err := writeRecordFrame(w, record); err != nil {
+				return false, err
+			}
+			if err := w.Flush(); err != nil {
+				return false, err
+			}
+			*nextLSN++
+		}
+	}
+}
+
+func (m *Master) streamDisk(w *bufio.Writer, nextLSN *uint64) error {
+	return wal.ReadRecordsFrom(m.dir, *nextLSN, func(record wal.Record) error {
+		if record.LSN < *nextLSN {
+			return nil
+		}
+		if err := writeRecordFrame(w, record); err != nil {
+			return err
+		}
+		*nextLSN = record.LSN + 1
+		return nil
+	})
+}
+
+func (m *Master) sendSnapshot(w *bufio.Writer) (uint64, error) {
+	lsn, path, ok, err := wal.LatestSnapshotInfo(m.dir)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, errors.New("standby needs resync but master has no snapshot")
+	}
+	file, err := os.Open(path) // #nosec G304 -- path comes from the WAL directory listing
+	if err != nil {
+		return 0, fmt.Errorf("open snapshot: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat snapshot: %w", err)
+	}
+	if err = writeSnapshotFrame(w, lsn, info.Size(), file); err != nil {
+		return 0, err
+	}
+	if err = w.Flush(); err != nil {
+		return 0, err
+	}
+	m.logger.Info("Sent snapshot to standby", "lsn", lsn, "bytes", info.Size())
+	return lsn, nil
+}

--- a/internal/replication/master.go
+++ b/internal/replication/master.go
@@ -105,24 +105,28 @@ func (m *Master) stream(ctx context.Context, w *bufio.Writer, requestedLSN uint6
 	defer unsub()
 
 	nextLSN := requestedLSN + 1
-	oldest, err := wal.OldestRecordLSN(m.dir, m.writer.LastLSN()+1)
-	if err != nil {
-		return err
-	}
-	if nextLSN < oldest {
-		snapLSN, serr := m.sendSnapshot(w)
-		if serr != nil {
-			return serr
-		}
-		if snapLSN+1 > nextLSN {
-			nextLSN = snapLSN + 1
-		}
-	}
 
 	ticker := time.NewTicker(m.heartbeatInterval)
 	defer ticker.Stop()
 
 	for {
+		// Re-check retention every iteration: the snapshot loop may have pruned
+		// the records this standby still needs since the last pass, so a gap
+		// recovery must resync from a snapshot rather than ship a non-contiguous
+		// LSN that the standby would reject.
+		oldest, err := wal.OldestRecordLSN(m.dir, m.writer.LastLSN()+1)
+		if err != nil {
+			return err
+		}
+		if nextLSN < oldest {
+			snapLSN, serr := m.sendSnapshot(w)
+			if serr != nil {
+				return serr
+			}
+			if snapLSN+1 > nextLSN {
+				nextLSN = snapLSN + 1
+			}
+		}
 		if err = m.streamDisk(w, &nextLSN); err != nil {
 			return err
 		}

--- a/internal/replication/protocol.go
+++ b/internal/replication/protocol.go
@@ -1,0 +1,122 @@
+// Package replication implements master/standby log shipping. The master streams
+// its write-ahead log to standbys, which persist and apply it in order and serve
+// reads. Replication is asynchronous: the master acknowledges clients without
+// waiting for standbys. Failover is manual via the PROMOTE admin command.
+//
+// The wire protocol runs on a dedicated master listener, separate from the
+// client-facing TCP server. A standby opens a connection and sends a single
+// RESP command handshake:
+//
+//	REPLICATE <lsn>
+//
+// where <lsn> is the highest LSN the standby has already applied. The master
+// then streams framed messages, each prefixed by a one-byte frame type:
+//
+//	'R' record    — a WAL record (wal.EncodeRecord bytes; self-delimiting)
+//	'S' snapshot  — resync payload: 8-byte LSN, 8-byte length, then that many
+//	                bytes of protocol-encoded SET commands (a snapshot blob)
+//	'H' heartbeat — 8-byte master LastLSN, sent while idle so the standby can
+//	                report replication lag even when no records are flowing
+package replication
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+const (
+	// handshakeCommand is the RESP command a standby sends to begin streaming.
+	handshakeCommand = "REPLICATE"
+
+	frameRecord    byte = 'R'
+	frameSnapshot  byte = 'S'
+	frameHeartbeat byte = 'H'
+
+	// handshakeMaxSize bounds the REPLICATE handshake command decode.
+	handshakeMaxSize = 128
+)
+
+// writeHandshake sends the REPLICATE <lsn> handshake to the master.
+func writeHandshake(w io.Writer, appliedLSN uint64) error {
+	return protocol.WriteCommand(w, handshakeCommand, []string{strconv.FormatUint(appliedLSN, 10)})
+}
+
+// readHandshake reads and validates a REPLICATE <lsn> handshake.
+func readHandshake(r *bufio.Reader) (uint64, error) {
+	cmd, args, err := protocol.ReadCommand(r, handshakeMaxSize)
+	if err != nil {
+		return 0, fmt.Errorf("read handshake: %w", err)
+	}
+	if cmd != handshakeCommand || len(args) != 1 {
+		return 0, fmt.Errorf("unexpected handshake %q with %d args", cmd, len(args))
+	}
+	lsn, err := parseUint(args[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid handshake LSN %q: %w", args[0], err)
+	}
+	return lsn, nil
+}
+
+func writeRecordFrame(w io.Writer, record wal.Record) error {
+	encoded, err := wal.EncodeRecord(record)
+	if err != nil {
+		return err
+	}
+	if _, err = w.Write([]byte{frameRecord}); err != nil {
+		return err
+	}
+	_, err = w.Write(encoded)
+	return err
+}
+
+func writeHeartbeatFrame(w io.Writer, lastLSN uint64) error {
+	buf := make([]byte, 1+8)
+	buf[0] = frameHeartbeat
+	binary.BigEndian.PutUint64(buf[1:], lastLSN)
+	_, err := w.Write(buf)
+	return err
+}
+
+// writeSnapshotFrame streams a snapshot blob of the given byte length. The body
+// is copied from src (typically a snapshot file) after the header.
+func writeSnapshotFrame(w io.Writer, lsn uint64, length int64, src io.Reader) error {
+	if length < 0 {
+		return fmt.Errorf("negative snapshot length %d", length)
+	}
+	header := make([]byte, 1+8+8)
+	header[0] = frameSnapshot
+	binary.BigEndian.PutUint64(header[1:9], lsn)
+	binary.BigEndian.PutUint64(header[9:17], uint64(length)) // #nosec G115 -- length guarded non-negative above
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	copied, err := io.CopyN(w, src, length)
+	if err != nil {
+		return fmt.Errorf("stream snapshot body: %w", err)
+	}
+	if copied != length {
+		return fmt.Errorf("short snapshot stream: wrote %d of %d bytes", copied, length)
+	}
+	return nil
+}
+
+func parseUint(s string) (uint64, error) {
+	var n uint64
+	if s == "" {
+		return 0, errors.New("empty number")
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("non-digit %q", r)
+		}
+		n = n*10 + uint64(r-'0')
+	}
+	return n, nil
+}

--- a/internal/replication/replication_test.go
+++ b/internal/replication/replication_test.go
@@ -1,0 +1,237 @@
+package replication_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/replication"
+	"github.com/OutOfStack/db/internal/storage"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+// node bundles the persistence and engine for one in-process server.
+type node struct {
+	dir    string
+	engine *engine.Engine
+	writer *wal.Writer
+	store  *storage.Storage
+}
+
+func newNode(t *testing.T, dir string) *node {
+	t.Helper()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 4 << 10}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	eng := engine.New()
+	t.Cleanup(func() { _ = writer.Close() })
+	return &node{
+		dir:    dir,
+		engine: eng,
+		writer: writer,
+		store:  storage.New(eng, storage.WithWAL(writer)),
+	}
+}
+
+// reopen recovers a node from its data directory, returning the recovered
+// applied LSN. It simulates a restart: load the snapshot, replay the WAL tail.
+func reopenNode(t *testing.T, dir string) (*node, uint64) {
+	t.Helper()
+	eng := engine.New()
+	var entries []engine.Entry
+	snapshotLSN, err := wal.LoadLatestSnapshot(dir, func(table, key, value string) error {
+		entries = append(entries, engine.Entry{Table: table, Key: key, Value: value})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("LoadLatestSnapshot: %v", err)
+	}
+	eng.Load(context.Background(), entries)
+	lastLSN, err := wal.NewReader(dir, nil).Replay(snapshotLSN, func(record wal.Record) error {
+		switch record.Command {
+		case wal.CommandSet:
+			return eng.Set(context.Background(), record.Args[0], record.Args[1], record.Args[2])
+		case wal.CommandDel:
+			_ = eng.Del(context.Background(), record.Args[0], record.Args[1])
+			return nil
+		default:
+			return nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 4 << 10}, lastLSN)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = writer.Close() })
+	return &node{
+		dir:    dir,
+		engine: eng,
+		writer: writer,
+		store:  storage.New(eng, storage.WithWAL(writer)),
+	}, lastLSN
+}
+
+func set(t *testing.T, n *node, table, key, value string) {
+	t.Helper()
+	if _, err := n.store.Execute(context.Background(), "SET", []string{table, key, value}); err != nil {
+		t.Fatalf("SET %s/%s: %v", table, key, err)
+	}
+}
+
+func snapshot(t *testing.T, n *node) {
+	t.Helper()
+	err := n.store.Snapshot(context.Background(), func(ctx context.Context, lsn uint64, src storage.SnapshotSource) error {
+		return wal.WriteSnapshot(ctx, n.dir, lsn, src)
+	})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+}
+
+func startMaster(t *testing.T, n *node) *replication.Master {
+	t.Helper()
+	master, err := replication.NewMaster("127.0.0.1:0", n.writer, n.dir, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewMaster: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go master.Serve(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = master.Close()
+	})
+	return master
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	for range 200 {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func mustGet(t *testing.T, n *node, table, key string) string {
+	t.Helper()
+	value, err := n.engine.Get(context.Background(), table, key)
+	if err != nil {
+		t.Fatalf("standby Get %s/%s: %v", table, key, err)
+	}
+	return value
+}
+
+// TestReplication_StreamsWrites verifies a standby receives and applies live
+// writes from the master and reports zero lag once caught up.
+func TestReplication_StreamsWrites(t *testing.T) {
+	t.Parallel()
+	master := newNode(t, t.TempDir())
+	standby := newNode(t, t.TempDir())
+	m := startMaster(t, master)
+
+	set(t, master, "users", "a", "one")
+	set(t, master, "users", "b", "two")
+
+	sb := replication.NewStandby(m.Addr().String(), standby.store, standby.dir, 0, 10*time.Millisecond, nil)
+	sb.Start(context.Background())
+	t.Cleanup(sb.Stop)
+
+	waitFor(t, "standby to apply both writes", func() bool { return sb.AppliedLSN() >= 2 })
+	if got := mustGet(t, standby, "users", "a"); got != "one" {
+		t.Errorf("standby users/a = %q, want one", got)
+	}
+	if got := mustGet(t, standby, "users", "b"); got != "two" {
+		t.Errorf("standby users/b = %q, want two", got)
+	}
+
+	// A write after the standby is connected streams live.
+	set(t, master, "users", "c", "three")
+	waitFor(t, "standby to apply live write", func() bool { return sb.AppliedLSN() >= 3 })
+	if got := mustGet(t, standby, "users", "c"); got != "three" {
+		t.Errorf("standby users/c = %q, want three", got)
+	}
+	waitFor(t, "lag to settle to zero", func() bool { return sb.Lag() == 0 })
+}
+
+// TestReplication_ResumesFromLSN verifies a restarted standby resumes from its
+// persisted LSN instead of re-fetching the whole log.
+func TestReplication_ResumesFromLSN(t *testing.T) {
+	t.Parallel()
+	master := newNode(t, t.TempDir())
+	standbyDir := t.TempDir()
+	standby := newNode(t, standbyDir)
+	m := startMaster(t, master)
+
+	set(t, master, "t", "k1", "v1")
+	set(t, master, "t", "k2", "v2")
+
+	sb := replication.NewStandby(m.Addr().String(), standby.store, standby.dir, 0, 10*time.Millisecond, nil)
+	sb.Start(context.Background())
+	waitFor(t, "initial catch-up", func() bool { return sb.AppliedLSN() >= 2 })
+	sb.Stop()
+	if err := standby.writer.Close(); err != nil {
+		t.Fatalf("close standby writer: %v", err)
+	}
+
+	// Master advances while the standby is offline.
+	set(t, master, "t", "k3", "v3")
+
+	reopened, lastLSN := reopenNode(t, standbyDir)
+	t.Cleanup(func() { _ = reopened.writer.Close() })
+	if lastLSN != 2 {
+		t.Fatalf("recovered standby LSN = %d, want 2", lastLSN)
+	}
+	sb2 := replication.NewStandby(m.Addr().String(), reopened.store, reopened.dir, lastLSN, 10*time.Millisecond, nil)
+	sb2.Start(context.Background())
+	t.Cleanup(sb2.Stop)
+
+	waitFor(t, "standby to resume and apply k3", func() bool { return sb2.AppliedLSN() >= 3 })
+	if got := mustGet(t, reopened, "t", "k3"); got != "v3" {
+		t.Errorf("resumed standby t/k3 = %q, want v3", got)
+	}
+	// Earlier keys survived the restart via the standby's own WAL.
+	if got := mustGet(t, reopened, "t", "k1"); got != "v1" {
+		t.Errorf("resumed standby t/k1 = %q, want v1", got)
+	}
+}
+
+// TestReplication_SnapshotResync verifies a standby far enough behind that the
+// master has pruned its WAL bootstraps from a shipped snapshot.
+func TestReplication_SnapshotResync(t *testing.T) {
+	t.Parallel()
+	master := newNode(t, t.TempDir())
+	standby := newNode(t, t.TempDir())
+	m := startMaster(t, master)
+
+	set(t, master, "t", "k1", "v1")
+	set(t, master, "t", "k2", "v2")
+	set(t, master, "t", "k3", "v3")
+	// Snapshot + prune removes the WAL segments below the snapshot LSN, so a
+	// fresh standby cannot be served from segments alone.
+	snapshot(t, master)
+	set(t, master, "t", "k4", "v4")
+
+	sb := replication.NewStandby(m.Addr().String(), standby.store, standby.dir, 0, 10*time.Millisecond, nil)
+	sb.Start(context.Background())
+	t.Cleanup(sb.Stop)
+
+	waitFor(t, "standby to resync and apply k4", func() bool { return sb.AppliedLSN() >= 4 })
+	for key, want := range map[string]string{"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"} {
+		if got := mustGet(t, standby, "t", key); got != want {
+			t.Errorf("standby t/%s = %q, want %q", key, got, want)
+		}
+	}
+	// The resync leaves a snapshot on the standby so it can restart standalone.
+	lsn, _, ok, err := wal.LatestSnapshotInfo(standby.dir)
+	if err != nil || !ok || lsn == 0 {
+		t.Fatalf("standby snapshot info = %d, %v, %v; want a snapshot", lsn, ok, err)
+	}
+}

--- a/internal/replication/standby.go
+++ b/internal/replication/standby.go
@@ -1,0 +1,271 @@
+package replication
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+// Applier persists and applies replicated records. It is satisfied by
+// *storage.Storage, which routes replicated writes through the same lock as
+// snapshots so a snapshot never captures a state ahead of the engine.
+type Applier interface {
+	// ApplyReplicated persists a record and applies it to the engine.
+	ApplyReplicated(ctx context.Context, record wal.Record) error
+	// ResetToSnapshot replaces all state with a resync snapshot at lsn.
+	ResetToSnapshot(ctx context.Context, dir string, lsn uint64, entries []engine.Entry) error
+}
+
+// defaultReconnectBackoff is the pause between replication reconnect attempts.
+const defaultReconnectBackoff = time.Second
+
+// maxSnapshotRecordSize bounds a single decoded SET command inside a snapshot
+// stream, mirroring the WAL's per-record limit. maxSnapshotBytes bounds the whole
+// snapshot blob so a malformed length cannot drive an unbounded read.
+const (
+	maxSnapshotRecordSize = 64 << 20
+	maxSnapshotBytes      = 1 << 40
+)
+
+// Standby connects to a master, persists the streamed WAL to its own log, and
+// applies it to its engine in order. It reconnects with backoff and tracks the
+// applied LSN and lag so a promoted standby has a complete, contiguous log.
+type Standby struct {
+	masterAddr string
+	applier    Applier
+	dir        string
+	logger     *slog.Logger
+	backoff    time.Duration
+	dialer     *net.Dialer
+
+	appliedLSN atomic.Uint64
+	masterLSN  atomic.Uint64
+	connected  atomic.Bool
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewStandby creates a standby that replicates from masterAddr into applier (the
+// server's storage). dir is the WAL/snapshot directory. appliedLSN is the last
+// LSN already durable, used as the resume point in the first handshake.
+func NewStandby(
+	masterAddr string,
+	applier Applier,
+	dir string,
+	appliedLSN uint64,
+	backoff time.Duration,
+	logger *slog.Logger,
+) *Standby {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	if backoff <= 0 {
+		backoff = defaultReconnectBackoff
+	}
+	s := &Standby{
+		masterAddr: masterAddr,
+		applier:    applier,
+		dir:        dir,
+		logger:     logger,
+		backoff:    backoff,
+		dialer:     &net.Dialer{Timeout: 10 * time.Second},
+		done:       make(chan struct{}),
+	}
+	s.appliedLSN.Store(appliedLSN)
+	s.masterLSN.Store(appliedLSN)
+	return s
+}
+
+// Start begins the replication loop in the background.
+func (s *Standby) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	go s.run(ctx)
+}
+
+// Stop ends replication and waits for the loop to exit.
+func (s *Standby) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	<-s.done
+}
+
+// AppliedLSN returns the highest LSN this standby has persisted and applied.
+func (s *Standby) AppliedLSN() uint64 { return s.appliedLSN.Load() }
+
+// Lag returns how many LSNs the standby trails the master by, based on the
+// latest record or heartbeat seen. It is a best-effort, eventually-consistent
+// estimate given asynchronous replication.
+func (s *Standby) Lag() uint64 {
+	master := s.masterLSN.Load()
+	applied := s.appliedLSN.Load()
+	if master <= applied {
+		return 0
+	}
+	return master - applied
+}
+
+// Connected reports whether the standby currently has a live master stream.
+func (s *Standby) Connected() bool { return s.connected.Load() }
+
+func (s *Standby) run(ctx context.Context) {
+	defer close(s.done)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := s.replicateOnce(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			s.logger.Warn("Replication disconnected, retrying", "error", err, "backoff", s.backoff)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(s.backoff):
+		}
+	}
+}
+
+func (s *Standby) replicateOnce(ctx context.Context) error {
+	conn, err := s.dialer.DialContext(ctx, "tcp", s.masterAddr)
+	if err != nil {
+		return fmt.Errorf("dial master %s: %w", s.masterAddr, err)
+	}
+	defer func() { _ = conn.Close() }()
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stop()
+
+	if err = writeHandshake(conn, s.appliedLSN.Load()); err != nil {
+		return fmt.Errorf("send handshake: %w", err)
+	}
+	s.connected.Store(true)
+	defer s.connected.Store(false)
+	s.logger.Info("Replicating from master", "master", s.masterAddr, "from_lsn", s.appliedLSN.Load())
+
+	reader := bufio.NewReader(conn)
+	for {
+		if err = s.readFrame(ctx, reader); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *Standby) readFrame(ctx context.Context, reader *bufio.Reader) error {
+	frameType, err := reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	switch frameType {
+	case frameRecord:
+		record, rErr := wal.ReadRecord(reader)
+		if rErr != nil {
+			return fmt.Errorf("read record frame: %w", rErr)
+		}
+		return s.applyRecord(ctx, record)
+	case frameHeartbeat:
+		lsn, rErr := readUint64(reader)
+		if rErr != nil {
+			return fmt.Errorf("read heartbeat frame: %w", rErr)
+		}
+		s.observeMasterLSN(lsn)
+		return nil
+	case frameSnapshot:
+		return s.applySnapshot(ctx, reader)
+	default:
+		return fmt.Errorf("unknown replication frame %q", frameType)
+	}
+}
+
+func (s *Standby) applyRecord(ctx context.Context, record wal.Record) error {
+	if err := s.applier.ApplyReplicated(ctx, record); err != nil {
+		return fmt.Errorf("apply replicated record %d: %w", record.LSN, err)
+	}
+	s.appliedLSN.Store(record.LSN)
+	s.observeMasterLSN(record.LSN)
+	return nil
+}
+
+// applySnapshot handles a resync: the standby's log was truncated past its
+// position, so the master shipped a full snapshot. The standby persists it,
+// resets its WAL to the snapshot LSN, and replaces its engine state.
+func (s *Standby) applySnapshot(ctx context.Context, reader *bufio.Reader) error {
+	lsn, err := readUint64(reader)
+	if err != nil {
+		return fmt.Errorf("read snapshot lsn: %w", err)
+	}
+	length, err := readUint64(reader)
+	if err != nil {
+		return fmt.Errorf("read snapshot length: %w", err)
+	}
+	if length > maxSnapshotBytes {
+		return fmt.Errorf("snapshot length %d exceeds maximum %d", length, maxSnapshotBytes)
+	}
+
+	entries, err := parseSnapshot(reader, int64(length)) // #nosec G115 -- length bounded by maxSnapshotBytes above
+	if err != nil {
+		return fmt.Errorf("parse snapshot: %w", err)
+	}
+
+	if err = s.applier.ResetToSnapshot(ctx, s.dir, lsn, entries); err != nil {
+		return fmt.Errorf("apply resync snapshot: %w", err)
+	}
+	s.appliedLSN.Store(lsn)
+	s.observeMasterLSN(lsn)
+	s.logger.Info("Applied resync snapshot", "lsn", lsn, "entries", len(entries))
+	return nil
+}
+
+func (s *Standby) observeMasterLSN(lsn uint64) {
+	for {
+		current := s.masterLSN.Load()
+		if lsn <= current {
+			return
+		}
+		if s.masterLSN.CompareAndSwap(current, lsn) {
+			return
+		}
+	}
+}
+
+func parseSnapshot(reader *bufio.Reader, length int64) ([]engine.Entry, error) {
+	limited := bufio.NewReader(io.LimitReader(reader, length))
+	var entries []engine.Entry
+	for {
+		command, args, err := protocol.ReadCommand(limited, maxSnapshotRecordSize)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if command != wal.CommandSet || len(args) != 3 {
+			return nil, fmt.Errorf("invalid snapshot record %q with %d args", command, len(args))
+		}
+		entries = append(entries, engine.Entry{Table: args[0], Key: args[1], Value: args[2]})
+	}
+	return entries, nil
+}
+
+func readUint64(reader *bufio.Reader) (uint64, error) {
+	buf := make([]byte, 8)
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(buf), nil
+}

--- a/internal/storage/mocks/storage.go
+++ b/internal/storage/mocks/storage.go
@@ -85,18 +85,6 @@ func (mr *MockEngineMockRecorder) Keys(ctx, table any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Keys", reflect.TypeOf((*MockEngine)(nil).Keys), ctx, table)
 }
 
-// Load mocks base method.
-func (m *MockEngine) Load(ctx context.Context, entries []engine.Entry) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Load", ctx, entries)
-}
-
-// Load indicates an expected call of Load.
-func (mr *MockEngineMockRecorder) Load(ctx, entries any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockEngine)(nil).Load), ctx, entries)
-}
-
 // Range mocks base method.
 func (m *MockEngine) Range(fn func(string, string, string) bool) {
 	m.ctrl.T.Helper()
@@ -109,16 +97,16 @@ func (mr *MockEngineMockRecorder) Range(fn any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Range", reflect.TypeOf((*MockEngine)(nil).Range), fn)
 }
 
-// Reset mocks base method.
-func (m *MockEngine) Reset() {
+// Replace mocks base method.
+func (m *MockEngine) Replace(entries []engine.Entry) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Reset")
+	m.ctrl.Call(m, "Replace", entries)
 }
 
-// Reset indicates an expected call of Reset.
-func (mr *MockEngineMockRecorder) Reset() *gomock.Call {
+// Replace indicates an expected call of Replace.
+func (mr *MockEngineMockRecorder) Replace(entries any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockEngine)(nil).Reset))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockEngine)(nil).Replace), entries)
 }
 
 // Set mocks base method.

--- a/internal/storage/mocks/storage.go
+++ b/internal/storage/mocks/storage.go
@@ -13,6 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	engine "github.com/OutOfStack/db/internal/engine"
+	wal "github.com/OutOfStack/db/internal/wal"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -83,8 +85,20 @@ func (mr *MockEngineMockRecorder) Keys(ctx, table any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Keys", reflect.TypeOf((*MockEngine)(nil).Keys), ctx, table)
 }
 
+// Load mocks base method.
+func (m *MockEngine) Load(ctx context.Context, entries []engine.Entry) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Load", ctx, entries)
+}
+
+// Load indicates an expected call of Load.
+func (mr *MockEngineMockRecorder) Load(ctx, entries any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockEngine)(nil).Load), ctx, entries)
+}
+
 // Range mocks base method.
-func (m *MockEngine) Range(fn func(table, key, value string) bool) {
+func (m *MockEngine) Range(fn func(string, string, string) bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Range", fn)
 }
@@ -93,6 +107,18 @@ func (m *MockEngine) Range(fn func(table, key, value string) bool) {
 func (mr *MockEngineMockRecorder) Range(fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Range", reflect.TypeOf((*MockEngine)(nil).Range), fn)
+}
+
+// Reset mocks base method.
+func (m *MockEngine) Reset() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset")
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockEngineMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockEngine)(nil).Reset))
 }
 
 // Set mocks base method.
@@ -135,4 +161,135 @@ func (m *MockEngine) Tables(ctx context.Context) []string {
 func (mr *MockEngineMockRecorder) Tables(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tables", reflect.TypeOf((*MockEngine)(nil).Tables), ctx)
+}
+
+// MockWAL is a mock of WAL interface.
+type MockWAL struct {
+	ctrl     *gomock.Controller
+	recorder *MockWALMockRecorder
+	isgomock struct{}
+}
+
+// MockWALMockRecorder is the mock recorder for MockWAL.
+type MockWALMockRecorder struct {
+	mock *MockWAL
+}
+
+// NewMockWAL creates a new mock instance.
+func NewMockWAL(ctrl *gomock.Controller) *MockWAL {
+	mock := &MockWAL{ctrl: ctrl}
+	mock.recorder = &MockWALMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWAL) EXPECT() *MockWALMockRecorder {
+	return m.recorder
+}
+
+// Append mocks base method.
+func (m *MockWAL) Append(ctx context.Context, command string, args []string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Append", ctx, command, args)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Append indicates an expected call of Append.
+func (mr *MockWALMockRecorder) Append(ctx, command, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockWAL)(nil).Append), ctx, command, args)
+}
+
+// AppendRecord mocks base method.
+func (m *MockWAL) AppendRecord(ctx context.Context, record wal.Record) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendRecord", ctx, record)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendRecord indicates an expected call of AppendRecord.
+func (mr *MockWALMockRecorder) AppendRecord(ctx, record any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendRecord", reflect.TypeOf((*MockWAL)(nil).AppendRecord), ctx, record)
+}
+
+// LastLSN mocks base method.
+func (m *MockWAL) LastLSN() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastLSN")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// LastLSN indicates an expected call of LastLSN.
+func (mr *MockWALMockRecorder) LastLSN() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastLSN", reflect.TypeOf((*MockWAL)(nil).LastLSN))
+}
+
+// Prune mocks base method.
+func (m *MockWAL) Prune(ctx context.Context, uptoLSN uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Prune", ctx, uptoLSN)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Prune indicates an expected call of Prune.
+func (mr *MockWALMockRecorder) Prune(ctx, uptoLSN any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockWAL)(nil).Prune), ctx, uptoLSN)
+}
+
+// Reset mocks base method.
+func (m *MockWAL) Reset(ctx context.Context, lsn uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reset", ctx, lsn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockWALMockRecorder) Reset(ctx, lsn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockWAL)(nil).Reset), ctx, lsn)
+}
+
+// MockSnapshotSource is a mock of SnapshotSource interface.
+type MockSnapshotSource struct {
+	ctrl     *gomock.Controller
+	recorder *MockSnapshotSourceMockRecorder
+	isgomock struct{}
+}
+
+// MockSnapshotSourceMockRecorder is the mock recorder for MockSnapshotSource.
+type MockSnapshotSourceMockRecorder struct {
+	mock *MockSnapshotSource
+}
+
+// NewMockSnapshotSource creates a new mock instance.
+func NewMockSnapshotSource(ctrl *gomock.Controller) *MockSnapshotSource {
+	mock := &MockSnapshotSource{ctrl: ctrl}
+	mock.recorder = &MockSnapshotSourceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSnapshotSource) EXPECT() *MockSnapshotSourceMockRecorder {
+	return m.recorder
+}
+
+// Range mocks base method.
+func (m *MockSnapshotSource) Range(fn func(string, string, string) bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Range", fn)
+}
+
+// Range indicates an expected call of Range.
+func (mr *MockSnapshotSourceMockRecorder) Range(fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Range", reflect.TypeOf((*MockSnapshotSource)(nil).Range), fn)
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/wal"
 )
 
 var (
 	// ErrNotFound is the error returned when a key is not found
 	ErrNotFound = errors.New("not found")
+	// ErrReadOnly is returned for mutating commands on a replication standby.
+	// It maps to the "ERR readonly" wire reply so a pool client can re-route
+	// the write to a master.
+	ErrReadOnly = errors.New("readonly")
 )
 
 // Engine is an interface for a storage engine
@@ -23,11 +29,18 @@ type Engine interface {
 	TableExists(ctx context.Context, table string) bool
 	Keys(ctx context.Context, table string) []string
 	Range(fn func(table, key, value string) bool)
+	// Reset and Load support snapshot resync on a replication standby.
+	Reset()
+	Load(ctx context.Context, entries []engine.Entry)
 }
 
 // WAL is the persistence stream used for mutating commands.
 type WAL interface {
 	Append(ctx context.Context, command string, args []string) (uint64, error)
+	// AppendRecord persists a record with a caller-assigned LSN (replication).
+	AppendRecord(ctx context.Context, record wal.Record) error
+	// Reset discards all segments and sets LastLSN to lsn (snapshot resync).
+	Reset(ctx context.Context, lsn uint64) error
 	LastLSN() uint64
 	Prune(ctx context.Context, uptoLSN uint64) error
 }
@@ -45,14 +58,22 @@ func WithWAL(log WAL) Option {
 	return func(storage *Storage) { storage.wal = log }
 }
 
+// WithReadOnly starts the storage in read-only mode, rejecting SET/DEL with
+// ErrReadOnly. Replication standbys use it; Promote lifts it.
+func WithReadOnly(readOnly bool) Option {
+	return func(storage *Storage) { storage.readOnly.Store(readOnly) }
+}
+
 // Storage implements a storage layer that provides a simple key-value store
 type Storage struct {
 	engine Engine
 	wal    WAL
 	// mu serializes snapshots (write lock) against mutations (read lock); many
 	// mutations may run concurrently so their WAL appends can be group-committed.
-	mu   sync.RWMutex
-	gate *applyGate
+	// It also serializes Promote's gate swap against in-flight mutations.
+	mu       sync.RWMutex
+	gate     *applyGate
+	readOnly atomic.Bool
 }
 
 // New returns a new Storage instance
@@ -196,6 +217,9 @@ func (s *Storage) del(ctx context.Context, args []string) (protocol.Reply, error
 // enabled, appends run concurrently (under the shared read lock) so the writer can
 // group-commit them, while the apply gate replays them into the engine in LSN order.
 func (s *Storage) mutate(ctx context.Context, command string, args []string, apply func() error) error {
+	if s.readOnly.Load() {
+		return ErrReadOnly
+	}
 	if s.wal == nil {
 		return apply()
 	}
@@ -208,6 +232,76 @@ func (s *Storage) mutate(ctx context.Context, command string, args []string, app
 		return err
 	}
 	return s.gate.run(lsn, apply)
+}
+
+// ReadOnly reports whether mutating commands are currently rejected.
+func (s *Storage) ReadOnly() bool { return s.readOnly.Load() }
+
+// Promote lifts read-only mode so the storage accepts writes. It resets the
+// apply gate to the WAL's current tail, because replication advanced LastLSN
+// past the value captured when the storage was created. Client writes are still
+// rejected while the gate is swapped, so no mutation observes a stale gate.
+func (s *Storage) Promote() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.wal != nil {
+		s.gate = newApplyGate(s.wal.LastLSN() + 1)
+	}
+	s.readOnly.Store(false)
+}
+
+// ApplyReplicated persists a record streamed from a master and applies it to the
+// engine. It holds the shared read lock so a concurrent Snapshot cannot capture
+// a state whose LSN is ahead of the engine (which would drop the record on
+// recovery). It bypasses the apply gate: a single master stream is already
+// ordered by LSN.
+func (s *Storage) ApplyReplicated(ctx context.Context, record wal.Record) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if err := s.wal.AppendRecord(ctx, record); err != nil {
+		return err
+	}
+	switch record.Command {
+	case wal.CommandSet:
+		return s.engine.Set(ctx, record.Args[0], record.Args[1], record.Args[2])
+	case wal.CommandDel:
+		if err := s.engine.Del(ctx, record.Args[0], record.Args[1]); err != nil && !errors.Is(err, engine.ErrNotFound) {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("unsupported replicated command: " + record.Command)
+	}
+}
+
+// ResetToSnapshot replaces all state with a snapshot received during resync: it
+// persists the snapshot, resets the WAL to lsn, and reloads the engine, all
+// under the exclusive lock so it is atomic against Snapshot.
+func (s *Storage) ResetToSnapshot(ctx context.Context, dir string, lsn uint64, entries []engine.Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := wal.WriteSnapshot(ctx, dir, lsn, entrySource(entries)); err != nil {
+		return err
+	}
+	if err := s.wal.Reset(ctx, lsn); err != nil {
+		return err
+	}
+	s.engine.Reset()
+	s.engine.Load(ctx, entries)
+	return nil
+}
+
+// entrySource adapts recovered entries to the wal.SnapshotSource interface.
+type entrySource []engine.Entry
+
+func (e entrySource) Range(fn func(table, key, value string) bool) {
+	for _, entry := range e {
+		if !fn(entry.Table, entry.Key, entry.Value) {
+			return
+		}
+	}
 }
 
 func fmtBool(value bool) string {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -29,9 +29,8 @@ type Engine interface {
 	TableExists(ctx context.Context, table string) bool
 	Keys(ctx context.Context, table string) []string
 	Range(fn func(table, key, value string) bool)
-	// Reset and Load support snapshot resync on a replication standby.
-	Reset()
-	Load(ctx context.Context, entries []engine.Entry)
+	// Replace atomically swaps all state for a resync snapshot on a standby.
+	Replace(entries []engine.Entry)
 }
 
 // WAL is the persistence stream used for mutating commands.
@@ -282,14 +281,18 @@ func (s *Storage) ResetToSnapshot(ctx context.Context, dir string, lsn uint64, e
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := wal.WriteSnapshot(ctx, dir, lsn, entrySource(entries)); err != nil {
-		return err
-	}
+	// Reset the WAL before publishing the snapshot. If we crash between the two,
+	// recovery falls back to the previous snapshot plus an empty WAL and re-syncs
+	// — safe. The reverse order would leave a high-LSN snapshot alongside old
+	// low-LSN segments, so the reopened writer appends a non-contiguous tail that
+	// recovery refuses.
 	if err := s.wal.Reset(ctx, lsn); err != nil {
 		return err
 	}
-	s.engine.Reset()
-	s.engine.Load(ctx, entries)
+	if err := wal.WriteSnapshot(ctx, dir, lsn, entrySource(entries)); err != nil {
+		return err
+	}
+	s.engine.Replace(entries)
 	return nil
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/storage"
 	mocks "github.com/OutOfStack/db/internal/storage/mocks"
+	"github.com/OutOfStack/db/internal/wal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -33,6 +34,13 @@ type fakeWAL struct {
 
 func (f *fakeWAL) Append(ctx context.Context, command string, args []string) (uint64, error) {
 	return f.append(ctx, command, args)
+}
+
+func (f *fakeWAL) AppendRecord(context.Context, wal.Record) error { return nil }
+
+func (f *fakeWAL) Reset(_ context.Context, lsn uint64) error {
+	f.last = lsn
+	return nil
 }
 
 func (f *fakeWAL) LastLSN() uint64 { return f.last }
@@ -287,4 +295,43 @@ func TestStorage_Execute(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 		assert.Empty(t, result)
 	})
+}
+
+func TestStorage_ReadOnly(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	store := storage.New(mockEngine, storage.WithReadOnly(true))
+
+	_, err := store.Execute(ctx, "SET", []string{"t", "k", "v"})
+	require.ErrorIs(t, err, storage.ErrReadOnly)
+	_, err = store.Execute(ctx, "DEL", []string{"t", "k"})
+	require.ErrorIs(t, err, storage.ErrReadOnly)
+
+	// Reads are unaffected by read-only mode.
+	mockEngine.EXPECT().Get(ctx, "t", "k").Return("v", nil)
+	res, err := store.Execute(ctx, "GET", []string{"t", "k"})
+	require.NoError(t, err)
+	assert.Equal(t, "v", res.Value)
+}
+
+func TestStorage_Promote(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	// Replication advanced the WAL to LSN 5 while the standby was read-only; the
+	// gate must reset to 6 on promotion so the first client write applies.
+	log := &fakeWAL{last: 5, append: func(context.Context, string, []string) (uint64, error) { return 6, nil }}
+	store := storage.New(mockEngine, storage.WithWAL(log), storage.WithReadOnly(true))
+
+	_, err := store.Execute(ctx, "SET", []string{"t", "k", "v"})
+	require.ErrorIs(t, err, storage.ErrReadOnly)
+
+	store.Promote()
+	require.False(t, store.ReadOnly())
+
+	mockEngine.EXPECT().Set(ctx, "t", "k", "v").Return(nil)
+	res, err := store.Execute(ctx, "SET", []string{"t", "k", "v"})
+	require.NoError(t, err)
+	assert.Equal(t, "OK", res.Value)
 }

--- a/internal/wal/record.go
+++ b/internal/wal/record.go
@@ -36,6 +36,20 @@ type Record struct {
 	Args    []string
 }
 
+// EncodeRecord serializes a record to its on-disk/on-wire form (LSN, protocol
+// command, CRC32). Replication reuses this so the master ships the exact bytes a
+// standby persists to its own WAL.
+func EncodeRecord(record Record) ([]byte, error) {
+	return encodeRecord(record)
+}
+
+// ReadRecord decodes a single record previously written by EncodeRecord. It is
+// used by standbys reading the master's replication stream. A partial or
+// checksum-invalid record returns ErrPartialRecord/ErrChecksum.
+func ReadRecord(reader *bufio.Reader) (Record, error) {
+	return readRecord(reader)
+}
+
 func encodeRecord(record Record) ([]byte, error) {
 	var body bytes.Buffer
 	if err := binary.Write(&body, binary.BigEndian, record.LSN); err != nil {

--- a/internal/wal/stream.go
+++ b/internal/wal/stream.go
@@ -1,0 +1,85 @@
+package wal
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// OldestRecordLSN returns the LSN of the oldest record still retained on disk.
+// It is the first LSN of the earliest WAL segment; when no segments exist it
+// returns fallback (the caller passes LastLSN+1, meaning "nothing on disk").
+func OldestRecordLSN(dir string, fallback uint64) (uint64, error) {
+	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
+	if err != nil {
+		return 0, fmt.Errorf("list WAL segments: %w", err)
+	}
+	if len(segments) == 0 {
+		return fallback, nil
+	}
+	return segments[0].number, nil
+}
+
+// LatestSnapshotInfo returns the LSN and path of the newest snapshot on disk.
+// ok is false when no snapshot exists.
+func LatestSnapshotInfo(dir string) (lsn uint64, path string, ok bool, err error) {
+	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	if err != nil {
+		return 0, "", false, fmt.Errorf("list snapshots: %w", err)
+	}
+	if len(snapshots) == 0 {
+		return 0, "", false, nil
+	}
+	latest := snapshots[len(snapshots)-1]
+	return latest.number, latest.path, true, nil
+}
+
+// ReadRecordsFrom streams records with LSN >= fromLSN from the on-disk segments
+// to fn, in LSN order. It is used by the replication master to catch a standby
+// up from segment files. Because the master appends concurrently, a partial or
+// checksum-invalid record at the tail of the final segment is treated as a
+// half-written live record and ends iteration cleanly (the caller streams the
+// rest from the live fan-out); the same damage in an earlier segment is an error.
+func ReadRecordsFrom(dir string, fromLSN uint64, fn func(Record) error) error {
+	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
+	if err != nil {
+		return fmt.Errorf("list WAL segments: %w", err)
+	}
+	for index, segment := range segments {
+		isLast := index == len(segments)-1
+		if err = readSegmentRecords(segment, isLast, fromLSN, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readSegmentRecords(segment numberedFile, isLast bool, fromLSN uint64, fn func(Record) error) error {
+	file, err := os.Open(segment.path)
+	if err != nil {
+		return fmt.Errorf("open WAL segment %s: %w", segment.path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+	for {
+		record, readErr := readRecord(reader)
+		if errors.Is(readErr, io.EOF) {
+			return nil
+		}
+		if readErr != nil {
+			if isLast && (errors.Is(readErr, ErrPartialRecord) || errors.Is(readErr, ErrChecksum)) {
+				return nil
+			}
+			return fmt.Errorf("read WAL segment %s: %w", segment.path, readErr)
+		}
+		if record.LSN < fromLSN {
+			continue
+		}
+		if err = fn(record); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/OutOfStack/db/internal/wal"
 )
@@ -303,5 +304,64 @@ func TestSnapshotIgnoresTemporaryFiles(t *testing.T) {
 	lsn, err := wal.LoadLatestSnapshot(dir, func(string, string, string) error { return nil })
 	if err != nil || lsn != 0 {
 		t.Fatalf("LoadLatestSnapshot() = %d, %v; want 0, nil", lsn, err)
+	}
+}
+
+func TestSubscribePublishesCommittedRecords(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1 << 20}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	sub, unsub := writer.Subscribe()
+	defer unsub()
+
+	if _, err = writer.Append(t.Context(), wal.CommandSet, []string{"t", "k", "v"}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	select {
+	case record := <-sub:
+		if record.LSN != 1 || record.Command != wal.CommandSet {
+			t.Fatalf("published record = %+v, want LSN 1 SET", record)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for published record")
+	}
+}
+
+func TestAppendRecordEnforcesContiguityAndReset(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1 << 20}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	// A standby persists records with the master's LSNs.
+	if err = writer.AppendRecord(t.Context(), wal.Record{LSN: 1, Command: wal.CommandSet, Args: []string{"t", "k", "v"}}); err != nil {
+		t.Fatalf("AppendRecord(1) error = %v", err)
+	}
+	// A gap is rejected.
+	if err = writer.AppendRecord(t.Context(), wal.Record{LSN: 3, Command: wal.CommandSet, Args: []string{"t", "k", "v"}}); err == nil {
+		t.Fatal("AppendRecord(3) after 1 should fail on the LSN gap")
+	}
+	if writer.LastLSN() != 1 {
+		t.Fatalf("LastLSN = %d, want 1", writer.LastLSN())
+	}
+
+	// Reset to a snapshot LSN, then continue from there.
+	if err = writer.Reset(t.Context(), 10); err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+	if writer.LastLSN() != 10 {
+		t.Fatalf("LastLSN after reset = %d, want 10", writer.LastLSN())
+	}
+	if err = writer.AppendRecord(t.Context(), wal.Record{LSN: 11, Command: wal.CommandSet, Args: []string{"t", "k2", "v2"}}); err != nil {
+		t.Fatalf("AppendRecord(11) after reset error = %v", err)
 	}
 }

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -37,7 +37,9 @@ type requestKind uint8
 
 const (
 	requestAppend requestKind = iota
+	requestAppendReplicated
 	requestPrune
+	requestReset
 	requestClose
 )
 
@@ -45,8 +47,19 @@ type writerRequest struct {
 	kind    requestKind
 	command string
 	args    []string
+	record  Record // used by requestAppendReplicated, which carries an explicit LSN
 	uptoLSN uint64
 	result  chan writerResult
+}
+
+// subscriberBuffer bounds how many committed records the writer can queue for a
+// single replication subscriber before dropping. A dropped record is not lost:
+// the master streaming loop detects the LSN gap and re-reads it from the WAL
+// segments on disk, so a slow standby never blocks the writer goroutine.
+const subscriberBuffer = 1024
+
+type subscriber struct {
+	ch chan Record
 }
 
 type writerResult struct {
@@ -66,6 +79,9 @@ type Writer struct {
 	lastLSN   atomic.Uint64
 	closeOnce sync.Once
 	closeErr  error
+
+	subsMu sync.RWMutex
+	subs   map[*subscriber]struct{}
 }
 
 // OpenWriter opens a writer after recovery. lastLSN must be the last LSN
@@ -111,6 +127,7 @@ func OpenWriter(config WriterConfig, lastLSN uint64) (*Writer, error) {
 		size:     size,
 		requests: make(chan writerRequest, 256),
 		done:     make(chan struct{}),
+		subs:     make(map[*subscriber]struct{}),
 	}
 	writer.lastLSN.Store(lastLSN)
 	go writer.run()
@@ -156,6 +173,58 @@ func (w *Writer) Append(ctx context.Context, command string, args []string) (uin
 	}
 }
 
+// AppendRecord writes a record with a caller-assigned LSN. Standbys use it to
+// persist records received from the master's replication stream, preserving the
+// master's LSNs so a promoted standby continues the same log. The record's LSN
+// must be exactly the current LastLSN+1.
+func (w *Writer) AppendRecord(ctx context.Context, record Record) error {
+	if w.closing.Load() {
+		return ErrClosed
+	}
+	if err := validateRecord(record); err != nil {
+		return err
+	}
+	if size := protocol.CommandSize(record.Command, record.Args); size > maxRecordSize {
+		return fmt.Errorf("WAL record size %d exceeds maximum %d bytes", size, maxRecordSize)
+	}
+	return w.control(ctx, writerRequest{kind: requestAppendReplicated, record: record})
+}
+
+// Reset discards all WAL segments and sets LastLSN to lsn, so the next appended
+// record must be lsn+1. Standbys call it after loading a snapshot at lsn during
+// resync, when their existing log is entirely superseded by the snapshot.
+func (w *Writer) Reset(ctx context.Context, lsn uint64) error {
+	return w.control(ctx, writerRequest{kind: requestReset, uptoLSN: lsn})
+}
+
+// Subscribe registers for committed records. The returned channel receives every
+// record the writer commits after the call; the returned function unsubscribes.
+// Sends are non-blocking (see subscriberBuffer): a subscriber that cannot keep up
+// misses records and must recover them by reading segments from disk.
+func (w *Writer) Subscribe() (<-chan Record, func()) {
+	sub := &subscriber{ch: make(chan Record, subscriberBuffer)}
+	w.subsMu.Lock()
+	w.subs[sub] = struct{}{}
+	w.subsMu.Unlock()
+	return sub.ch, func() {
+		w.subsMu.Lock()
+		delete(w.subs, sub)
+		w.subsMu.Unlock()
+	}
+}
+
+// publish delivers a committed record to every subscriber without blocking.
+func (w *Writer) publish(record Record) {
+	w.subsMu.RLock()
+	defer w.subsMu.RUnlock()
+	for sub := range w.subs {
+		select {
+		case sub.ch <- record:
+		default:
+		}
+	}
+}
+
 // LastLSN returns the most recently written LSN.
 func (w *Writer) LastLSN() uint64 { return w.lastLSN.Load() }
 
@@ -192,13 +261,21 @@ func (w *Writer) control(ctx context.Context, request writerRequest) error {
 	case <-w.done:
 		return ErrClosed
 	}
+	// Once enqueued, wait for the outcome regardless of ctx cancellation: the
+	// writer will still process this request and mutate durable state (assign an
+	// LSN, remove segments), so abandoning it here would desync a caller that
+	// applies records in LSN order — e.g. a standby whose context is cancelled by
+	// Stop() mid-append, leaving its engine one record behind its own WAL.
 	select {
 	case response := <-request.result:
 		return response.err
-	case <-ctx.Done():
-		return ctx.Err()
 	case <-w.done:
-		return ErrClosed
+		select {
+		case response := <-request.result:
+			return response.err
+		default:
+			return ErrClosed
+		}
 	}
 }
 
@@ -299,6 +376,14 @@ func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
 	for index, request := range batch {
 		request.result <- results[index]
 	}
+
+	// Publish only records the callers were acked for; a failed append or sync
+	// leaves the record non-durable, so it must not be streamed to standbys.
+	for index, request := range batch {
+		if results[index].err == nil {
+			w.publish(Record{LSN: results[index].lsn, Command: request.command, Args: request.args})
+		}
+	}
 }
 
 func (w *Writer) appendOne(request writerRequest, state *writerState) (uint64, error) {
@@ -320,6 +405,67 @@ func (w *Writer) appendOne(request writerRequest, state *writerState) (uint64, e
 	}
 	w.lastLSN.Store(lsn)
 	return lsn, nil
+}
+
+// appendReplicated writes a record with its own LSN, enforcing contiguity with
+// the current tail. Under a durable sync policy it fsyncs before returning so an
+// acked replicated record survives a standby crash, mirroring Append.
+func (w *Writer) appendReplicated(record Record, state *writerState) error {
+	expected := w.lastLSN.Load() + 1
+	if record.LSN != expected {
+		return fmt.Errorf("non-contiguous replicated LSN: got %d, want %d", record.LSN, expected)
+	}
+	encoded, err := encodeRecord(record)
+	if err != nil {
+		return err
+	}
+	if err = w.ensureSegment(state, record.LSN, int64(len(encoded))); err != nil {
+		return err
+	}
+	written, err := state.file.Write(encoded)
+	state.size += int64(written)
+	if err != nil {
+		state.terminalErr = fmt.Errorf("append replicated WAL record: %w", err)
+		return state.terminalErr
+	}
+	if written != len(encoded) {
+		state.terminalErr = fmt.Errorf("append replicated WAL record: %w", io.ErrShortWrite)
+		return state.terminalErr
+	}
+	if w.config.Sync != SyncNo && state.file != nil {
+		if err = state.file.Sync(); err != nil {
+			state.terminalErr = fmt.Errorf("sync WAL: %w", err)
+			return state.terminalErr
+		}
+	}
+	w.lastLSN.Store(record.LSN)
+	return nil
+}
+
+// reset removes every WAL segment and sets LastLSN to lsn, so the next record
+// appended must be lsn+1 into a fresh segment.
+func (w *Writer) reset(state *writerState, lsn uint64) error {
+	if state.file != nil {
+		if err := state.file.Close(); err != nil {
+			return fmt.Errorf("close WAL before reset: %w", err)
+		}
+		state.file = nil
+		state.size = 0
+	}
+	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	if err != nil {
+		return fmt.Errorf("list WAL segments for reset: %w", err)
+	}
+	for _, segment := range segments {
+		if err = os.Remove(segment.path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove WAL segment during reset: %w", err)
+		}
+	}
+	if err = syncDirectory(w.config.Dir); err != nil {
+		return fmt.Errorf("sync WAL directory during reset: %w", err)
+	}
+	w.lastLSN.Store(lsn)
+	return nil
 }
 
 func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64) error {
@@ -368,6 +514,23 @@ func (w *Writer) closeForRotation(state *writerState) error {
 
 func (w *Writer) handleControl(request writerRequest, state *writerState) bool {
 	switch request.kind {
+	case requestAppendReplicated:
+		err := state.terminalErr
+		if err == nil {
+			err = w.appendReplicated(request.record, state)
+		}
+		request.result <- writerResult{err: err}
+		if err == nil {
+			w.publish(request.record)
+		}
+		return false
+	case requestReset:
+		err := state.terminalErr
+		if err == nil {
+			err = w.reset(state, request.uptoLSN)
+		}
+		request.result <- writerResult{err: err}
+		return false
 	case requestPrune:
 		err := state.terminalErr
 		if err == nil {
@@ -376,23 +539,27 @@ func (w *Writer) handleControl(request writerRequest, state *writerState) bool {
 		request.result <- writerResult{err: err}
 		return false
 	case requestClose:
-		err := state.terminalErr
-		if state.file != nil {
-			if syncErr := state.file.Sync(); err == nil && syncErr != nil {
-				err = fmt.Errorf("sync WAL during close: %w", syncErr)
-			}
-			if closeErr := state.file.Close(); err == nil && closeErr != nil {
-				err = fmt.Errorf("close WAL: %w", closeErr)
-			}
-		}
-		if syncErr := w.syncAllSegments(); err == nil && syncErr != nil {
-			err = syncErr
-		}
-		request.result <- writerResult{err: err}
+		request.result <- writerResult{err: w.handleClose(state)}
 		return true
 	default:
 		return false
 	}
+}
+
+func (w *Writer) handleClose(state *writerState) error {
+	err := state.terminalErr
+	if state.file != nil {
+		if syncErr := state.file.Sync(); err == nil && syncErr != nil {
+			err = fmt.Errorf("sync WAL during close: %w", syncErr)
+		}
+		if closeErr := state.file.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close WAL: %w", closeErr)
+		}
+	}
+	if syncErr := w.syncAllSegments(); err == nil && syncErr != nil {
+		err = syncErr
+	}
+	return err
 }
 
 func (w *Writer) syncAllSegments() error {


### PR DESCRIPTION
Master streams the WAL to standbys over a REPLICATE handshake (async log shipping with disk catch-up, live tail, heartbeats, and snapshot resync when a standby falls behind pruned WAL). Standbys apply records through the storage lock and reject writes with ERR readonly. PROMOTE flips a standby to master and, when a listen address is set, serves replication so other standbys can be re-aimed; REPLICATION STATUS reports role/applied LSN/lag. The pool routes writes to masters only and fails over reads, retrying on ERR readonly.