### PR TITLE
feat(protocol)!: add typed values with atomic INCR, APPEND, HSET, TYPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ bin/
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories (remove the comment below to include it) vendor/
 .vscode
 .idea
 
@@ -26,4 +25,3 @@ requirements
 CLAUDE.MD
 AGENTS.md
 /docs/plans
-

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,12 @@ linters:
     goconst:
       min-len: 3
       min-occurrences: 2
+    godox:
+      keywords:
+        - TODO
+        - FIXME
+        - BUG
+        - ponytail
     govet:
       enable:
         - shadow

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/db ./cmd/db
+RUN mkdir -p /out/data
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/db /db
-# bind all interfaces so the server is reachable through the published port
+# Relative config and data paths resolve from here.
+WORKDIR /home/nonroot
+# Make the default data directory writable by the runtime user.
+COPY --from=build --chown=65532:65532 /out/data ./data
 ENV DB_ADDRESS=0.0.0.0:3223
 EXPOSE 3223
 ENTRYPOINT ["/db"]

--- a/README.md
+++ b/README.md
@@ -17,18 +17,56 @@ The project consists of three main components:
 - Structured logging with configurable levels
 - Graceful shutdown with proper resource cleanup
 - Command-line interface for database operations
-- In-memory key-value storage engine
+- Two storage engines: `in_memory` (RAM-only) and `tiered`, whose dataset grows past RAM by keeping values in on-disk
+  segments behind an LRU cache
 - Tables: keys are scoped per table, created implicitly on first write
+- Typed values (string, int, float, bool, array, map) with server-side atomic operations: `INCR`, `APPEND`,
+  `HSET`/`HGET`, `TYPE`
+- Durability: write-ahead log with `always`/`everysec`/`no` fsync policies, periodic snapshots, and crash recovery that
+  truncates a torn tail
+- Replication: asynchronous master/standby WAL shipping with manual `PROMOTE`
 - Connection limiting to prevent resource exhaustion
 - **Master/Standby Connection Pooling** with automatic failover
 - Configurable server selection strategies (master_first, round_robin, random)
 
 ## Commands
 
-Commands are entered in the CLI using the simple syntax below and sent to the
-server as RESP2 frames (see [Network Protocol](#network-protocol)). Every key belongs to a table:
-tables are created implicitly on the first `SET` and removed automatically when
-their last key is deleted.
+Commands are entered in the CLI using the simple syntax below and sent to the server as RESP2 frames (see [Network
+Protocol](#network-protocol)). Every key belongs to a table: tables are created implicitly on the first `SET` and
+removed automatically when their last key is deleted.
+
+### Value types
+
+Values are typed. The type comes from the literal syntax of the value, and `GET` returns a human-readable
+representation:
+
+| Literal | Type | Notes |
+|---------|------|-------|
+| `hello world` | string | anything that is not one of the forms below |
+| `"42"` | string | quoting forces text that would otherwise be a number |
+| `42`, `-7` | int | 64-bit; `INCR` past the range is an error, never a wraparound |
+| `42.5`, `1e3` | float | a whole float renders back as `1.0`, so its type survives |
+| `true`, `false` | bool | |
+| `[1,"two",true]` | array | JSON syntax; elements may be any type, including nested |
+| `{"a":1,"b":[2]}` | map | JSON syntax; keys are strings, values any type |
+
+A string renders bare, so a plain `SET`/`GET` round-trips to exactly the text that was stored; strings nested in an
+array or map render quoted. Use `TYPE` to see what a key actually holds.
+
+**Quoting in the CLI.** The CLI splits an input line the way a shell does: it uses `'` and `"` to group a token and
+removes them. A literal that contains double quotes or spaces therefore has to be wrapped in single quotes, or the
+server never sees it as written:
+
+```
+SET t conf '{"a":1}'      # map     — without the single quotes: {a:1}, an error
+SET t tags '["a","b"]'    # array   — without them: [a,b], an error
+SET t zip '"01234"'       # string  — without them: 01234, an int
+SET t nums [1,2,3]        # no quotes or spaces inside, so it needs no wrapping
+SET t path 'C:\tmp'       # single quotes are literal: \n, \t and \ are not escapes inside them
+```
+
+Programs using the client library pass the literal directly and need none of this — the quoting is a property of the
+CLI's line splitting, not of the syntax.
 
 ### SET
 Set a key-value pair in a table:
@@ -38,6 +76,8 @@ SET <table> <key> <value>
 Example:
 ```
 SET users name John
+SET users age 42
+SET users tags [1,2,3]
 ```
 
 ### GET
@@ -73,11 +113,54 @@ EXISTS <table>
 ```
 
 ### KEYS
-List all keys in a table in sorted order. A missing table returns an empty
-list. List responses are subject to the configured client and server message
-size limits; pagination is not currently supported.
+List all keys in a table in sorted order. A missing table returns an empty list. List responses are subject to the
+configured client and server message size limits; pagination is not currently supported.
 ```
 KEYS <table>
+```
+
+### TYPE
+Report the type of a stored value (`string`, `int`, `float`, `bool`, `array`, `map`):
+```
+TYPE <table> <key>
+```
+
+### INCR
+Add `delta` (default `1`) to a numeric value and return the new value. A missing key starts at `0`. Int arithmetic stays
+exact; a float operand makes the result a float. Concurrent increments are atomic.
+```
+INCR <table> <key> [delta]
+```
+Example:
+```
+INCR stats hits
+INCR stats hits 10
+INCR stats ratio 0.5
+```
+
+### APPEND
+Push a value onto an array and return the new length. A missing key becomes a new array:
+```
+APPEND <table> <key> <value>
+```
+
+### HSET / HGET
+Set and read one field of a map value. A missing key becomes a new map; reading a missing field replies like a missing
+key:
+```
+HSET <table> <key> <field> <value>
+HGET <table> <key> <field>
+```
+Example:
+```
+HSET users u1 name John
+HSET users u1 age 42
+HGET users u1 age
+```
+
+Running a typed command against a value of another type is an error and changes nothing:
+```
+ERR wrong type: key holds array, INCR requires int or float
 ```
 
 ## Configuration
@@ -107,12 +190,29 @@ logging:
 
 #### Server Configuration Options
 
-- **engine.type**: Storage engine type (currently only "in_memory")
+- **engine.type**: `in_memory` (RAM-only) or `tiered` (memory over disk)
+
+The `engine.*` options below apply only to the tiered engine. It carries its own durable store, so it cannot be combined
+with `wal.enabled` or replication — the server refuses that combination at startup.
+
+- **engine.data_dir**: Directory for the tiered segment store
+- **engine.max_memory**: MiB of hot values kept in RAM (the LRU budget)
+- **engine.max_storage**: MiB ceiling on live data; `SET` past it returns `ERR storage full`
+- **engine.sync**: Fsync policy for segments (`always`, `everysec`, or `no`)
+- **engine.segment_size**: Segment file size in MiB
+- **engine.compaction_threshold**: Reclaim a sealed segment once this fraction of it is dead bytes
+- **engine.compaction_interval**: How often to compact and log cache/disk stats
+
 - **wal.enabled**: Enable durable write-ahead logging (disabled by default)
 - **wal.data_dir**: Directory for WAL segments and snapshots
 - **wal.sync**: Fsync policy (`always`, `everysec`, or `no`)
 - **wal.segment_size**: WAL segment rollover size in MiB
 - **wal.snapshot_interval**: Interval between snapshots when data has changed
+- **replication.role**: `""` (standalone), `master`, or `standby`; requires `wal.enabled`
+- **replication.listen_address**: Master: where standbys connect for the WAL stream. Standby: optional, so `PROMOTE` can
+  start serving replication from this node
+- **replication.master_address**: Standby: the master to replicate from
+- **replication.reconnect_backoff**: Standby: pause between reconnect attempts
 - **network.address**: Server listening address
 - **network.max_connections**: Maximum concurrent client connections (enforced by server)
 - **network.max_message_size**: Maximum message size in KB
@@ -122,8 +222,8 @@ logging:
 
 #### Environment Variable Overrides
 
-Server settings can be overridden with environment variables, which take the highest priority
-(environment > config file > defaults):
+Server settings can be overridden with environment variables, which take the highest priority (environment > config file
+> defaults):
 
 - `DB_ADDRESS` — listening address
 - `DB_MAX_CONNECTIONS` — maximum concurrent client connections
@@ -158,13 +258,27 @@ docker build -t db .
 docker run --rm -p 3223:3223 db
 ```
 
-The image runs on default configuration with `DB_ADDRESS=0.0.0.0:3223` set, so the server is
-reachable through the published port, and logs to stdout for `docker logs`. Configure it with
-environment variables:
+The image runs on default configuration with `DB_ADDRESS=0.0.0.0:3223` set, so the server is reachable through the
+published port, and logs to stdout for `docker logs`. Configure it with environment variables:
 
 ```bash
 docker run --rm -p 3223:3223 -e DB_LOG_LEVEL=debug -e DB_MAX_CONNECTIONS=500 db
 ```
+
+Settings without an environment variable (engine type, WAL, replication) come from a YAML file. The `-config` path is
+resolved relative to the working directory, which is `/home/nonroot`, so mount the file there — an absolute path is
+rejected, and a path that resolves nowhere falls back to defaults silently:
+
+```bash
+docker run --rm -p 3223:3223 \
+  -v "$PWD/config.server.yaml:/home/nonroot/db.yaml" \
+  -v db-data:/home/nonroot/data \
+  db -config db.yaml
+```
+
+The image ships an empty `data` directory owned by the `nonroot` user, so a named volume mounted over it inherits that
+ownership and the WAL and tiered engine can write to it. Without the volume, data lives in the container's writable
+layer and is lost with the container.
 
 ## Using the CLI Client
 
@@ -267,21 +381,39 @@ Available commands:
   TABLES
   EXISTS table
   KEYS table
+  TYPE table key
+  INCR table key [delta]
+  APPEND table key value
+  HSET table key field value
+  HGET table key field
 Type 'exit' to quit
 
 > SET users name Alice
 OK
 > GET users name
 Alice
+> SET users age 42
+OK
+> TYPE users age
+int
+> INCR users age
+43
 > DEL users name
 OK
 > exit
 ```
 
+The CLI also reads commands from stdin, skipping blank and `#` lines, so a prepared script runs end to end.
+[`examples/commands.txt`](examples/commands.txt) covers every command:
+
+```bash
+./bin/db-cli < examples/commands.txt
+```
+
 ## Go Client Library
 
-External Go programs can use the database through the public client package —
-the only supported import path for external consumers:
+External Go programs can use the database through the public client package — the only supported import path for
+external consumers:
 
 ```go
 import "github.com/OutOfStack/db/client"
@@ -295,6 +427,17 @@ defer c.Close()
 err = c.Set(ctx, "users", "name", "Alice")
 val, err := c.Get(ctx, "users", "name") // returns client.ErrNotFound if the key is missing
 err = c.Del(ctx, "users", "name")
+```
+
+Values are typed by their literal syntax (see [Value types](#value-types)), and the typed operations are available too:
+
+```go
+err = c.Set(ctx, "users", "age", "42")       // int
+kind, err := c.Type(ctx, "users", "age")     // "int"
+hits, err := c.Incr(ctx, "stats", "hits", "")   // "" increments by 1
+n, err := c.Append(ctx, "users", "tags", "go")  // new array length
+err = c.HSet(ctx, "users", "u1", "name", "Alice")
+name, err := c.HGet(ctx, "users", "u1", "name") // ErrNotFound if the field is missing
 ```
 
 For distributed deployments, configure a connection pool instead of a single address:
@@ -337,16 +480,20 @@ go build -o bin/db-cli ./cmd/db-cli
 │   │   └── main.go
 │   └── db-cli/                  # CLI client
 │       └── main.go
+├── examples/commands.txt        # Runnable command reference for the CLI
 ├── config.client.example.yaml   # Example client configuration
 ├── config.server.example.yaml   # Example server configuration
 ├── example-pool-config.yaml     # Example pool configuration
 └── internal/                    # Internal packages
     ├── compute/                 # Request handling and command execution
     ├── config/                  # Configuration management
-    ├── engine/                  # Storage engine implementation
+    ├── engine/                  # In-memory storage engine
+    │   └── tiered/              # Memory/disk engine: segments, keydir, LRU, compaction
     ├── network/                 # TCP networking layer
     ├── parser/                  # Command parsing
     ├── pool/                    # Connection pooling and failover
+    ├── protocol/                # RESP2 framing and the typed-value codec
+    ├── replication/             # Master/standby WAL streaming
     ├── storage/                 # Storage layer
     └── wal/                     # Write-ahead log and snapshots
 ```
@@ -375,24 +522,21 @@ make generate
 
 ## Network Protocol
 
-The server speaks a RESP2-style protocol over TCP (the same framing used by
-Redis). The CLI accepts the human-friendly command syntax shown above and
-encodes it into RESP on the wire.
+The server speaks a RESP2-style protocol over TCP (the same framing used by Redis). The CLI accepts the human-friendly
+command syntax shown above and encodes it into RESP on the wire.
 
-- **Requests** are sent as a RESP array of bulk strings, one element per token.
-  For example, `SET users name Alice` is encoded as:
+- **Requests** are sent as a RESP array of bulk strings, one element per token. For example, `SET users name Alice` is
+  encoded as:
   ```
   *4\r\n$3\r\nSET\r\n$5\r\nusers\r\n$4\r\nname\r\n$5\r\nAlice\r\n
   ```
 - **Responses** use standard RESP2 reply types, each terminated with `\r\n`:
   - Simple strings (`+OK\r\n`) for successful writes
-  - Bulk strings (`$5\r\nAlice\r\n`) for values, and the null bulk string
-    (`$-1\r\n`) for a missing key
+  - Bulk strings (`$5\r\nAlice\r\n`) for values, and the null bulk string (`$-1\r\n`) for a missing key
   - Arrays (`*<n>\r\n…`) for list replies such as `TABLES` and `KEYS`
   - Integers (`:<n>\r\n`)
   - Errors (`-ERR <message>\r\n`)
-- Messages are bounded by the configured `max_message_size`; oversized requests
-  are rejected.
+- Messages are bounded by the configured `max_message_size`; oversized requests are rejected.
 
 ## Error Handling
 

--- a/client/client.go
+++ b/client/client.go
@@ -92,17 +92,7 @@ func (c *Client) Set(ctx context.Context, table, key, value string) error {
 	if err != nil {
 		return err
 	}
-	switch resp.Kind {
-	case protocol.ReplySimpleString:
-		if resp.Value == respOK {
-			return nil
-		}
-		return &ServerError{Msg: replyText(resp)}
-	case protocol.ReplyError:
-		return &ServerError{Msg: resp.Value}
-	default:
-		return &ServerError{Msg: replyText(resp)}
-	}
+	return okReply(resp)
 }
 
 // Get returns the value stored under key in table. Returns ErrNotFound if the key does not exist.
@@ -128,19 +118,10 @@ func (c *Client) Del(ctx context.Context, table, key string) error {
 	if err != nil {
 		return err
 	}
-	switch resp.Kind {
-	case protocol.ReplySimpleString:
-		if resp.Value == respOK {
-			return nil
-		}
-		return &ServerError{Msg: replyText(resp)}
-	case protocol.ReplyNull:
+	if resp.Kind == protocol.ReplyNull {
 		return ErrNotFound
-	case protocol.ReplyError:
-		return &ServerError{Msg: resp.Value}
-	default:
-		return &ServerError{Msg: replyText(resp)}
 	}
+	return okReply(resp)
 }
 
 // Incr adds delta to the numeric value at key, creating it as 0 when the key is missing, and returns the new value.
@@ -172,10 +153,7 @@ func (c *Client) Append(ctx context.Context, table, key, value string) (int64, e
 		return 0, err
 	}
 	if resp.Kind != protocol.ReplyInteger {
-		if resp.Kind == protocol.ReplyError {
-			return 0, &ServerError{Msg: resp.Value}
-		}
-		return 0, &ServerError{Msg: replyText(resp)}
+		return 0, errReply(resp)
 	}
 	return resp.Integer, nil
 }
@@ -190,13 +168,7 @@ func (c *Client) HSet(ctx context.Context, table, key, field, value string) erro
 	if err != nil {
 		return err
 	}
-	if resp.Kind == protocol.ReplySimpleString && resp.Value == respOK {
-		return nil
-	}
-	if resp.Kind == protocol.ReplyError {
-		return &ServerError{Msg: resp.Value}
-	}
-	return &ServerError{Msg: replyText(resp)}
+	return okReply(resp)
 }
 
 // HGet returns one field of the map at key. Returns ErrNotFound if the key or the field does not exist.
@@ -233,11 +205,25 @@ func textReply(resp protocol.Reply) (string, error) {
 		return resp.Value, nil
 	case protocol.ReplyNull:
 		return "", ErrNotFound
-	case protocol.ReplyError:
-		return "", &ServerError{Msg: resp.Value}
 	default:
-		return "", &ServerError{Msg: replyText(resp)}
+		return "", errReply(resp)
 	}
+}
+
+// okReply maps a write acknowledgement to the client error contract: nil for +OK, an error otherwise.
+func okReply(resp protocol.Reply) error {
+	if resp.Kind == protocol.ReplySimpleString && resp.Value == respOK {
+		return nil
+	}
+	return errReply(resp)
+}
+
+// errReply maps a reply already known not to be the expected kind to the shared error contract.
+func errReply(resp protocol.Reply) error {
+	if resp.Kind == protocol.ReplyError {
+		return &ServerError{Msg: resp.Value}
+	}
+	return &ServerError{Msg: replyText(resp)}
 }
 
 // Tables returns all table names in sorted order.
@@ -259,11 +245,8 @@ func (c *Client) TableExists(ctx context.Context, table string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if resp.Kind == protocol.ReplyError {
-		return false, &ServerError{Msg: resp.Value}
-	}
 	if resp.Kind != protocol.ReplyBulkString && resp.Kind != protocol.ReplySimpleString {
-		return false, &ServerError{Msg: replyText(resp)}
+		return false, errReply(resp)
 	}
 	switch resp.Value {
 	case "true":
@@ -290,11 +273,8 @@ func (c *Client) Keys(ctx context.Context, table string) ([]string, error) {
 }
 
 func stringArray(resp protocol.Reply) ([]string, error) {
-	if resp.Kind == protocol.ReplyError {
-		return nil, &ServerError{Msg: resp.Value}
-	}
 	if resp.Kind != protocol.ReplyArray {
-		return nil, &ServerError{Msg: replyText(resp)}
+		return nil, errReply(resp)
 	}
 	values := make([]string, 0, len(resp.Array))
 	for _, item := range resp.Array {

--- a/client/client.go
+++ b/client/client.go
@@ -1,5 +1,5 @@
-// Package client provides a Go client for the database server.
-// It is the only package in this module intended for import by external programs:
+// Package client provides a Go client for the database server. It is the only package in this module intended for
+// import by external programs:
 //
 //	import "github.com/OutOfStack/db/client"
 //
@@ -7,6 +7,9 @@
 //	err = c.Set(ctx, "users", "name", "vlad")
 //	val, err := c.Get(ctx, "users", "name")
 //	err = c.Del(ctx, "users", "name")
+//
+// Values are typed. A value is sent as a literal: 42 is an int, 42.5 a float, true a bool, [1,2] an array, {"a":1} a
+// map, "42" and any other text a string. Values come back in a human-readable form, and Type reports what a key holds.
 package client
 
 import (
@@ -24,13 +27,11 @@ import (
 const (
 	respOK = "OK"
 
-	// maxTableNameLen mirrors the server-side parser limit so invalid
-	// table names are rejected before reaching the wire
+	// maxTableNameLen mirrors the server-side parser limit so invalid table names are rejected before reaching the wire
 	maxTableNameLen = 128
 )
 
-// transport is the minimal connection interface the client needs.
-// Satisfied by *network.TCPClient and *pool.Client
+// transport is the minimal connection interface the client needs. Satisfied by *network.TCPClient and *pool.Client
 type transport interface {
 	Send(cmd string, args []string) (protocol.Reply, error)
 	Close() error
@@ -41,10 +42,9 @@ type Client struct {
 	transport transport
 }
 
-// New creates a new Client configured by the given options.
-// With WithServers, connections are pooled across the given servers with
-// automatic failover; otherwise a single connection is established to the
-// address set by WithAddress (default 127.0.0.1:3223)
+// New creates a new Client configured by the given options. With WithServers, connections are pooled across the given
+// servers with automatic failover; otherwise a single connection is established to the address set by WithAddress
+// (default 127.0.0.1:3223)
 func New(opts ...Option) (*Client, error) {
 	o := defaultOptions()
 	for _, opt := range opts {
@@ -105,8 +105,7 @@ func (c *Client) Set(ctx context.Context, table, key, value string) error {
 	}
 }
 
-// Get returns the value stored under key in table.
-// Returns ErrNotFound if the key does not exist.
+// Get returns the value stored under key in table. Returns ErrNotFound if the key does not exist.
 func (c *Client) Get(ctx context.Context, table, key string) (string, error) {
 	if err := validateArgs(table, key); err != nil {
 		return "", err
@@ -116,20 +115,10 @@ func (c *Client) Get(ctx context.Context, table, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch resp.Kind {
-	case protocol.ReplyBulkString, protocol.ReplySimpleString:
-		return resp.Value, nil
-	case protocol.ReplyNull:
-		return "", ErrNotFound
-	case protocol.ReplyError:
-		return "", &ServerError{Msg: resp.Value}
-	default:
-		return "", &ServerError{Msg: replyText(resp)}
-	}
+	return textReply(resp)
 }
 
-// Del deletes key from table.
-// Returns ErrNotFound if the key does not exist
+// Del deletes key from table. Returns ErrNotFound if the key does not exist
 func (c *Client) Del(ctx context.Context, table, key string) error {
 	if err := validateArgs(table, key); err != nil {
 		return err
@@ -151,6 +140,103 @@ func (c *Client) Del(ctx context.Context, table, key string) error {
 		return &ServerError{Msg: resp.Value}
 	default:
 		return &ServerError{Msg: replyText(resp)}
+	}
+}
+
+// Incr adds delta to the numeric value at key, creating it as 0 when the key is missing, and returns the new value.
+// delta is a literal ("1", "-2", "0.5"); an empty delta increments by 1.
+func (c *Client) Incr(ctx context.Context, table, key, delta string) (string, error) {
+	if err := validateArgs(table, key); err != nil {
+		return "", err
+	}
+
+	args := []string{table, key}
+	if delta != "" {
+		args = append(args, delta)
+	}
+	resp, err := c.send(ctx, "INCR", args)
+	if err != nil {
+		return "", err
+	}
+	return textReply(resp)
+}
+
+// Append pushes value onto the array at key, creating the array when the key is missing, and returns the new length.
+func (c *Client) Append(ctx context.Context, table, key, value string) (int64, error) {
+	if err := validateArgs(table, key, value); err != nil {
+		return 0, err
+	}
+
+	resp, err := c.send(ctx, "APPEND", []string{table, key, value})
+	if err != nil {
+		return 0, err
+	}
+	if resp.Kind != protocol.ReplyInteger {
+		if resp.Kind == protocol.ReplyError {
+			return 0, &ServerError{Msg: resp.Value}
+		}
+		return 0, &ServerError{Msg: replyText(resp)}
+	}
+	return resp.Integer, nil
+}
+
+// HSet sets field of the map at key, creating the map when the key is missing.
+func (c *Client) HSet(ctx context.Context, table, key, field, value string) error {
+	if err := validateArgs(table, key, value); err != nil {
+		return err
+	}
+
+	resp, err := c.send(ctx, "HSET", []string{table, key, field, value})
+	if err != nil {
+		return err
+	}
+	if resp.Kind == protocol.ReplySimpleString && resp.Value == respOK {
+		return nil
+	}
+	if resp.Kind == protocol.ReplyError {
+		return &ServerError{Msg: resp.Value}
+	}
+	return &ServerError{Msg: replyText(resp)}
+}
+
+// HGet returns one field of the map at key. Returns ErrNotFound if the key or the field does not exist.
+func (c *Client) HGet(ctx context.Context, table, key, field string) (string, error) {
+	if err := validateArgs(table, key); err != nil {
+		return "", err
+	}
+
+	resp, err := c.send(ctx, "HGET", []string{table, key, field})
+	if err != nil {
+		return "", err
+	}
+	return textReply(resp)
+}
+
+// Type returns the type of the value at key: string, int, float, bool, array or map. Returns ErrNotFound if the key
+// does not exist.
+func (c *Client) Type(ctx context.Context, table, key string) (string, error) {
+	if err := validateArgs(table, key); err != nil {
+		return "", err
+	}
+
+	resp, err := c.send(ctx, "TYPE", []string{table, key})
+	if err != nil {
+		return "", err
+	}
+	return textReply(resp)
+}
+
+// textReply maps a value-returning reply to its text, with the same missing-key contract as Get.
+func textReply(resp protocol.Reply) (string, error) {
+	switch resp.Kind {
+	case protocol.ReplyBulkString, protocol.ReplySimpleString:
+		return resp.Value, nil
+	case protocol.ReplyNull:
+		return "", ErrNotFound
+	case protocol.ReplyError:
+		return "", &ServerError{Msg: resp.Value}
+	default:
+		return "", &ServerError{Msg: replyText(resp)}
 	}
 }
 
@@ -189,8 +275,8 @@ func (c *Client) TableExists(ctx context.Context, table string) (bool, error) {
 	}
 }
 
-// Keys returns all keys in table in sorted order. A missing table returns an
-// empty slice. The response is subject to the configured message-size limit.
+// Keys returns all keys in table in sorted order. A missing table returns an empty slice. The response is subject to
+// the configured message-size limit.
 func (c *Client) Keys(ctx context.Context, table string) ([]string, error) {
 	if err := validateArgs(table); err != nil {
 		return nil, err
@@ -220,9 +306,8 @@ func stringArray(resp protocol.Reply) ([]string, error) {
 	return values, nil
 }
 
-// Raw sends a raw command line to the server and returns the response text
-// as is, without error mapping. It gives access to commands that have no
-// typed wrapper yet.
+// Raw sends a raw command line to the server and returns the response text as is, without error mapping. It gives
+// access to commands that have no typed wrapper yet.
 func (c *Client) Raw(ctx context.Context, command string) (string, error) {
 	parts, err := splitCommandLine(command)
 	if err != nil {
@@ -245,8 +330,7 @@ func (c *Client) Close() error {
 
 // send sends a command to the server and returns a typed response.
 func (c *Client) send(ctx context.Context, cmd string, args []string) (protocol.Reply, error) {
-	// the current transport cannot honor cancellation mid-call,
-	// so check the context before sending
+	// the current transport cannot honor cancellation mid-call, so check the context before sending
 	if err := ctx.Err(); err != nil {
 		return protocol.Reply{}, err
 	}
@@ -277,8 +361,8 @@ func replyText(reply protocol.Reply) string {
 	}
 }
 
-// validateArgs checks command arguments that are still constrained by database
-// semantics. RESP framing itself can carry whitespace, newlines, and NUL bytes.
+// validateArgs checks command arguments that are still constrained by database semantics. RESP framing itself can carry
+// whitespace, newlines, and NUL bytes.
 func validateArgs(table string, args ...string) error {
 	if table == "" {
 		return errors.New("table cannot be empty")
@@ -305,6 +389,15 @@ func splitCommandLine(command string) ([]string, error) {
 	inToken := false
 
 	for _, r := range command {
+		if quote == '\'' {
+			if r == '\'' {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+
 		if escaped {
 			current.WriteRune(unescape(r))
 			escaped = false

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -238,6 +238,43 @@ func TestClient_Raw(t *testing.T) {
 	}
 }
 
+// TestSplitCommandLineQuoting covers the quoting rules the README documents for typed literals: single quotes are
+// literal, so a value carrying backslashes (a JSON escape, a Windows path) survives the split unchanged, while escapes
+// are still processed outside them and inside double quotes.
+func TestSplitCommandLineQuoting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{"single quotes keep backslashes", `SET t k '{"path":"C:\\tmp"}'`, []string{"SET", "t", "k", `{"path":"C:\\tmp"}`}},
+		{"single quotes keep escape text", `SET t k 'a\nb'`, []string{"SET", "t", "k", `a\nb`}},
+		{"single quotes keep spaces", `SET t k 'hello world'`, []string{"SET", "t", "k", "hello world"}},
+		{"single quotes keep double quotes", `SET t k '{"a":1}'`, []string{"SET", "t", "k", `{"a":1}`}},
+		{"empty single-quoted token", `SET t k ''`, []string{"SET", "t", "k", ""}},
+		{"double quotes still unescape", `SET t k "a\nb"`, []string{"SET", "t", "k", "a\nb"}},
+		{"bare escapes still unescape", `SET t k a\tb`, []string{"SET", "t", "k", "a\tb"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := client.SplitCommandLine(tc.line)
+			if err != nil {
+				t.Fatalf("SplitCommandLine(%s) error = %v", tc.line, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitCommandLine(%s) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+
+	if _, err := client.SplitCommandLine(`SET t k 'unterminated`); err == nil {
+		t.Error("unterminated single quote should fail")
+	}
+}
+
 func TestClient_ArgValidation(t *testing.T) {
 	t.Parallel()
 
@@ -344,4 +381,74 @@ func TestNew_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_TypedCommands(t *testing.T) {
+	t.Parallel()
+
+	t.Run("incr sends the delta only when given", func(t *testing.T) {
+		t.Parallel()
+		ft := &fakeTransport{resp: protocol.BulkString("3")}
+		c := client.NewWithTransport(ft)
+
+		got, err := c.Incr(t.Context(), "stats", "hits", "")
+		if err != nil || got != "3" {
+			t.Fatalf("Incr() = %q, %v", got, err)
+		}
+		if _, err = c.Incr(t.Context(), "stats", "hits", "2"); err != nil {
+			t.Fatal(err)
+		}
+		wantSent := []sentCommand{
+			{cmd: "INCR", args: []string{"stats", "hits"}},
+			{cmd: "INCR", args: []string{"stats", "hits", "2"}},
+		}
+		if !reflect.DeepEqual(ft.sent, wantSent) {
+			t.Errorf("sent = %#v, want %#v", ft.sent, wantSent)
+		}
+	})
+
+	t.Run("append returns the new length", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.NewWithTransport(&fakeTransport{resp: protocol.Integer(2)}).
+			Append(t.Context(), "t", "list", "x")
+		if err != nil || got != 2 {
+			t.Fatalf("Append() = %d, %v", got, err)
+		}
+	})
+
+	t.Run("hset ok", func(t *testing.T) {
+		t.Parallel()
+		if err := client.NewWithTransport(&fakeTransport{resp: protocol.SimpleString("OK")}).
+			HSet(t.Context(), "t", "user", "name", "vlad"); err != nil {
+			t.Fatalf("HSet() error = %v", err)
+		}
+	})
+
+	t.Run("hget missing field is ErrNotFound", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.NewWithTransport(&fakeTransport{resp: protocol.NullBulkString()}).
+			HGet(t.Context(), "t", "user", "nope")
+		if !errors.Is(err, client.ErrNotFound) {
+			t.Fatalf("HGet() error = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("type returns the type name", func(t *testing.T) {
+		t.Parallel()
+		got, err := client.NewWithTransport(&fakeTransport{resp: protocol.SimpleString("array")}).
+			Type(t.Context(), "t", "list")
+		if err != nil || got != "array" {
+			t.Fatalf("Type() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("server error surfaces", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.NewWithTransport(&fakeTransport{resp: protocol.Error("wrong type: key holds array, INCR requires int or float")}).
+			Incr(t.Context(), "t", "list", "")
+		var srvErr *client.ServerError
+		if !errors.As(err, &srvErr) {
+			t.Fatalf("Incr() error = %v, want ServerError", err)
+		}
+	})
 }

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -7,3 +7,6 @@ type Transport = transport
 func NewWithTransport(t Transport) *Client {
 	return &Client{transport: t}
 }
+
+// SplitCommandLine exposes the CLI line splitter for testing.
+func SplitCommandLine(command string) ([]string, error) { return splitCommandLine(command) }

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -20,8 +20,7 @@ import (
 	"github.com/OutOfStack/db/internal/storage"
 )
 
-// startServer starts an in-process database server on an ephemeral port
-// and returns its address
+// startServer starts an in-process database server on an ephemeral port and returns its address
 func startServer(t *testing.T, opts ...network.TCPServerOption) string {
 	t.Helper()
 
@@ -29,9 +28,8 @@ func startServer(t *testing.T, opts ...network.TCPServerOption) string {
 	return addr
 }
 
-// startStoppableServer starts an in-process database server on an ephemeral
-// port and returns its address and a stop function. The stop function blocks
-// until the server no longer accepts new connections
+// startStoppableServer starts an in-process database server on an ephemeral port and returns its address and a stop
+// function. The stop function blocks until the server no longer accepts new connections
 func startStoppableServer(t *testing.T, opts ...network.TCPServerOption) (addr string, stop func()) {
 	t.Helper()
 
@@ -272,8 +270,7 @@ func TestClient_MessageSizeLimit(t *testing.T) {
 
 	ctx := t.Context()
 
-	// large-but-legal request near the limit round-trips
-	// (frame overhead for SET users big <value> is ~40 bytes)
+	// large-but-legal request near the limit round-trips (frame overhead for SET users big <value> is ~40 bytes)
 	nearLimit := strings.Repeat("x", serverLimit-64)
 	if err = c.Set(ctx, "users", "big", nearLimit); err != nil {
 		t.Fatalf("Set() near limit error = %v", err)
@@ -322,8 +319,7 @@ func TestClient_OversizedReplyDoesNotDesyncConnection(t *testing.T) {
 		t.Fatalf("Get() oversized reply error = %v, want size limit error", err)
 	}
 
-	// ...without leaving the rejected reply's bytes on the connection:
-	// subsequent commands must see their own replies
+	// ...without leaving the rejected reply's bytes on the connection: subsequent commands must see their own replies
 	if err = c.Set(ctx, "users", "small", "v"); err != nil {
 		t.Fatalf("Set() after oversized reply error = %v", err)
 	}
@@ -389,8 +385,8 @@ func TestClient_Pool_Failover(t *testing.T) {
 		t.Fatalf("Get() = %q, %v; want %q, nil", got, err, "master-value")
 	}
 
-	// Seed the standby directly (these in-process servers do not replicate) so a
-	// read that fails over to it returns an observably different value.
+	// Seed the standby directly (these in-process servers do not replicate) so a read that fails over to it returns an
+	// observably different value.
 	standby, err := client.New(client.WithAddress(standbyAddr))
 	if err != nil {
 		t.Fatalf("standby client New() error = %v", err)
@@ -402,8 +398,8 @@ func TestClient_Pool_Failover(t *testing.T) {
 
 	stopMaster()
 
-	// Reads fail over to the standby. The master's established connection may
-	// absorb at most one more request before it closes, so retry until failover.
+	// Reads fail over to the standby. The master's established connection may absorb at most one more request before it
+	// closes, so retry until failover.
 	if err = eventually(func() bool {
 		v, gErr := c.Get(ctx, "t", "key")
 		return gErr == nil && v == "standby-value"
@@ -411,8 +407,8 @@ func TestClient_Pool_Failover(t *testing.T) {
 		t.Errorf("Get() did not fail over to standby: %v", err)
 	}
 
-	// Writes route only to masters, so with the master down they must fail rather
-	// than silently land on the read-only standby.
+	// Writes route only to masters, so with the master down they must fail rather than silently land on the read-only
+	// standby.
 	if err = eventually(func() bool {
 		return c.Set(ctx, "t", "key", "new-value") != nil
 	}); err != nil {
@@ -429,4 +425,77 @@ func eventually(cond func() bool) error {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return errors.New("condition not met within timeout")
+}
+
+func TestClient_TypedValuesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	addr := startServer(t)
+
+	c, err := client.New(client.WithAddress(addr))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer c.Close()
+
+	ctx := t.Context()
+
+	types := []struct{ key, literal, kind, want string }{
+		{"text", "vlad", "string", "vlad"},
+		{"quoted", `"42"`, "string", "42"},
+		{"count", "42", "int", "42"},
+		{"ratio", "0.5", "float", "0.5"},
+		{"on", "true", "bool", "true"},
+		{"list", "[1,2]", "array", "[1,2]"},
+		{"conf", `{"b":2,"a":"x"}`, "map", `{"a":"x","b":2}`},
+	}
+	for _, tt := range types {
+		if err = c.Set(ctx, "t", tt.key, tt.literal); err != nil {
+			t.Fatalf("Set(%s) error = %v", tt.literal, err)
+		}
+		kind, tErr := c.Type(ctx, "t", tt.key)
+		if tErr != nil || kind != tt.kind {
+			t.Errorf("Type(%s) = %q, %v; want %q", tt.literal, kind, tErr, tt.kind)
+		}
+		got, gErr := c.Get(ctx, "t", tt.key)
+		if gErr != nil || got != tt.want {
+			t.Errorf("Get(%s) = %q, %v; want %q", tt.literal, got, gErr, tt.want)
+		}
+	}
+
+	if got, iErr := c.Incr(ctx, "stats", "hits", ""); iErr != nil || got != "1" {
+		t.Errorf("Incr() = %q, %v; want 1", got, iErr)
+	}
+	if got, iErr := c.Incr(ctx, "stats", "hits", "1.5"); iErr != nil || got != "2.5" {
+		t.Errorf("Incr(1.5) = %q, %v; want 2.5", got, iErr)
+	}
+
+	if n, aErr := c.Append(ctx, "t", "log", "first"); aErr != nil || n != 1 {
+		t.Errorf("Append() = %d, %v; want 1", n, aErr)
+	}
+	if n, aErr := c.Append(ctx, "t", "log", "2"); aErr != nil || n != 2 {
+		t.Errorf("Append() = %d, %v; want 2", n, aErr)
+	}
+	if got, gErr := c.Get(ctx, "t", "log"); gErr != nil || got != `["first",2]` {
+		t.Errorf("Get(log) = %q, %v", got, gErr)
+	}
+
+	if err = c.HSet(ctx, "t", "user", "name", "vlad"); err != nil {
+		t.Fatalf("HSet() error = %v", err)
+	}
+	if got, hErr := c.HGet(ctx, "t", "user", "name"); hErr != nil || got != "vlad" {
+		t.Errorf("HGet() = %q, %v; want vlad", got, hErr)
+	}
+	if _, hErr := c.HGet(ctx, "t", "user", "missing"); !errors.Is(hErr, client.ErrNotFound) {
+		t.Errorf("HGet(missing field) error = %v, want ErrNotFound", hErr)
+	}
+
+	_, err = c.Incr(ctx, "t", "list", "")
+	var srvErr *client.ServerError
+	if !errors.As(err, &srvErr) {
+		t.Fatalf("Incr() on an array error = %v, want ServerError", err)
+	}
+	if want := "wrong type: key holds array, INCR requires int or float"; srvErr.Msg != want {
+		t.Errorf("Incr() on an array = %q, want %q", srvErr.Msg, want)
+	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -58,16 +58,14 @@ func defaultOptions() *options {
 // Option configures a Client
 type Option func(*options)
 
-// WithAddress sets the server address for single-server mode.
-// Ignored when WithServers is also provided
+// WithAddress sets the server address for single-server mode. Ignored when WithServers is also provided
 func WithAddress(addr string) Option {
 	return func(o *options) {
 		o.address = addr
 	}
 }
 
-// WithServers enables pool mode with the given servers.
-// At least one server must have RoleMaster
+// WithServers enables pool mode with the given servers. At least one server must have RoleMaster
 func WithServers(servers ...Server) Option {
 	return func(o *options) {
 		o.servers = servers

--- a/cmd/db-cli/main.go
+++ b/cmd/db-cli/main.go
@@ -59,6 +59,13 @@ func main() {
 	fmt.Println("  TABLES")
 	fmt.Println("  EXISTS table")
 	fmt.Println("  KEYS table")
+	fmt.Println("  TYPE table key")
+	fmt.Println("  INCR table key [delta]")
+	fmt.Println("  APPEND table key value")
+	fmt.Println("  HSET table key field value")
+	fmt.Println("  HGET table key field")
+	fmt.Println("Values are typed: 42 int, 42.5 float, true bool, [1,2] array, {\"a\":1} map, anything else string")
+	fmt.Println("Wrap a literal in single quotes when it contains quotes, spaces or backslashes: SET t conf '{\"a\":1}'")
 	fmt.Println("Type 'exit' to quit")
 	fmt.Println()
 
@@ -75,7 +82,7 @@ func main() {
 			break
 		}
 
-		if input == "" {
+		if input == "" || strings.HasPrefix(input, "#") {
 			continue
 		}
 

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -28,8 +28,8 @@ func main() {
 	os.Exit(execute())
 }
 
-// execute runs the server and returns a process exit code. It is separate from
-// main so deferred cleanup (e.g. closing the log file) runs before os.Exit.
+// execute runs the server and returns a process exit code. It is separate from main so deferred cleanup (e.g. closing
+// the log file) runs before os.Exit.
 func execute() int {
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "Path to configuration file")
@@ -84,8 +84,8 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
-	// Only the tiered engine holds resources; the in-memory one is not an
-	// io.Closer. Deferred so an early return below still flushes it.
+	// Only the tiered engine holds resources; the in-memory one is not an io.Closer. Deferred so an early return below
+	// still flushes it.
 	if closer, ok := dbEngine.(io.Closer); ok {
 		defer func() { _ = closer.Close() }()
 	}
@@ -97,8 +97,8 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 	if walWriter != nil {
 		options = append(options, storage.WithWAL(walWriter))
 	}
-	// A standby starts read-only: client writes are rejected until PROMOTE, while
-	// replication applies the master's log directly to the engine.
+	// A standby starts read-only: client writes are rejected until PROMOTE, while replication applies the master's log
+	// directly to the engine.
 	if cfg.Replication.Role == config.RoleStandby {
 		options = append(options, storage.WithReadOnly(true))
 	}
@@ -117,9 +117,8 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 	return serve(cfg, logger, comp, store, walWriter, repl, snapshotLSN)
 }
 
-// buildEngine constructs the configured storage engine. The tiered engine keeps
-// its own durable segment store (no WAL); the in-memory engine recovers from the
-// WAL/snapshot when persistence is enabled, and so returns a writer and the LSN
+// buildEngine constructs the configured storage engine. The tiered engine keeps its own durable segment store (no WAL);
+// the in-memory engine recovers from the WAL/snapshot when persistence is enabled, and so returns a writer and the LSN
 // to resume from.
 func buildEngine( //nolint:ireturn // returns the configured engine (in-memory or tiered) behind storage.Engine
 	cfg *config.ServerConfig,
@@ -168,7 +167,7 @@ func recoverPersistence(
 	dbEngine.Load(context.Background(), entries)
 
 	lastLSN, err := wal.NewReader(cfg.WAL.DataDir, logger).Replay(snapshotLSN, func(record wal.Record) error {
-		return applyRecoveredRecord(dbEngine, record)
+		return storage.ApplyReplay(context.Background(), dbEngine, record.Command, record.Args)
 	})
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("replay WAL: %w", err)
@@ -183,21 +182,6 @@ func recoverPersistence(
 	}
 	logger.Info("Persistence recovered", "snapshot_lsn", snapshotLSN, "last_lsn", lastLSN)
 	return dbEngine, writer, snapshotLSN, nil
-}
-
-func applyRecoveredRecord(dbEngine *engine.Engine, record wal.Record) error {
-	switch record.Command {
-	case wal.CommandSet:
-		return dbEngine.Set(context.Background(), record.Args[0], record.Args[1], record.Args[2])
-	case wal.CommandDel:
-		err := dbEngine.Del(context.Background(), record.Args[0], record.Args[1])
-		if errors.Is(err, engine.ErrNotFound) {
-			return nil
-		}
-		return err
-	default:
-		return fmt.Errorf("unsupported WAL command %q", record.Command)
-	}
 }
 
 func serve(
@@ -224,9 +208,8 @@ func serve(
 		defer close(serverDone)
 		srv.Start(ctx, requestHandler(comp))
 	}()
-	// Snapshots run for every role: a standby applies replicated records through
-	// the storage layer under the same lock a snapshot takes, so its snapshots
-	// are consistent, and this keeps a promoted node's WAL bounded.
+	// Snapshots run for every role: a standby applies replicated records through the storage layer under the same lock a
+	// snapshot takes, so its snapshots are consistent, and this keeps a promoted node's WAL bounded.
 	snapshotDone := startSnapshotLoop(ctx, cfg, logger, store, walWriter, recoveredSnapshotLSN)
 	replDone := startReplication(ctx, logger, repl)
 

--- a/cmd/db/main_test.go
+++ b/cmd/db/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OutOfStack/db/internal/config"
 	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/replication"
 	"github.com/OutOfStack/db/internal/storage"
 	"github.com/OutOfStack/db/internal/wal"
@@ -39,8 +40,8 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Fatalf("timed out waiting for %s", what)
 }
 
-// TestPromoteServesReplication promotes a standby and verifies it both accepts
-// writes and serves replication to a downstream standby.
+// TestPromoteServesReplication promotes a standby and verifies it both accepts writes and serves replication to a
+// downstream standby.
 func TestPromoteServesReplication(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultServerConfig()
@@ -95,7 +96,7 @@ func TestPromoteServesReplication(t *testing.T) {
 
 	waitFor(t, "downstream standby to replicate from promoted node", func() bool {
 		v, gErr := dsEngine.Get(context.Background(), "t", "k")
-		return gErr == nil && v == "v1"
+		return gErr == nil && stored(v) == "v1"
 	})
 }
 
@@ -142,7 +143,82 @@ func TestRecoverPersistenceSnapshotAndWALTail(t *testing.T) {
 		t.Fatalf("deleted key error = %v, want ErrNotFound", err)
 	}
 	value, err := recovered.Get(t.Context(), "users", "b")
-	if err != nil || value != "two" {
+	if err != nil || stored(value) != "two" {
 		t.Fatalf("recovered value = %q, %v; want two, nil", value, err)
+	}
+}
+
+func stored(value string) string {
+	return protocol.Render(protocol.Decode(value))
+}
+
+func TestRecoverPersistenceTypedValues(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultServerConfig()
+	cfg.WAL.Enabled = true
+	cfg.WAL.DataDir = t.TempDir()
+	cfg.WAL.Sync = wal.SyncAlways
+	cfg.WAL.SegmentSizeMB = 1
+	cfg.WAL.SnapshotInterval = time.Minute
+	logger := slog.New(slog.DiscardHandler)
+
+	dbEngine, writer, _, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		t.Fatalf("initial recoverPersistence() error = %v", err)
+	}
+	store := storage.New(dbEngine, storage.WithWAL(writer))
+
+	commands := [][]string{
+		{"SET", "t", "conf", `{"a":[1,2],"b":"x"}`},
+		{"SET", "t", "name", "vlad"},
+		{"INCR", "t", "hits", "5"},
+		{"INCR", "t", "hits", "0.5"},
+		{"APPEND", "t", "log", "first"},
+		{"APPEND", "t", "log", "2"},
+		{"HSET", "t", "user", "name", "vlad"},
+		{"HSET", "t", "user", "age", "42"},
+		{"SET", "t", "big", "9223372036854775807"},
+		// Both fail after they are already durable, so recovery has to replay them as the no-ops they were instead of
+		// refusing to start.
+		{"INCR", "t", "name"}, // wrong type
+		{"INCR", "t", "big"},  // int64 overflow
+	}
+	for _, command := range commands {
+		if _, err = store.Execute(t.Context(), command[0], command[1:]); err != nil && command[0] != "INCR" {
+			t.Fatalf("%v: %v", command, err)
+		}
+	}
+	if _, err = createSnapshot(t.Context(), cfg.WAL.DataDir, store); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.Execute(t.Context(), "APPEND", []string{"t", "log", "true"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, recoveredWriter, _, err := recoverPersistence(cfg, logger)
+	if err != nil {
+		t.Fatalf("recoverPersistence() error = %v", err)
+	}
+	defer func() { _ = recoveredWriter.Close() }()
+
+	want := map[string]string{
+		"conf": `{"a":[1,2],"b":"x"}`,
+		"name": "vlad",
+		"hits": "5.5",
+		"log":  `["first",2,true]`,
+		"user": `{"age":42,"name":"vlad"}`,
+		"big":  "9223372036854775807",
+	}
+	for key, wantValue := range want {
+		value, gErr := recovered.Get(t.Context(), "t", key)
+		if gErr != nil {
+			t.Fatalf("recovered Get(%s) error = %v", key, gErr)
+		}
+		if got := stored(value); got != wantValue {
+			t.Errorf("recovered t/%s = %s, want %s", key, got, wantValue)
+		}
 	}
 }

--- a/cmd/db/replication.go
+++ b/cmd/db/replication.go
@@ -14,17 +14,16 @@ import (
 	"github.com/OutOfStack/db/internal/wal"
 )
 
-// replicationRuntime bundles the replication components for a server, exactly
-// one of master/standby is non-nil (both nil for a standalone server).
+// replicationRuntime bundles the replication components for a server, exactly one of master/standby is non-nil (both
+// nil for a standalone server).
 type replicationRuntime struct {
 	master  *replication.Master
 	standby *replication.Standby
 	admin   *replicationAdmin
 }
 
-// setupReplication builds the replication runtime for the configured role. It
-// returns nil for a standalone server. Replication requires the WAL, which the
-// config validation guarantees is enabled for master/standby roles.
+// setupReplication builds the replication runtime for the configured role. It returns nil for a standalone server.
+// Replication requires the WAL, which the config validation guarantees is enabled for master/standby roles.
 func setupReplication(
 	cfg *config.ServerConfig,
 	logger *slog.Logger,
@@ -65,9 +64,8 @@ func setupReplication(
 	}
 }
 
-// startReplication launches replication background work. The returned channel
-// closes when a master stops accepting connections; for a standby the loop is
-// owned by the standby and drained by stopReplication.
+// startReplication launches replication background work. The returned channel closes when a master stops accepting
+// connections; for a standby the loop is owned by the standby and drained by stopReplication.
 func startReplication(ctx context.Context, _ *slog.Logger, repl *replicationRuntime) <-chan struct{} {
 	done := make(chan struct{})
 	if repl == nil {
@@ -107,8 +105,8 @@ func stopReplication(logger *slog.Logger, repl *replicationRuntime) {
 	}
 }
 
-// replicationAdmin implements compute.Admin, handling PROMOTE and REPLICATION
-// STATUS. Its role changes from standby to master on promotion.
+// replicationAdmin implements compute.Admin, handling PROMOTE and REPLICATION STATUS. Its role changes from standby to
+// master on promotion.
 type replicationAdmin struct {
 	store      *storage.Storage
 	writer     *wal.Writer
@@ -123,10 +121,9 @@ type replicationAdmin struct {
 	promotedCancel context.CancelFunc
 }
 
-// Promote flips a standby to master: it stops replication, lifts read-only mode
-// so the server accepts writes, and — when a listen address is configured —
-// starts serving replication so other standbys can be re-aimed here. Demoting
-// the old master remains an operator action.
+// Promote flips a standby to master: it stops replication, lifts read-only mode so the server accepts writes, and —
+// when a listen address is configured — starts serving replication so other standbys can be re-aimed here. Demoting the
+// old master remains an operator action.
 func (a *replicationAdmin) Promote(_ context.Context) (protocol.Reply, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -141,8 +138,7 @@ func (a *replicationAdmin) Promote(_ context.Context) (protocol.Reply, error) {
 	a.logger.Info("Promoted standby to master", "applied_lsn", a.writer.LastLSN())
 
 	if a.listenAddr != "" {
-		// The promoted master outlives this request, so it runs on its own
-		// lifetime context rather than the request context.
+		// The promoted master outlives this request, so it runs on its own lifetime context rather than the request context.
 		if err := a.startMasterLocked(); err != nil { //nolint:contextcheck // intentional: master uses its own lifetime context
 			// Writes are already enabled; log rather than fail the promotion.
 			a.logger.Error("Promoted master could not serve replication", "error", err)
@@ -151,8 +147,7 @@ func (a *replicationAdmin) Promote(_ context.Context) (protocol.Reply, error) {
 	return protocol.SimpleString("OK"), nil
 }
 
-// startMasterLocked starts a replication listener for the promoted node. The
-// caller holds a.mu.
+// startMasterLocked starts a replication listener for the promoted node. The caller holds a.mu.
 func (a *replicationAdmin) startMasterLocked() error {
 	master, err := replication.NewMaster(a.listenAddr, a.writer, a.dir, a.logger)
 	if err != nil {
@@ -166,8 +161,7 @@ func (a *replicationAdmin) startMasterLocked() error {
 	return nil
 }
 
-// close stops a replication listener started by promotion. It is called during
-// server shutdown.
+// close stops a replication listener started by promotion. It is called during server shutdown.
 func (a *replicationAdmin) close() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -181,8 +175,7 @@ func (a *replicationAdmin) close() {
 	}
 }
 
-// Status returns role, applied LSN, lag, and connection state as a flat
-// key/value array reply.
+// Status returns role, applied LSN, lag, and connection state as a flat key/value array reply.
 func (a *replicationAdmin) Status(_ context.Context) (protocol.Reply, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/config.client.example.yaml
+++ b/config.client.example.yaml
@@ -1,5 +1,4 @@
-# Example client configuration file
-# Copy this to client.yaml and modify as needed
+# Example client configuration file. Copy this to client.yaml and modify as needed
 
 network:
   address: "127.0.0.1:3223"

--- a/config.server.example.yaml
+++ b/config.server.example.yaml
@@ -1,14 +1,11 @@
-# Example server configuration file
-# Copy this to config.yaml and modify as needed
+# Example server configuration file. Copy this to config.yaml and modify as needed
 
 engine:
   type: "in_memory"          # "in_memory" (RAM-only) or "tiered" (memory/disk)
 
-  # The "tiered" engine lets the dataset grow beyond RAM: an append-only on-disk
-  # segment store is the source of truth, a full in-memory keydir indexes every
-  # key, and an LRU cache holds hot values. It provides its own durability, so it
-  # cannot be combined with wal.enabled or replication. The fields below apply
-  # only when type is "tiered".
+  # The "tiered" engine lets the dataset grow beyond RAM: an append-only on-disk segment store is the source of truth, a
+  # full in-memory keydir indexes every key, and an LRU cache holds hot values. It provides its own durability, so it
+  # cannot be combined with wal.enabled or replication. The fields below apply only when type is "tiered".
   data_dir: "data"           # directory for the tiered segment store
   max_memory: 64             # MiB of hot values kept in RAM (LRU budget)
   max_storage: 1024          # MiB ceiling on live data; SET returns "ERR storage full" beyond it
@@ -17,7 +14,8 @@ engine:
   compaction_threshold: 0.5  # reclaim a sealed segment once this fraction is dead bytes
   compaction_interval: 30s   # how often to compact and log cache/disk stats
 
-# WAL is disabled by default for backward compatibility.
+# The WAL is off by default: the in-memory engine runs without touching disk until persistence is asked for. It cannot
+# be combined with engine.type tiered, which keeps its own durable store.
 wal:
   enabled: false
   data_dir: "data"
@@ -25,13 +23,12 @@ wal:
   segment_size: 64          # MiB
   snapshot_interval: 5m
 
-# Replication ships the WAL from a master to standbys (asynchronous). It requires
-# wal.enabled. Leave role empty for a standalone server.
+# Replication ships the WAL from a master to standbys (asynchronous). It requires wal.enabled. Leave role empty for a
+# standalone server.
 replication:
   role: ""                        # "", "master", or "standby"
-  # master: address standbys connect to for the WAL stream.
-  # standby (optional): if set, PROMOTE starts serving replication here so other
-  # standbys can be re-aimed at the promoted node.
+  # master: address standbys connect to for the WAL stream. standby (optional): if set, PROMOTE starts serving
+  # replication here so other standbys can be re-aimed at the promoted node.
   listen_address: ""              # e.g. "127.0.0.1:3224"
   # standby: the master's listen_address to replicate from.
   master_address: ""              # e.g. "127.0.0.1:3224"

--- a/example-pool-config.yaml
+++ b/example-pool-config.yaml
@@ -32,10 +32,6 @@ pool:
   # Delay between retry attempts
   retry_delay: 1s
 
-  # Health check period (for future use)
-  health_check_period: 10s
-
-  # Time after which failed servers are automatically retried
-  # Failed servers are temporarily excluded from the pool but will
-  # be retried after this timeout, allowing recovery from transient failures
+  # Time after which failed servers are automatically retried Failed servers are temporarily excluded from the pool but
+  # will be retried after this timeout, allowing recovery from transient failures
   failure_timeout: 30s

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -1,7 +1,11 @@
-# Example commands for the Simple DB service
-# Keys are scoped by table: SET <table> <key> <value>
+# Example commands for the Simple DB service. Pipe this file into the CLI to run it:
+#
+#   ./bin/db-cli < examples/commands.txt
+#
+# Comments must be on their own line: the CLI skips those, but anything after a command on the same line is parsed as
+# another argument.
 
-# Basic operations
+# Basic operations. Keys are scoped by table.
 SET users name John
 GET users name
 
@@ -9,20 +13,63 @@ GET users name
 DEL users name
 GET users name
 
-# Special characters
+# Values with special characters
 SET files path/to/file.txt /home/user/documents/file.txt
 GET files path/to/file.txt
 
+# Values are typed by their literal syntax, and TYPE reports what a key holds.
+SET types text 'hello world'
+SET types count 42
+SET types ratio 42.5
+SET types active true
+SET types tags [1,2,3]
+TYPE types text
+TYPE types count
+TYPE types ratio
+TYPE types active
+TYPE types tags
+
+# The CLI strips quotes while splitting a line, so a literal containing quotes or spaces has to be wrapped in single
+# quotes.
+SET types conf '{"a":1,"b":"x"}'
+GET types conf
+SET types zip '"01234"'
+TYPE types zip
+
+# Counters. A missing key starts at 0, and the delta defaults to 1.
+INCR stats hits
+INCR stats hits 10
+INCR stats hits 0.5
+GET stats hits
+
+# Arrays: APPEND returns the new length.
+APPEND events log first
+APPEND events log 2
+GET events log
+
+# Maps: HSET writes one field, HGET reads one back.
+HSET users u1 name John
+HSET users u1 age 42
+HGET users u1 age
+GET users u1
+
 # Introspection
-TABLES                 # list all tables
-EXISTS users           # does the table exist
-KEYS users             # list keys in a table
+TABLES
+EXISTS users
+KEYS users
 
-# Replication (master/standby)
-REPLICATION STATUS     # role, applied LSN, lag, connection state
-PROMOTE                # promote a standby to master
+# Replication (master/standby): role, applied LSN, lag, connection state
+REPLICATION STATUS
+# Promote a standby to master
+PROMOTE
 
-# Invalid commands
-SET users name         # Missing value
-GET users name extra   # Too many args
-UNKNOWN foo            # Unknown command
+# Errors: each of these is rejected and changes nothing. Missing value
+SET users name
+# Too many arguments
+GET users name extra
+# Unknown command
+UNKNOWN foo
+# Wrong type for the operation
+INCR events log
+# Malformed map literal
+SET types broken '{"a":'

--- a/internal/compute/compute.go
+++ b/internal/compute/compute.go
@@ -20,8 +20,7 @@ type Parser interface {
 	Parse(cmd string, args []string) (string, []string, error)
 }
 
-// Admin handles replication control-plane commands that live above the storage
-// layer and are never written to the WAL.
+// Admin handles replication control-plane commands that live above the storage layer and are never written to the WAL.
 type Admin interface {
 	Promote(ctx context.Context) (protocol.Reply, error)
 	Status(ctx context.Context) (protocol.Reply, error)
@@ -79,8 +78,8 @@ func (c *Compute) HandleRequest(ctx context.Context, cmd string, args []string) 
 	return result, nil
 }
 
-// handleAdmin dispatches replication control commands. handled is true when cmd
-// is such a command, in which case the caller returns reply/err directly.
+// handleAdmin dispatches replication control commands. handled is true when cmd is such a command, in which case the
+// caller returns reply/err directly.
 func (c *Compute) handleAdmin(ctx context.Context, cmd string, args []string) (protocol.Reply, bool, error) {
 	switch cmd {
 	case "PROMOTE":

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -20,9 +20,8 @@ type ClientNetworkConfig struct {
 	IdleTimeout      time.Duration `yaml:"idle_timeout"`
 }
 
-// DefaultClientConfig returns a ClientConfig instance with sensible default values.
-// This is used as a fallback when no configuration file is provided or when
-// certain configuration parameters are missing
+// DefaultClientConfig returns a ClientConfig instance with sensible default values. This is used as a fallback when no
+// configuration file is provided or when certain configuration parameters are missing
 func DefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		Network: ClientNetworkConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,11 @@ import (
 // defaultAddress is the default server address shared by server and client configs
 const defaultAddress = "127.0.0.1:3223"
 
-// defaultDataDir is the default on-disk directory for WAL segments, snapshots,
-// and tiered-engine segments.
+// defaultDataDir is the default on-disk directory for WAL segments, snapshots, and tiered-engine segments.
 const defaultDataDir = "data"
 
-// getAllowedConfigDirs returns the list of directories to search for config files.
-// It checks current directory, user config directory, and user home directory
+// getAllowedConfigDirs returns the list of directories to search for config files. It checks current directory, user
+// config directory, and user home directory
 func getAllowedConfigDirs() []string {
 	var dirs []string
 
@@ -34,8 +33,8 @@ func getAllowedConfigDirs() []string {
 	return dirs
 }
 
-// load reads a configuration file into the provided config struct.
-// If the file is not found, it returns nil data and no error
+// load reads a configuration file into the provided config struct. If the file is not found, it returns nil data and no
+// error
 func load(filename string) (data []byte, err error) {
 	if !fs.ValidPath(filename) {
 		return nil, fmt.Errorf("invalid config filename: %q", filename)
@@ -58,8 +57,7 @@ func load(filename string) (data []byte, err error) {
 	return nil, nil
 }
 
-// LoadServerConfig loads the server configuration from a YAML file and
-// applies DB_* environment variable overrides.
+// LoadServerConfig loads the server configuration from a YAML file and applies DB_* environment variable overrides.
 // Priority: environment variables > file values > defaults
 func LoadServerConfig(filename string) (*ServerConfig, error) {
 	cfg := DefaultServerConfig()

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -37,10 +37,9 @@ type ServerConfig struct {
 	Logging     ServerLoggingConfig     `yaml:"logging"`
 }
 
-// ServerReplicationConfig controls master/standby log shipping. Role is
-// "master", "standby", or empty (standalone). A master streams its WAL to
-// standbys that connect to ListenAddress; a standby connects to MasterAddress.
-// Replication requires WAL persistence to be enabled.
+// ServerReplicationConfig controls master/standby log shipping. Role is "master", "standby", or empty (standalone). A
+// master streams its WAL to standbys that connect to ListenAddress; a standby connects to MasterAddress. Replication
+// requires WAL persistence to be enabled.
 type ServerReplicationConfig struct {
 	Role             string        `yaml:"role"`
 	ListenAddress    string        `yaml:"listen_address"`
@@ -48,8 +47,7 @@ type ServerReplicationConfig struct {
 	ReconnectBackoff time.Duration `yaml:"reconnect_backoff"`
 }
 
-// ServerWALConfig controls durable write-ahead logging and snapshots.
-// SegmentSizeMB is measured in MiB.
+// ServerWALConfig controls durable write-ahead logging and snapshots. SegmentSizeMB is measured in MiB.
 type ServerWALConfig struct {
 	Enabled          bool           `yaml:"enabled"`
 	DataDir          string         `yaml:"data_dir"`
@@ -58,9 +56,8 @@ type ServerWALConfig struct {
 	SnapshotInterval time.Duration  `yaml:"snapshot_interval"`
 }
 
-// ServerEngineConfig holds configuration for the database engine. Type is
-// "in_memory" (RAM-only) or "tiered" (memory/disk). The Tiered* fields apply
-// only to the tiered engine, which provides its own durability and therefore
+// ServerEngineConfig holds configuration for the database engine. Type is "in_memory" (RAM-only) or "tiered"
+// (memory/disk). The Tiered* fields apply only to the tiered engine, which provides its own durability and therefore
 // cannot be combined with the WAL or replication.
 type ServerEngineConfig struct {
 	Type                string         `yaml:"type"`
@@ -81,16 +78,15 @@ type ServerNetworkConfig struct {
 	IdleTimeout      time.Duration `yaml:"idle_timeout"`
 }
 
-// ServerLoggingConfig - logging configuration including log level and output destination.
-// Level can be "debug", "info", "warn", or "error". Output can be empty for stdout or a file path
+// ServerLoggingConfig - logging configuration including log level and output destination. Level can be "debug", "info",
+// "warn", or "error". Output can be empty for stdout or a file path
 type ServerLoggingConfig struct {
 	Level  string `yaml:"level"`
 	Output string `yaml:"output"`
 }
 
-// DefaultServerConfig returns a serverConfig instance with sensible default values.
-// This is used as a fallback when no configuration file is provided or when
-// certain configuration parameters are missing
+// DefaultServerConfig returns a serverConfig instance with sensible default values. This is used as a fallback when no
+// configuration file is provided or when certain configuration parameters are missing
 func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		Engine: ServerEngineConfig{
@@ -127,8 +123,8 @@ func DefaultServerConfig() *ServerConfig {
 	}
 }
 
-// applyEnvOverrides overrides configuration values from DB_* environment
-// variables. Environment variables take precedence over file values
+// applyEnvOverrides overrides configuration values from DB_* environment variables. Environment variables take
+// precedence over file values
 func (c *ServerConfig) applyEnvOverrides() error {
 	if v := os.Getenv(envAddress); v != "" {
 		c.Network.Address = v
@@ -205,9 +201,8 @@ func (c *ServerConfig) Validate() error {
 	return c.Replication.validate(c.WAL.Enabled)
 }
 
-// validate checks engine settings. The tiered engine keeps its own durable
-// segment store, so it is mutually exclusive with the WAL and with replication
-// (which ships the WAL); enabling either alongside it is a configuration error.
+// validate checks engine settings. The tiered engine keeps its own durable segment store, so it is mutually exclusive
+// with the WAL and with replication (which ships the WAL); enabling either alongside it is a configuration error.
 func (c *ServerEngineConfig) validate(walEnabled bool, replicationRole string) error {
 	switch c.Type {
 	case engine.TypeInMemory:
@@ -252,8 +247,7 @@ func (c *ServerEngineConfig) validate(walEnabled bool, replicationRole string) e
 	return nil
 }
 
-// validate checks replication settings. Replication requires WAL persistence,
-// since the WAL is the replication stream.
+// validate checks replication settings. Replication requires WAL persistence, since the WAL is the replication stream.
 func (r *ServerReplicationConfig) validate(walEnabled bool) error {
 	switch r.Role {
 	case RoleStandalone:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -76,8 +76,7 @@ func New() *Engine {
 	}
 }
 
-// Range calls fn for every stored value while holding a read lock. Iteration
-// stops when fn returns false.
+// Range calls fn for every stored value while holding a read lock. Iteration stops when fn returns false.
 func (e *Engine) Range(fn func(table, key, value string) bool) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -91,9 +90,8 @@ func (e *Engine) Range(fn func(table, key, value string) bool) {
 	}
 }
 
-// Reset removes all stored data. A standby calls it during snapshot resync,
-// before loading the master's snapshot, since the snapshot fully replaces the
-// standby's superseded state.
+// Reset removes all stored data. A standby calls it during snapshot resync, before loading the master's snapshot, since
+// the snapshot fully replaces the standby's superseded state.
 func (e *Engine) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -107,9 +105,8 @@ func (e *Engine) Load(_ context.Context, entries []Entry) {
 	e.load(entries)
 }
 
-// Replace atomically swaps all stored data for entries under a single lock, so a
-// concurrent reader never observes the empty intermediate state that separate
-// Reset + Load calls would expose. Used by snapshot resync on a serving standby.
+// Replace atomically swaps all stored data for entries under a single lock, so a concurrent reader never observes the
+// empty intermediate state that separate Reset + Load calls would expose. Used by snapshot resync on a serving standby.
 func (e *Engine) Replace(entries []Entry) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -155,6 +152,30 @@ func (e *Engine) Get(_ context.Context, table, key string) (string, error) {
 	}
 
 	return val, nil
+}
+
+// Update atomically replaces the value of key with what fn returns. fn receives the stored value and whether it exists,
+// and runs while the engine is locked, so no concurrent write can slip between its read and its write. It is the
+// primitive behind the read-modify-write commands (INCR, APPEND, HSET); an error from fn leaves the store untouched.
+func (e *Engine) Update(_ context.Context, table, key string, fn func(old string, exists bool) (string, error)) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	t, tableExists := e.store[table]
+	if !tableExists {
+		t = make(map[string]string)
+	}
+	old, exists := t[key]
+	value, err := fn(old, exists)
+	if err != nil {
+		return err
+	}
+	if !tableExists {
+		e.store[table] = t // publish a new table only once the update succeeded
+	}
+	t[key] = value
+
+	return nil
 }
 
 // Del deletes the value for a given key in a table, removing the table when it becomes empty

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,8 +1,10 @@
 package engine_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -233,8 +235,8 @@ func TestEngine_ConcurrentAccess(t *testing.T) {
 	// Create a channel to signal when all operations are done
 	done := make(chan struct{})
 
-	// Start multiple goroutines performing concurrent operations,
-	// each goroutine working in its own table and a shared table
+	// Start multiple goroutines performing concurrent operations, each goroutine working in its own table and a shared
+	// table
 	for i := range numGoroutines {
 		go func() {
 			table := fmt.Sprintf("table-%d", i%3)
@@ -282,5 +284,56 @@ func TestEngine_ConcurrentAccess(t *testing.T) {
 	// Wait for all goroutines to finish
 	for range numGoroutines {
 		<-done
+	}
+}
+
+func TestEngine_UpdateIsAtomic(t *testing.T) {
+	t.Parallel()
+	eng := engine.New()
+
+	const n = 200
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			err := eng.Update(t.Context(), "t", "counter", func(old string, exists bool) (string, error) {
+				count := 0
+				if exists {
+					var pErr error
+					if count, pErr = strconv.Atoi(old); pErr != nil {
+						return "", pErr
+					}
+				}
+				return strconv.Itoa(count + 1), nil
+			})
+			if err != nil {
+				t.Errorf("Update failed: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	got, err := eng.Get(t.Context(), "t", "counter")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got != strconv.Itoa(n) {
+		t.Errorf("counter = %s, want %d (lost updates)", got, n)
+	}
+}
+
+func TestEngine_UpdateErrorStoresNothing(t *testing.T) {
+	t.Parallel()
+	eng := engine.New()
+
+	wantErr := errors.New("rejected")
+	err := eng.Update(t.Context(), "t", "k", func(string, bool) (string, error) { return "v", wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Update error = %v, want %v", err, wantErr)
+	}
+	if _, err = eng.Get(t.Context(), "t", "k"); !errors.Is(err, engine.ErrNotFound) {
+		t.Errorf("Get after failed Update = %v, want ErrNotFound", err)
+	}
+	if eng.TableExists(t.Context(), "t") {
+		t.Error("failed Update created the table")
 	}
 }

--- a/internal/engine/tiered/compaction.go
+++ b/internal/engine/tiered/compaction.go
@@ -1,9 +1,11 @@
 package tiered
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
-// Stats is a point-in-time snapshot of engine counters, used for observability
-// and tests.
+// Stats is a point-in-time snapshot of engine counters, used for observability and tests.
 type Stats struct {
 	Keys        int
 	LiveBytes   int64
@@ -16,16 +18,16 @@ type Stats struct {
 
 // Stats returns a snapshot of engine metrics.
 func (e *Engine) Stats() Stats {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return Stats{
 		Keys:        e.keyCount(),
 		LiveBytes:   e.liveBytes,
 		DiskBytes:   e.store.diskBytes(),
 		Segments:    len(e.store.sizes),
-		Hits:        e.hits,
-		Misses:      e.misses,
-		Compactions: e.compactions,
+		Hits:        e.hits.Load(),
+		Misses:      e.misses.Load(),
+		Compactions: e.compactions.Load(),
 	}
 }
 
@@ -56,38 +58,77 @@ func (e *Engine) logStats() {
 		"segments", s.Segments, "cache_hit_rate", hitRate, "compactions", s.Compactions)
 }
 
-// Compact runs one compaction pass immediately, independent of the background
-// interval: it reclaims the oldest sealed segment whose dead-bytes ratio exceeds
-// the threshold, rewriting its live records into the active segment. Useful for
+// Compact runs one compaction pass immediately, independent of the background interval: it reclaims the oldest sealed
+// segment whose dead-bytes ratio exceeds the threshold, rewriting its live records into the active segment. Useful for
 // operators and for deterministic tests.
-//
-// ponytail: whole compaction runs under the engine mutex, so it stalls writes
-// while a segment is rewritten. Correct and simple; go two-phase (read sealed
-// segments lock-free, swap keydir pointers under a short lock) if write-latency
-// spikes during compaction ever matter.
 func (e *Engine) Compact() {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	seg, ok := e.pickCompactible()
+	seg, file, ok := e.beginCompaction()
 	if !ok {
 		return
 	}
-	if err := e.compactSegment(seg); err != nil {
-		e.logger.Error("Compaction failed", "segment", seg, "error", err)
+	defer e.endCompaction()
+
+	var rewriteErr error
+	_, scanErr := scanPinnedSegment(seg, file, false, func(rec decoded, recPos int64) {
+		if rewriteErr != nil {
+			return
+		}
+		e.mu.Lock()
+		if !e.closed {
+			rewriteErr = e.rewriteRecord(seg, rec, recPos)
+		}
+		e.mu.Unlock()
+	})
+	e.store.unpin(seg)
+	if scanErr != nil || rewriteErr != nil {
+		if scanErr == nil {
+			scanErr = rewriteErr
+		}
+		e.logger.Error("Compaction failed", "segment", seg, "error", scanErr)
 		return
 	}
-	e.compactions++
+	if err := e.finishCompaction(seg); err != nil {
+		e.logger.Error("Compaction failed", "segment", seg, "error", err)
+	}
 }
 
-// pickCompactible returns the oldest sealed segment past the dead-bytes
-// threshold. The active segment is never chosen: it is still being appended to.
+// beginCompaction claims the compaction slot and picks a segment to reclaim. Only one pass runs at a time: two passes
+// over the same segment would let one delete the file the other is still reading.
+func (e *Engine) beginCompaction() (uint32, *os.File, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.compacting || e.closed {
+		return 0, nil, false
+	}
+	seg, ok := e.pickCompactible()
+	if !ok {
+		return 0, nil, false
+	}
+	file, ok := e.store.pin(seg)
+	if !ok {
+		return 0, nil, false
+	}
+	e.compacting = true
+	e.compactWG.Add(1)
+	return seg, file, true
+}
+
+func (e *Engine) endCompaction() {
+	e.mu.Lock()
+	e.compacting = false
+	e.mu.Unlock()
+	e.compactWG.Done()
+}
+
+// pickCompactible returns the oldest sealed segment past the dead-bytes threshold. The active segment is never chosen:
+// it is still being appended to.
 func (e *Engine) pickCompactible() (uint32, bool) {
 	for _, seg := range e.store.segments() {
 		if seg == e.store.activeSeg {
 			continue
 		}
-		size := e.store.sizes[seg]
+		size := e.store.dataSize(seg)
 		if size == 0 {
 			continue
 		}
@@ -99,45 +140,36 @@ func (e *Engine) pickCompactible() (uint32, bool) {
 	return 0, false
 }
 
-// compactSegment rewrites the live records of seg into the active segment and
-// deletes seg. A record is live iff the keydir still points to its exact
-// (segment, offset); everything else is a superseded overwrite or a tombstone.
-func (e *Engine) compactSegment(seg uint32) error {
-	var writeErr error
-	oldest := e.store.segments()[0]
-	scanErr := e.store.scanSegment(seg, false, func(rec decoded, recPos int64) {
-		if writeErr != nil {
-			return
-		}
-		if rec.tombstone {
-			if err := e.keepTombstone(seg, oldest, rec); err != nil {
-				writeErr = err
-			}
-			return
-		}
-		location, ok := e.lookup(rec.table, rec.key)
-		if !ok || location.seg != seg || location.valPos != valPosFor(recPos, rec.table, rec.key) {
-			return // dead: overwritten or deleted since it was written
-		}
-		newRec := encodeRecord(rec.table, rec.key, rec.value, false)
-		newSeg, newRecPos, err := e.store.append(newRec)
-		if err != nil {
-			writeErr = err
-			return
-		}
-		// Net-zero for liveBytes: the rewritten record encodes identically.
-		e.dropLive(rec.table, rec.key)
-		e.setLoc(newSeg, rec.table, rec.key, len(rec.value), newRecPos, int64(len(newRec)))
-	})
-	if scanErr != nil {
-		return scanErr
+// rewriteRecord copies one still-live record into the active segment. A record is live iff the keydir points at its
+// exact (segment, offset); everything else is a superseded overwrite or a tombstone.
+func (e *Engine) rewriteRecord(seg uint32, rec decoded, recPos int64) error {
+	if rec.tombstone {
+		return e.keepTombstone(seg, rec)
 	}
-	if writeErr != nil {
-		return writeErr
+	location, ok := e.lookup(rec.table, rec.key)
+	if !ok || location.seg != seg || location.valPos != valPosFor(recPos, rec.table, rec.key) {
+		return nil // dead: overwritten or deleted since it was written
 	}
-	// The rewritten records must be durable before the only other copy is
-	// unlinked: a crash between the two would lose keys that were already durable.
-	// This is unconditional except under SyncNo, where durability is opted out of.
+	newRec := encodeRecord(rec.table, rec.key, rec.value, false)
+	newSeg, newRecPos, err := e.store.append(newRec)
+	if err != nil {
+		return err
+	}
+	e.dropLive(rec.table, rec.key)
+	e.setLoc(newSeg, rec.table, rec.key, len(rec.value), newRecPos, int64(len(newRec)))
+	return nil
+}
+
+// finishCompaction makes the rewrites durable and unlinks the reclaimed segment.
+func (e *Engine) finishCompaction(seg uint32) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return nil
+	}
+	// The rewritten records must be durable before the only other copy is unlinked: a crash between the two would lose
+	// keys that were already durable. This is unconditional except under SyncNo, where durability is opted out of.
 	if err := e.store.syncActive(); err != nil {
 		return err
 	}
@@ -145,24 +177,20 @@ func (e *Engine) compactSegment(seg uint32) error {
 		return err
 	}
 	delete(e.segLive, seg)
+	delete(e.segSets, seg)
+	e.compactions.Add(1)
 	return nil
 }
 
-// keepTombstone carries a delete forward when dropping it could resurrect a key.
-// An older segment may still hold the SET this tombstone buried; once the
-// tombstone's segment is unlinked, recovery would scan that SET with nothing
-// after it and bring the key back. Rewriting into the active segment keeps the
-// delete newer than any surviving value.
-//
-// ponytail: a carried tombstone is only ever dropped once its segment is the
-// oldest, so deletes can ride along for several passes. Track the oldest
-// segment that could hold each key if tombstone churn ever shows up on disk.
-func (e *Engine) keepTombstone(seg, oldest uint32, rec decoded) error {
-	if seg == oldest {
-		return nil // nothing older can hold the deleted value
-	}
+// keepTombstone carries a delete forward when dropping it could resurrect a key. An older segment may still hold the
+// SET this tombstone buried; once the tombstone's segment is unlinked, recovery would scan that SET with nothing after
+// it and bring the key back. Rewriting into the active segment keeps the delete newer than any surviving value.
+func (e *Engine) keepTombstone(seg uint32, rec decoded) error {
 	if _, live := e.lookup(rec.table, rec.key); live {
 		return nil // a later SET already superseded this delete
+	}
+	if !e.buriedBefore(hashKey(rec.table, rec.key), seg) {
+		return nil // nothing older left to resurrect, so the delete goes away with its segment
 	}
 	_, _, err := e.store.append(encodeRecord(rec.table, rec.key, "", true))
 	return err

--- a/internal/engine/tiered/engine.go
+++ b/internal/engine/tiered/engine.go
@@ -1,14 +1,11 @@
-// Package tiered implements a durable key-value engine whose dataset can exceed
-// RAM. It is a Bitcask-style store: an append-only set of on-disk segments is the
-// source of truth, a full in-memory keydir maps every live (table,key) to its
-// on-disk location, and an LRU cache keeps hot values in memory. Evicting a cached
-// value is free and lossless because the value is already durable on disk.
+// Package tiered implements a durable key-value engine whose dataset can exceed RAM. It is a Bitcask-style store: an
+// append-only set of on-disk segments is the source of truth, a full in-memory keydir maps every live (table,key) to
+// its on-disk location, and an LRU cache keeps hot values in memory. Evicting a cached value is free and lossless
+// because the value is already durable on disk.
 //
-// The engine is self-contained: it provides its own durability (fsync of its
-// segments) and needs no write-ahead log — it borrows only wal.SyncPolicy, to
-// spell the fsync policy the same way the WAL-backed engine does. It implements
-// the storage.Engine interface, so the server selects it via engine.type=tiered
-// instead of the RAM-only engine.
+// The engine is self-contained: it provides its own durability (fsync of its segments) and needs no write-ahead log —
+// it borrows only wal.SyncPolicy, to spell the fsync policy the same way the WAL-backed engine does. It implements the
+// storage.Engine interface, so the server selects it via engine.type=tiered instead of the RAM-only engine.
 package tiered
 
 import (
@@ -19,14 +16,15 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/wal"
 )
 
-// ErrStorageFull is returned by Set when the live dataset would exceed the
-// configured storage limit. It surfaces to clients as "ERR storage full".
+// ErrStorageFull is returned by Set when the live dataset would exceed the configured storage limit. It surfaces to
+// clients as "ERR storage full".
 var ErrStorageFull = errors.New("storage full")
 
 // Config configures a tiered engine.
@@ -48,9 +46,32 @@ type loc struct {
 	recSize int64
 }
 
+// keyID identifies a key by a 64-bit FNV-1a hash of its table and key rather than by the strings themselves: the
+// tombstone index below holds an entry per key per segment, and this is the engine whose whole purpose is a dataset
+// larger than RAM. A hash collision makes keepTombstone believe an older SET exists and keep a delete longer than
+// necessary — the behavior this index replaced — so collisions cost disk, never correctness.
+type keyID uint64
+
+func hashKey(table, key string) keyID {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	h := uint64(offset64)
+	for i := range len(table) {
+		h = (h ^ uint64(table[i])) * prime64
+	}
+	h = (h ^ 0xff) * prime64 // separator, so ("ab","c") and ("a","bc") differ
+	for i := range len(key) {
+		h = (h ^ uint64(key[i])) * prime64
+	}
+	return keyID(h)
+}
+
 // Engine is a tiered (memory + disk) storage engine.
 type Engine struct {
-	mu     sync.Mutex
+	// mu guards the keydir, byte accounting, and store metadata.
+	mu     sync.RWMutex
 	store  *store
 	keydir map[string]map[string]loc // table -> key -> location
 	lru    *lruCache
@@ -58,17 +79,24 @@ type Engine struct {
 
 	liveBytes int64
 	segLive   map[uint32]int64 // live bytes per segment (for compaction & dead-ratio)
+	// segSets records which keys have a SET record in each segment, which lets a tombstone be dropped as soon as no older
+	// segment can contradict it. A segment's entry is reclaimed when it is compacted away, so the index tracks what is
+	// actually on disk.
+	segSets   map[uint32]map[keyID]struct{}
 	maxStore  int64
 	threshold float64
 
-	hits, misses, compactions uint64
+	hits, misses, compactions atomic.Uint64
+
+	compacting bool
+	closed     bool
+	compactWG  sync.WaitGroup
 
 	done chan struct{}
 	wg   sync.WaitGroup
 }
 
-// Open recovers the keydir from the on-disk segments and starts the background
-// sync (everysec) and compaction loops.
+// Open recovers the keydir from the on-disk segments and starts the background sync (everysec) and compaction loops.
 func Open(cfg Config, logger *slog.Logger) (*Engine, error) {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
@@ -83,6 +111,7 @@ func Open(cfg Config, logger *slog.Logger) (*Engine, error) {
 		lru:       newLRU(cfg.MaxMemoryBytes),
 		logger:    logger,
 		segLive:   make(map[uint32]int64),
+		segSets:   make(map[uint32]map[keyID]struct{}),
 		maxStore:  cfg.MaxStorageBytes,
 		threshold: cfg.CompactionThreshold,
 		done:      make(chan struct{}),
@@ -107,6 +136,10 @@ func (e *Engine) Close() error {
 	close(e.done)
 	e.wg.Wait()
 	e.mu.Lock()
+	e.closed = true
+	e.mu.Unlock()
+	e.compactWG.Wait()
+	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.store.close()
 }
@@ -115,8 +148,8 @@ func (e *Engine) recover() error {
 	segs := e.store.segments()
 	for i, seg := range segs {
 		isLast := i == len(segs)-1
-		// Later records win, so an overwrite or tombstone supersedes the earlier
-		// value. Only the newest segment may carry a torn tail from a crash.
+		// Later records win, so an overwrite or tombstone supersedes the earlier value. Only the newest segment may carry a
+		// torn tail from a crash.
 		if err := e.store.scanSegment(seg, isLast, func(rec decoded, recPos int64) {
 			e.dropLive(rec.table, rec.key)
 			if !rec.tombstone {
@@ -147,10 +180,10 @@ func (e *Engine) dropLive(table, key string) {
 	}
 }
 
-// setLoc records a live value's location and adds its live-byte accounting.
-// Callers pass valLen rather than the value itself: recovery never needs the
-// bytes, only their length.
+// setLoc records a live value's location and adds its live-byte accounting. Callers pass valLen rather than the value
+// itself: recovery never needs the bytes, only their length.
 func (e *Engine) setLoc(seg uint32, table, key string, valLen int, recPos, recSize int64) {
+	e.noteSet(seg, table, key)
 	keys, ok := e.keydir[table]
 	if !ok {
 		keys = make(map[string]loc)
@@ -166,9 +199,65 @@ func (e *Engine) setLoc(seg uint32, table, key string, valLen int, recPos, recSi
 	e.segLive[seg] += recSize
 }
 
-// Set appends the value and updates the keydir and cache. It rejects the write
-// with ErrStorageFull if the live dataset would exceed the configured limit.
+func (e *Engine) noteSet(seg uint32, table, key string) {
+	id := hashKey(table, key)
+	keys := e.segSets[seg]
+	if keys == nil {
+		keys = make(map[keyID]struct{})
+		e.segSets[seg] = keys
+	}
+	keys[id] = struct{}{}
+}
+
+// buriedBefore reports whether a segment older than seg still holds a SET for id, which is what makes a tombstone in
+// seg worth carrying forward. The index is consulted per tombstone rather than kept as a per-key hint: a hint would
+// have to be repaired whenever the segment it names is reclaimed, and a hint that survives its segment silently keeps
+// a delete alive forever.
+func (e *Engine) buriedBefore(id keyID, seg uint32) bool {
+	for other, keys := range e.segSets {
+		if other >= seg {
+			continue
+		}
+		if _, ok := keys[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Set appends the value and updates the keydir and cache. It rejects the write with ErrStorageFull if the live dataset
+// would exceed the configured limit.
 func (e *Engine) Set(_ context.Context, tbl, key, value string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.setLocked(tbl, key, value)
+}
+
+// Update atomically replaces the value of key with what fn returns, reading the current value from the cache or its
+// segment first. It holds the engine mutex across the whole read-modify-write, which is what makes INCR, APPEND and
+// HSET atomic here. An error from fn appends nothing.
+func (e *Engine) Update(_ context.Context, tbl, key string, fn func(old string, exists bool) (string, error)) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var old string
+	location, exists := e.lookup(tbl, key)
+	if exists {
+		var err error
+		if old, err = e.value(tbl, key, location); err != nil {
+			return err
+		}
+	}
+	value, err := fn(old, exists)
+	if err != nil {
+		return err
+	}
+	return e.setLocked(tbl, key, value)
+}
+
+// setLocked appends a value and updates the keydir and cache. The caller holds e.mu.
+func (e *Engine) setLocked(tbl, key, value string) error {
 	if len(tbl) > maxFieldLen || len(key) > maxFieldLen {
 		return fmt.Errorf("table/key exceeds %d bytes", maxFieldLen)
 	}
@@ -177,9 +266,6 @@ func (e *Engine) Set(_ context.Context, tbl, key, value string) error {
 	}
 	rec := encodeRecord(tbl, key, value, false)
 	recSize := int64(len(rec))
-
-	e.mu.Lock()
-	defer e.mu.Unlock()
 
 	old, exists := e.lookup(tbl, key)
 	newLive := e.liveBytes + recSize
@@ -200,25 +286,75 @@ func (e *Engine) Set(_ context.Context, tbl, key, value string) error {
 	return e.store.syncIfAlways()
 }
 
-// Get returns a value, populating the cache on a miss by reading from disk.
-//
-// ponytail: the cache-miss pread happens under the engine mutex, so a slow disk
-// serializes every other operation behind it. Dropping the lock around the read
-// needs the segment pinned against concurrent compaction; do that if read
-// latency under a cold cache ever matters.
+// maxReadAttempts bounds the optimistic read loop. A retry means the record moved between the lookup and the read — a
+// concurrent overwrite or a compaction pass — and after a few of those the read falls back to holding the engine
+// exclusively, where nothing can move it. Without the bound a key rewritten in a tight loop could keep a reader
+// spinning.
+const maxReadAttempts = 3
+
+// Get returns a value, populating the cache on a miss by reading from a pinned segment without holding the engine lock.
 func (e *Engine) Get(_ context.Context, tbl, key string) (string, error) {
+	for range maxReadAttempts {
+		value, done, err := e.tryGet(tbl, key)
+		if done {
+			return value, err
+		}
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
-
 	location, ok := e.lookup(tbl, key)
 	if !ok {
 		return "", engine.ErrNotFound
 	}
+	return e.value(tbl, key, location)
+}
+
+// tryGet serves one optimistic attempt: it pins the value's segment under the read lock, reads it with the lock
+// released, then keeps what it read only if the keydir still points at the same record. done is false when the record
+// moved underneath it and the caller should look again.
+func (e *Engine) tryGet(tbl, key string) (value string, done bool, err error) {
+	e.mu.RLock()
+	location, ok := e.lookup(tbl, key)
+	if !ok {
+		e.mu.RUnlock()
+		return "", true, engine.ErrNotFound
+	}
+	if cached, hit := e.lru.get(tbl, key); hit {
+		e.hits.Add(1)
+		e.mu.RUnlock()
+		return cached, true, nil
+	}
+	pinned, ok := e.store.pin(location.seg)
+	e.mu.RUnlock()
+	if !ok {
+		return "", false, nil // segment reclaimed since the lookup
+	}
+
+	value, err = readPinnedValue(location.seg, pinned, location.valPos, location.valLen)
+	e.store.unpin(location.seg)
+	if err != nil {
+		return "", true, err
+	}
+
+	// Re-check and cache under the read lock, not an exclusive one: the keydir is only read here and the cache carries its
+	// own mutex, so concurrent cold reads do not queue up behind each other at the end of every miss.
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if current, exists := e.lookup(tbl, key); !exists || current != location {
+		return "", false, nil
+	}
+	e.misses.Add(1)
+	e.lru.put(tbl, key, value)
+	return value, true, nil
+}
+
+func (e *Engine) value(tbl, key string, location loc) (string, error) {
 	if value, hit := e.lru.get(tbl, key); hit {
-		e.hits++
+		e.hits.Add(1)
 		return value, nil
 	}
-	e.misses++
+	e.misses.Add(1)
 	value, err := e.store.readValue(location.seg, location.valPos, location.valLen)
 	if err != nil {
 		return "", err
@@ -245,30 +381,30 @@ func (e *Engine) Del(_ context.Context, tbl, key string) error {
 
 // Tables returns all table names in sorted order.
 func (e *Engine) Tables(_ context.Context) []string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return slices.Sorted(maps.Keys(e.keydir))
 }
 
 // TableExists reports whether a table has at least one live key.
 func (e *Engine) TableExists(_ context.Context, tbl string) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	_, ok := e.keydir[tbl]
 	return ok
 }
 
 // Keys returns all keys in a table in sorted order.
 func (e *Engine) Keys(_ context.Context, tbl string) []string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return slices.Sorted(maps.Keys(e.keydir[tbl]))
 }
 
 // Range calls fn for every live value, reading from disk on a cache miss.
 func (e *Engine) Range(fn func(table, key, value string) bool) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	for tbl, keys := range e.keydir {
 		for key, location := range keys {
 			value, hit := e.lru.get(tbl, key)
@@ -287,10 +423,9 @@ func (e *Engine) Range(fn func(table, key, value string) bool) {
 	}
 }
 
-// Replace swaps all state for a replication resync snapshot — unreachable here:
-// it is called only by a standby, and the config rejects tiered alongside
-// replication. It stays a stub rather than untested machinery; wiring the two
-// together needs a shared LSN-tagged log, not this method (see docs/plans/05).
+// Replace swaps all state for a replication resync snapshot — unreachable here: it is called only by a standby, and the
+// config rejects tiered alongside replication. It stays a stub rather than untested machinery; wiring the two together
+// needs a shared LSN-tagged log, not this method (see docs/plans/05).
 func (e *Engine) Replace([]engine.Entry) {
 	e.logger.Error("Replace is not supported by the tiered engine")
 }

--- a/internal/engine/tiered/engine_test.go
+++ b/internal/engine/tiered/engine_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -101,8 +103,8 @@ func TestIntrospection(t *testing.T) {
 	}
 }
 
-// TestEvictionServesFromDisk forces constant eviction with a tiny memory budget
-// and verifies every value is still readable (from disk on a miss).
+// TestEvictionServesFromDisk forces constant eviction with a tiny memory budget and verifies every value is still
+// readable (from disk on a miss).
 func TestEvictionServesFromDisk(t *testing.T) {
 	cfg := testConfig(t.TempDir())
 	cfg.MaxMemoryBytes = 64 // only ~1 value fits in RAM at a time
@@ -190,8 +192,8 @@ func TestRecovery(t *testing.T) {
 	}
 }
 
-// TestCompactionReclaimsDisk overwrites one key across many sealed segments,
-// then compacts and checks the dataset is intact and disk usage dropped.
+// TestCompactionReclaimsDisk overwrites one key across many sealed segments, then compacts and checks the dataset is
+// intact and disk usage dropped.
 func TestCompactionReclaimsDisk(t *testing.T) {
 	cfg := testConfig(t.TempDir())
 	cfg.SegmentSize = 256 // tiny segments so overwrites roll and seal quickly
@@ -226,11 +228,9 @@ func TestCompactionReclaimsDisk(t *testing.T) {
 	}
 }
 
-// TestCompactionKeepsTombstoneAboveLiveSegment pins the resurrection case: the
-// tombstone sits in a compactible segment while the value it buried is in an
-// older segment that stays live. Dropping the tombstone with its segment would
-// leave the old SET as the newest record for that key, and recovery would bring
-// the key back.
+// TestCompactionKeepsTombstoneAboveLiveSegment pins the resurrection case: the tombstone sits in a compactible segment
+// while the value it buried is in an older segment that stays live. Dropping the tombstone with its segment would leave
+// the old SET as the newest record for that key, and recovery would bring the key back.
 func TestCompactionKeepsTombstoneAboveLiveSegment(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(dir)
@@ -243,8 +243,8 @@ func TestCompactionKeepsTombstoneAboveLiveSegment(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = e.Close() })
 
-	// Segment 1: the victim plus filler that is never overwritten, so the segment
-	// stays fully live and is never itself compacted.
+	// Segment 1: the victim plus filler that is never overwritten, so the segment stays fully live and is never itself
+	// compacted.
 	if err = e.Set(ctx, "t", "victim", "buried"); err != nil {
 		t.Fatal(err)
 	}
@@ -282,9 +282,8 @@ func TestCompactionKeepsTombstoneAboveLiveSegment(t *testing.T) {
 	}
 }
 
-// TestRestartAfterCompaction reopens the data directory without closing the
-// engine (a crash right after a compaction pass): the rewritten records must be
-// on disk, since compaction already deleted the segment they came from.
+// TestRestartAfterCompaction reopens the data directory without closing the engine (a crash right after a compaction
+// pass): the rewritten records must be on disk, since compaction already deleted the segment they came from.
 func TestRestartAfterCompaction(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(dir)
@@ -295,8 +294,8 @@ func TestRestartAfterCompaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Closed only at teardown, after the reopened engine has been asserted, so
-	// its sync cannot stand in for the one compaction owes.
+	// Closed only at teardown, after the reopened engine has been asserted, so its sync cannot stand in for the one
+	// compaction owes.
 	t.Cleanup(func() { _ = e.Close() })
 	for i := range 20 {
 		if err = e.Set(ctx, "t", fmt.Sprintf("k%02d", i), fmt.Sprintf("value-%02d", i)); err != nil {
@@ -324,8 +323,8 @@ func TestRestartAfterCompaction(t *testing.T) {
 	}
 }
 
-// TestOversizedValueStaysDiskOnly checks max_memory is a real ceiling: a value
-// bigger than the whole budget is served from disk, never cached.
+// TestOversizedValueStaysDiskOnly checks max_memory is a real ceiling: a value bigger than the whole budget is served
+// from disk, never cached.
 func TestOversizedValueStaysDiskOnly(t *testing.T) {
 	cfg := testConfig(t.TempDir())
 	cfg.MaxMemoryBytes = 128
@@ -355,8 +354,8 @@ func TestOversizedValueStaysDiskOnly(t *testing.T) {
 	}
 }
 
-// TestParityWithInMemory runs the same random workload against the tiered engine
-// (with constant eviction) and the plain in-memory engine; GET results must match.
+// TestParityWithInMemory runs the same random workload against the tiered engine (with constant eviction) and the plain
+// in-memory engine; GET results must match.
 func TestParityWithInMemory(t *testing.T) {
 	cfg := testConfig(t.TempDir())
 	cfg.MaxMemoryBytes = 128
@@ -405,8 +404,8 @@ func assertSameGet(t *testing.T, tieredEngine *tiered.Engine, memEngine *engine.
 	}
 }
 
-// TestRecoveryTruncatesTornTail simulates a crash mid-write: garbage bytes are
-// appended to the last segment. Recovery must truncate them and keep prior data.
+// TestRecoveryTruncatesTornTail simulates a crash mid-write: garbage bytes are appended to the last segment. Recovery
+// must truncate them and keep prior data.
 func TestRecoveryTruncatesTornTail(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(dir)
@@ -459,8 +458,8 @@ func lastSegment(t *testing.T, dir string) string {
 	return matches[len(matches)-1]
 }
 
-// TestConcurrentWritesAndCompaction exercises writes racing compaction under the
-// engine lock. Run with -race in CI; here it asserts final-state correctness.
+// TestConcurrentWritesAndCompaction exercises writes racing compaction under the engine lock. Run with -race in CI;
+// here it asserts final-state correctness.
 func TestConcurrentWritesAndCompaction(t *testing.T) {
 	cfg := testConfig(t.TempDir())
 	cfg.SegmentSize = 512
@@ -513,5 +512,100 @@ func TestBackgroundLoopsStartAndStop(t *testing.T) {
 	time.Sleep(30 * time.Millisecond) // let the loops run at least once
 	if err = e.Close(); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestUpdateReadsThroughToDisk(t *testing.T) {
+	cfg := testConfig(t.TempDir())
+	cfg.MaxMemoryBytes = 64 // only ~1 value fits in RAM at a time
+	e := open(t, cfg)
+	ctx := context.Background()
+
+	if err := e.Set(ctx, "t", "counter", "1"); err != nil {
+		t.Fatal(err)
+	}
+	// Push the counter out of the cache. The filler must fit the budget itself: a value larger than the whole budget is
+	// never admitted, so it would evict nothing.
+	for i := range 50 {
+		if err := e.Set(ctx, "t", fmt.Sprintf("filler%d", i), strings.Repeat("x", 5)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := e.Update(ctx, "t", "counter", func(old string, exists bool) (string, error) {
+		if !exists || old != "1" {
+			t.Fatalf("update saw old=%q exists=%v, want the stored value", old, exists)
+		}
+		return "2", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mustGet(t, e, "t", "counter"); got != "2" {
+		t.Fatalf("counter = %q, want 2", got)
+	}
+	if s := e.Stats(); s.Misses == 0 {
+		t.Fatal("expected the update to read through to disk")
+	}
+}
+
+func TestUpdateIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	e, err := tiered.Open(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	const n = 100
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			uErr := e.Update(ctx, "t", "counter", func(old string, exists bool) (string, error) {
+				count := 0
+				if exists {
+					var pErr error
+					if count, pErr = strconv.Atoi(old); pErr != nil {
+						return "", pErr
+					}
+				}
+				return strconv.Itoa(count + 1), nil
+			})
+			if uErr != nil {
+				t.Errorf("update: %v", uErr)
+			}
+		})
+	}
+	wg.Wait()
+	if err = e.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened := open(t, cfg)
+	if got := mustGet(t, reopened, "t", "counter"); got != strconv.Itoa(n) {
+		t.Fatalf("counter after reopen = %q, want %d (lost updates)", got, n)
+	}
+}
+
+func TestUpdateErrorAppendsNothing(t *testing.T) {
+	cfg := testConfig(t.TempDir())
+	e := open(t, cfg)
+	ctx := context.Background()
+
+	if err := e.Set(ctx, "t", "k", "v"); err != nil {
+		t.Fatal(err)
+	}
+	before := e.Stats().DiskBytes
+
+	wantErr := errors.New("rejected")
+	if err := e.Update(ctx, "t", "k", func(string, bool) (string, error) { return "new", wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("Update error = %v, want %v", err, wantErr)
+	}
+	if got := mustGet(t, e, "t", "k"); got != "v" {
+		t.Fatalf("value = %q, want the original", got)
+	}
+	if after := e.Stats().DiskBytes; after != before {
+		t.Fatalf("disk grew by %d bytes on a rejected update", after-before)
 	}
 }

--- a/internal/engine/tiered/lru.go
+++ b/internal/engine/tiered/lru.go
@@ -1,10 +1,12 @@
 package tiered
 
-import "container/list"
+import (
+	"container/list"
+	"sync"
+)
 
-// lruEntryOverhead approximates the fixed per-entry cost (map bucket, list
-// element, string headers) so the cache is sized by real memory, not payload
-// bytes alone.
+// lruEntryOverhead approximates the fixed per-entry cost (map bucket, list element, string headers) so the cache is
+// sized by real memory, not payload bytes alone.
 const lruEntryOverhead = 48
 
 type lruKey struct {
@@ -18,10 +20,11 @@ type lruNode struct {
 	bytes int64
 }
 
-// lruCache is a byte-sized LRU: a map for O(1) lookup plus a list ordering
-// entries most- to least-recently-used. It is not safe for concurrent use; the
-// engine calls it under its mutex.
+// lruCache is a byte-sized LRU: a map for O(1) lookup plus a list ordering entries most- to least-recently-used. It
+// carries its own mutex because a cache hit reorders the list, and the engine serves reads under a shared read lock:
+// concurrent readers mutate this while none of them holds the engine exclusively.
 type lruCache struct {
+	mu       sync.Mutex
 	maxBytes int64
 	curBytes int64
 	items    map[lruKey]*list.Element
@@ -37,6 +40,9 @@ func nodeBytes(k lruKey, value string) int64 {
 }
 
 func (c *lruCache) get(table, key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	element, ok := c.items[lruKey{table, key}]
 	if !ok {
 		return "", false
@@ -46,12 +52,15 @@ func (c *lruCache) get(table, key string) (string, bool) {
 	return element.Value.(*lruNode).value, true
 }
 
-// put caches value, evicting to stay within budget. An entry that alone exceeds
-// the whole budget is never cached: it stays disk-only, so max_memory is a real
-// ceiling. Any previously cached value for the key is dropped, never left stale.
+// put caches value, evicting to stay within budget. An entry that alone exceeds the whole budget is never cached: it
+// stays disk-only, so max_memory is a real ceiling. Any previously cached value for the key is dropped, never left
+// stale.
 func (c *lruCache) put(table, key, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	k := lruKey{table, key}
-	c.remove(table, key)
+	c.dropKey(k)
 	bytes := nodeBytes(k, value)
 	if bytes > c.maxBytes {
 		return
@@ -62,7 +71,15 @@ func (c *lruCache) put(table, key, value string) {
 }
 
 func (c *lruCache) remove(table, key string) {
-	if element, ok := c.items[lruKey{table, key}]; ok {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.dropKey(lruKey{table, key})
+}
+
+// dropKey removes a key if it is cached. The caller holds c.mu.
+func (c *lruCache) dropKey(k lruKey) {
+	if element, ok := c.items[k]; ok {
 		c.drop(element)
 	}
 }

--- a/internal/engine/tiered/store.go
+++ b/internal/engine/tiered/store.go
@@ -41,9 +41,6 @@ const (
 // truncated away.
 const segmentHeader = "DBSEG\x00\x02"
 
-// errUnsupportedFormat is returned for a segment this build cannot read.
-var errUnsupportedFormat = errors.New("unsupported segment format")
-
 var (
 	errPartial  = errors.New("partial tiered record")
 	errChecksum = errors.New("tiered record checksum mismatch")
@@ -203,11 +200,11 @@ func openStore(dir string, segmentSize int64, sync wal.SyncPolicy) (*store, erro
 		if size == 0 {
 			// A crash between creating a segment and writing its header leaves an empty file; finish the job rather than
 			// rejecting it as unreadable.
-			if _, err = file.WriteAt([]byte(segmentHeader), 0); err != nil {
+			if err = wal.WriteHeader(file, segmentHeader); err != nil {
 				return nil, fmt.Errorf("write segment %d header: %w", num, err)
 			}
 			size = int64(len(segmentHeader))
-		} else if err = requireSegmentHeader(file); err != nil {
+		} else if _, err = wal.RequireHeader(file, segmentHeader); err != nil {
 			return nil, fmt.Errorf("segment %d: %w", num, err)
 		}
 		s.sizes[num] = size
@@ -239,11 +236,7 @@ func (s *store) openNewActive(num uint32) error {
 	if err != nil {
 		return fmt.Errorf("create segment %d: %w", num, err)
 	}
-	written, err := file.WriteAt([]byte(segmentHeader), 0)
-	if err == nil && written != len(segmentHeader) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
+	if err = wal.WriteHeader(file, segmentHeader); err != nil {
 		_ = file.Close()
 		return fmt.Errorf("write segment header: %w", err)
 	}
@@ -449,19 +442,6 @@ func (s *store) close() error {
 		}
 	}
 	return firstErr
-}
-
-// requireSegmentHeader verifies that a non-empty segment carries the current format header.
-func requireSegmentHeader(file *os.File) error {
-	buf := make([]byte, len(segmentHeader))
-	n, err := file.ReadAt(buf, 0)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return err
-	}
-	if string(buf[:n]) != segmentHeader {
-		return errUnsupportedFormat
-	}
-	return nil
 }
 
 func segFilename(num uint32) string {

--- a/internal/engine/tiered/store.go
+++ b/internal/engine/tiered/store.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	stdsync "sync"
 
 	"github.com/OutOfStack/db/internal/wal"
 )
@@ -20,9 +21,8 @@ import (
 //
 //	tableLen uint16 | keyLen uint16 | valLen uint32 | table | key | value | crc32
 //
-// valLen == tombstoneMarker marks a delete (no value bytes follow). The crc32
-// covers the header and body, mirroring the WAL, so a torn tail from a crash is
-// detected and truncated on recovery.
+// valLen == tombstoneMarker marks a delete (no value bytes follow). The crc32 covers the header and body, mirroring the
+// WAL, so a torn tail from a crash is detected and truncated on recovery.
 const (
 	headerSize      = 8
 	crcSize         = 4
@@ -35,6 +35,14 @@ const (
 	segPrefix = "seg-"
 	segSuffix = ".data"
 )
+
+// segmentHeader identifies a segment written by this build; the trailing byte is the format version. A non-empty
+// segment without it is rejected at open rather than parsed, since misreading one looks like a torn tail and gets
+// truncated away.
+const segmentHeader = "DBSEG\x00\x02"
+
+// errUnsupportedFormat is returned for a segment this build cannot read.
+var errUnsupportedFormat = errors.New("unsupported segment format")
 
 var (
 	errPartial  = errors.New("partial tiered record")
@@ -50,16 +58,14 @@ type decoded struct {
 	recSize   int64
 }
 
-// valPosFor returns the absolute offset of a record's value bytes given the
-// offset of the record start. The keydir stores this so a cache miss reads only
-// the value, not the whole record.
+// valPosFor returns the absolute offset of a record's value bytes given the offset of the record start. The keydir
+// stores this so a cache miss reads only the value, not the whole record.
 func valPosFor(recPos int64, table, key string) int64 {
 	return recPos + headerSize + int64(len(table)+len(key))
 }
 
-// u16/u32 convert lengths callers have already bounded: Set rejects table/key
-// over maxFieldLen and values over maxValueLen, and lengths of decoded records
-// come from on-disk uint16/uint32 fields. Centralized so the gosec overflow
+// u16/u32 convert lengths callers have already bounded: Set rejects table/key over maxFieldLen and values over
+// maxValueLen, and lengths of decoded records come from on-disk uint16/uint32 fields. Centralized so the gosec overflow
 // suppression lives in one place.
 func u16(n int) uint16 { return uint16(n) } // #nosec G115 -- length bounded by maxFieldLen
 func u32(n int) uint32 { return uint32(n) } // #nosec G115 -- length bounded by maxValueLen
@@ -134,11 +140,14 @@ func decodeRecord(reader *bufio.Reader) (decoded, error) {
 	return rec, nil
 }
 
-// store owns the append-only segment files. All methods are called under the
-// engine mutex; it holds no lock of its own.
+// store owns the append-only segment files.
 //
-// readers and sizes are the only state: the active segment is just readers and
-// sizes at activeSeg, so there is no shadow copy to keep in step.
+// Its maps are guarded by the engine lock: readers hold it at least shared, and the engine takes it exclusively to add
+// or remove a segment. pinMu is a second, narrower lock covering only the pin counts and the handle lookup that hands
+// one out. The two exist because a pinned segment is read with the engine lock released, so removeSegment waits for the
+// pin to drop rather than closing the file underneath a reader.
+//
+// The active segment is just readers and sizes at activeSeg, so there is no shadow copy to keep in step.
 type store struct {
 	dir         string
 	segmentSize int64
@@ -147,11 +156,20 @@ type store struct {
 	activeSeg uint32
 	readers   map[uint32]*os.File // open handles per segment (includes active)
 	sizes     map[uint32]int64    // bytes written per segment
+
+	pinMu stdsync.Mutex
+	pins  map[uint32]int
+	cond  *stdsync.Cond
 }
 
 func (s *store) active() *os.File { return s.readers[s.activeSeg] }
 
 func (s *store) activeSize() int64 { return s.sizes[s.activeSeg] }
+
+// dataSize is a segment's record bytes, excluding its format header.
+func (s *store) dataSize(seg uint32) int64 {
+	return max(0, s.sizes[seg]-int64(len(segmentHeader)))
+}
 
 func openStore(dir string, segmentSize int64, sync wal.SyncPolicy) (*store, error) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -163,7 +181,9 @@ func openStore(dir string, segmentSize int64, sync wal.SyncPolicy) (*store, erro
 		sync:        sync,
 		readers:     make(map[uint32]*os.File),
 		sizes:       make(map[uint32]int64),
+		pins:        make(map[uint32]int),
 	}
+	s.cond = stdsync.NewCond(&s.pinMu)
 	nums, err := listSegments(dir)
 	if err != nil {
 		return nil, err
@@ -179,7 +199,18 @@ func openStore(dir string, segmentSize int64, sync wal.SyncPolicy) (*store, erro
 		if statErr != nil {
 			return nil, fmt.Errorf("stat segment %d: %w", num, statErr)
 		}
-		s.sizes[num] = info.Size()
+		size := info.Size()
+		if size == 0 {
+			// A crash between creating a segment and writing its header leaves an empty file; finish the job rather than
+			// rejecting it as unreadable.
+			if _, err = file.WriteAt([]byte(segmentHeader), 0); err != nil {
+				return nil, fmt.Errorf("write segment %d header: %w", num, err)
+			}
+			size = int64(len(segmentHeader))
+		} else if err = requireSegmentHeader(file); err != nil {
+			return nil, fmt.Errorf("segment %d: %w", num, err)
+		}
+		s.sizes[num] = size
 	}
 	if len(nums) > 0 {
 		s.activeSeg = nums[len(nums)-1]
@@ -201,17 +232,29 @@ func (s *store) segments() []uint32 {
 
 func (s *store) openNewActive(num uint32) error {
 	path := filepath.Join(s.dir, segFilename(num))
-	// No O_APPEND: writes use WriteAt at an explicit offset, so the record
-	// position never depends on the file's current seek offset (recovery leaves
-	// it mid-file after buffered reads).
+	// No O_APPEND: writes use WriteAt at an explicit offset, so the record position never depends on the file's current
+	// seek offset (recovery leaves it mid-file after buffered reads).
 	// #nosec G304 -- path built from the configured dir and a numeric segment id.
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("create segment %d: %w", num, err)
 	}
-	// Syncing the file alone does not persist its directory entry, so a crash
-	// right after rotation could lose the whole segment along with writes that
-	// were already acknowledged.
+	written, err := file.WriteAt([]byte(segmentHeader), 0)
+	if err == nil && written != len(segmentHeader) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write segment header: %w", err)
+	}
+	if s.sync != wal.SyncNo {
+		if err = file.Sync(); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("sync segment header: %w", err)
+		}
+	}
+	// Syncing the file alone does not persist its directory entry, so a crash right after rotation could lose the whole
+	// segment along with writes that were already acknowledged.
 	if s.sync != wal.SyncNo {
 		if err = wal.SyncDirectory(s.dir); err != nil {
 			return fmt.Errorf("sync data directory: %w", err)
@@ -219,14 +262,14 @@ func (s *store) openNewActive(num uint32) error {
 	}
 	s.activeSeg = num
 	s.readers[num] = file
-	s.sizes[num] = 0
+	s.sizes[num] = int64(len(segmentHeader))
 	return nil
 }
 
-// append writes rec to the active segment (rotating first if it would overflow)
-// and returns the segment number and the record's start offset.
+// append writes rec to the active segment (rotating first if it would overflow) and returns the segment number and the
+// record's start offset.
 func (s *store) append(rec []byte) (uint32, int64, error) {
-	if size := s.activeSize(); size > 0 && size+int64(len(rec)) > s.segmentSize {
+	if dataSize := s.dataSize(s.activeSeg); dataSize > 0 && dataSize+int64(len(rec)) > s.segmentSize {
 		if err := s.syncActive(); err != nil {
 			return 0, 0, err
 		}
@@ -240,9 +283,8 @@ func (s *store) append(rec []byte) (uint32, int64, error) {
 		err = io.ErrShortWrite
 	}
 	if err != nil {
-		// Drop the partial record instead of counting it: leaving it in place
-		// would put later (acknowledged) appends behind damage that recovery
-		// truncates away.
+		// Drop the partial record instead of counting it: leaving it in place would put later (acknowledged) appends behind
+		// damage that recovery truncates away.
 		if truncErr := s.active().Truncate(recPos); truncErr != nil {
 			return 0, 0, errors.Join(fmt.Errorf("write record: %w", err), truncErr)
 		}
@@ -254,10 +296,15 @@ func (s *store) append(rec []byte) (uint32, int64, error) {
 
 // readValue reads valLen bytes at valPos from segment seg.
 func (s *store) readValue(seg uint32, valPos int64, valLen uint32) (string, error) {
-	file, ok := s.readers[seg]
+	file, ok := s.pin(seg)
 	if !ok {
 		return "", fmt.Errorf("segment %d not open", seg)
 	}
+	defer s.unpin(seg)
+	return readPinnedValue(seg, file, valPos, valLen)
+}
+
+func readPinnedValue(seg uint32, file *os.File, valPos int64, valLen uint32) (string, error) {
 	buf := make([]byte, valLen)
 	if _, err := file.ReadAt(buf, valPos); err != nil {
 		return "", fmt.Errorf("read value from segment %d: %w", seg, err)
@@ -265,21 +312,37 @@ func (s *store) readValue(seg uint32, valPos int64, valLen uint32) (string, erro
 	return string(buf), nil
 }
 
-// scanBufSize buffers segment reads during recovery and compaction; the default
-// bufio size would be one read syscall per 4 KiB of a multi-MiB segment.
+// scanBufSize buffers segment reads during recovery and compaction; the default bufio size would be one read syscall
+// per 4 KiB of a multi-MiB segment.
 const scanBufSize = 1 << 16
 
-// scanSegment decodes seg from the start, invoking fn for each record with its
-// start offset, and records the segment's real size. allowTornTail truncates a
-// torn or checksum-invalid tail instead of failing — correct for the newest
+// scanSegment decodes seg from the start, invoking fn for each record with its start offset, and records the segment's
+// real size. allowTornTail truncates a torn or checksum-invalid tail instead of failing — correct for the newest
 // segment at recovery (it is a crash tail), never for a sealed one.
 func (s *store) scanSegment(seg uint32, allowTornTail bool, fn func(rec decoded, recPos int64)) error {
-	file := s.readers[seg]
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek segment %d: %w", seg, err)
+	file, ok := s.pin(seg)
+	if !ok {
+		return fmt.Errorf("segment %d not open", seg)
+	}
+	defer s.unpin(seg)
+	offset, err := scanPinnedSegment(seg, file, allowTornTail, fn)
+	if err != nil {
+		return err
+	}
+	s.sizes[seg] = offset
+	return nil
+}
+
+// scanPinnedSegment decodes a pinned segment from its first record and returns the offset it stopped at. It seeks the
+// shared handle, so only one scan may run on a segment at a time: recovery scans before the engine serves anything, and
+// compaction is serialized by the compacting flag. Value reads are unaffected — they use ReadAt, which ignores the file
+// offset.
+func scanPinnedSegment(seg uint32, file *os.File, allowTornTail bool, fn func(rec decoded, recPos int64)) (int64, error) {
+	offset := int64(len(segmentHeader))
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seek segment %d: %w", seg, err)
 	}
 	reader := bufio.NewReaderSize(file, scanBufSize)
-	var offset int64
 	for {
 		rec, err := decodeRecord(reader)
 		if errors.Is(err, io.EOF) {
@@ -288,32 +351,60 @@ func (s *store) scanSegment(seg uint32, allowTornTail bool, fn func(rec decoded,
 		if err != nil {
 			if allowTornTail && (errors.Is(err, errPartial) || errors.Is(err, errChecksum)) {
 				if truncErr := file.Truncate(offset); truncErr != nil {
-					return fmt.Errorf("truncate damaged tail: %w", truncErr)
+					return 0, fmt.Errorf("truncate damaged tail: %w", truncErr)
 				}
 				break
 			}
-			return fmt.Errorf("corrupt segment %d at offset %d: %w", seg, offset, err)
+			return 0, fmt.Errorf("corrupt segment %d at offset %d: %w", seg, offset, err)
 		}
 		fn(rec, offset)
 		offset += rec.recSize
 	}
-	s.sizes[seg] = offset
-	return nil
+	return offset, nil
 }
 
 // removeSegment closes and deletes a segment (used by compaction).
 func (s *store) removeSegment(seg uint32) error {
+	s.pinMu.Lock()
+	for s.pins[seg] > 0 {
+		s.cond.Wait()
+	}
 	if file, ok := s.readers[seg]; ok {
 		if err := file.Close(); err != nil {
+			s.pinMu.Unlock()
 			return fmt.Errorf("close segment %d: %w", seg, err)
 		}
 		delete(s.readers, seg)
 	}
+	s.pinMu.Unlock()
 	delete(s.sizes, seg)
 	if err := os.Remove(filepath.Join(s.dir, segFilename(seg))); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove segment %d: %w", seg, err)
 	}
 	return nil
+}
+
+// pin hands out a segment's handle and holds it open: the caller reads from it with the engine lock released, and
+// removeSegment waits for the pin to drop.
+func (s *store) pin(seg uint32) (*os.File, bool) {
+	s.pinMu.Lock()
+	defer s.pinMu.Unlock()
+	file, ok := s.readers[seg]
+	if !ok {
+		return nil, false
+	}
+	s.pins[seg]++
+	return file, true
+}
+
+func (s *store) unpin(seg uint32) {
+	s.pinMu.Lock()
+	s.pins[seg]--
+	if s.pins[seg] == 0 {
+		delete(s.pins, seg)
+		s.cond.Broadcast()
+	}
+	s.pinMu.Unlock()
 }
 
 // diskBytes is the total size of every segment, and len(sizes) their count.
@@ -336,8 +427,8 @@ func (s *store) syncActive() error {
 	return nil
 }
 
-// syncIfAlways fsyncs the active segment only under the SyncAlways policy; the
-// per-write durability path calls it, while SyncEverySec relies on the ticker.
+// syncIfAlways fsyncs the active segment only under the SyncAlways policy; the per-write durability path calls it,
+// while SyncEverySec relies on the ticker.
 func (s *store) syncIfAlways() error {
 	if s.sync != wal.SyncAlways {
 		return nil
@@ -346,6 +437,11 @@ func (s *store) syncIfAlways() error {
 }
 
 func (s *store) close() error {
+	s.pinMu.Lock()
+	for len(s.pins) > 0 {
+		s.cond.Wait()
+	}
+	defer s.pinMu.Unlock()
 	firstErr := s.syncActive()
 	for _, file := range s.readers {
 		if err := file.Close(); err != nil && firstErr == nil {
@@ -353,6 +449,19 @@ func (s *store) close() error {
 		}
 	}
 	return firstErr
+}
+
+// requireSegmentHeader verifies that a non-empty segment carries the current format header.
+func requireSegmentHeader(file *os.File) error {
+	buf := make([]byte, len(segmentHeader))
+	n, err := file.ReadAt(buf, 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if string(buf[:n]) != segmentHeader {
+		return errUnsupportedFormat
+	}
+	return nil
 }
 
 func segFilename(num uint32) string {

--- a/internal/network/client.go
+++ b/internal/network/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/OutOfStack/db/internal/protocol"
@@ -86,14 +85,12 @@ func (tc *TCPClient) sendWithRetry(cmd string, args []string, allowRetry bool) (
 	return resp, nil
 }
 
-// handleReadError recovers from a failed reply read: connection errors are
-// retried once on a fresh connection; decode errors drop the connection
-// because unread reply bytes may remain on the wire and would otherwise be
-// read as the next command's reply
+// handleReadError recovers from a failed reply read: connection errors are retried once on a fresh connection; decode
+// errors drop the connection because unread reply bytes may remain on the wire and would otherwise be read as the next
+// command's reply
 func (tc *TCPClient) handleReadError(cmd string, args []string, err error, allowRetry bool) (protocol.Reply, error) {
 	if !tc.isConnectionError(err) {
-		// reconnect eagerly; if that fails the connection is still closed
-		// and the next Send re-dials via its own retry path
+		// reconnect eagerly; if that fails the connection is still closed and the next Send re-dials via its own retry path
 		_ = tc.reconnect()
 		return protocol.Reply{}, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -136,11 +133,7 @@ func (tc *TCPClient) isConnectionError(err error) bool {
 		}
 	}
 
-	// fallback to string matching for compatibility
-	errStr := err.Error()
-	return strings.Contains(errStr, "broken pipe") ||
-		strings.Contains(errStr, "connection reset") ||
-		strings.Contains(errStr, "connection refused")
+	return false
 }
 
 // reconnect attempts to establish a new connection to the server

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -19,9 +19,8 @@ const (
 	defaultMaxMessageSize = 4096
 	defaultTimeout        = 1 * time.Minute
 
-	// errorDrainTimeout bounds draining of unread request bytes before closing
-	// a connection after a protocol error, so the error reply is not lost to a
-	// TCP reset caused by closing with pending input
+	// errorDrainTimeout bounds draining of unread request bytes before closing a connection after a protocol error, so the
+	// error reply is not lost to a TCP reset caused by closing with pending input
 	errorDrainTimeout = 100 * time.Millisecond
 )
 
@@ -39,8 +38,8 @@ type TCPServer struct {
 	maxMessageSize int
 }
 
-// NewTCPServer creates a new Server instance with the given configuration and logger.
-// It initializes the server with default values and sets up connection management.
+// NewTCPServer creates a new Server instance with the given configuration and logger. It initializes the server with
+// default values and sets up connection management.
 func NewTCPServer(address string, logger *slog.Logger, options ...TCPServerOption) (*TCPServer, error) {
 	if logger == nil {
 		logger = slog.Default()
@@ -148,8 +147,8 @@ func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler
 				s.logger.Error("Failed to send protocol error", "error", wErr)
 				return
 			}
-			// drain pending request bytes briefly: closing with unread input
-			// can trigger a TCP reset that discards the queued error reply
+			// drain pending request bytes briefly: closing with unread input can trigger a TCP reset that discards the queued
+			// error reply
 			if dErr := conn.SetReadDeadline(time.Now().Add(errorDrainTimeout)); dErr == nil {
 				_, _ = io.Copy(io.Discard, reader)
 			}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -44,6 +44,17 @@ var commands = map[string]commandSpec{ //nolint:gochecknoglobals // a single reg
 	"REPLICATION":  {args: 1, readOnly: true, admin: true, usage: "REPLICATION STATUS"},
 }
 
+// IsWrite reports whether cmd mutates state and so has to be routed to a master. The pool asks this rather than keeping
+// its own list: a command whose two classifications disagree is sent to a standby, refused with "ERR readonly", and not
+// retried, because the caller that would fail it over believes it was a read.
+//
+// An unknown command is not a write — the server rejects it either way. Neither are the control-plane commands: PROMOTE
+// mutates, but it is aimed at one specific node, not at whichever server currently holds the master role.
+func IsWrite(cmd string) bool {
+	spec, ok := commands[strings.ToUpper(strings.TrimSpace(cmd))]
+	return ok && !spec.readOnly && !spec.admin
+}
+
 // New creates a new Parser instance.
 func New() *Parser {
 	return &Parser{}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,24 +19,29 @@ type Parser struct{}
 
 type commandSpec struct {
 	args     int
+	optional int
 	readOnly bool
-	// admin marks a control-plane command (e.g. replication management) whose
-	// arguments are not table-scoped and so skip table/key validation.
+	// admin marks a control-plane command (e.g. replication management) whose arguments are not table-scoped and so skip
+	// table/key validation.
 	admin bool
 	usage string
 }
 
-// commands is the central command registry used for validation and future
-// read/write routing.
+// commands is the central command registry used for validation and future read/write routing.
 var commands = map[string]commandSpec{ //nolint:gochecknoglobals // a single registry is intentional
-	"SET":         {args: 3, readOnly: false, usage: "SET <table> <key> <value>"},
-	"GET":         {args: 2, readOnly: true, usage: "GET <table> <key>"},
-	"DEL":         {args: 2, readOnly: false, usage: "DEL <table> <key>"},
-	commandTables: {args: 0, readOnly: true, usage: commandTables},
-	"EXISTS":      {args: 1, readOnly: true, usage: "EXISTS <table>"},
-	"KEYS":        {args: 1, readOnly: true, usage: "KEYS <table>"},
+	"SET":          {args: 3, readOnly: false, usage: "SET <table> <key> <value>"},
+	"GET":          {args: 2, readOnly: true, usage: "GET <table> <key>"},
+	"DEL":          {args: 2, readOnly: false, usage: "DEL <table> <key>"},
+	commandTables:  {args: 0, readOnly: true, usage: commandTables},
+	"EXISTS":       {args: 1, readOnly: true, usage: "EXISTS <table>"},
+	"KEYS":         {args: 1, readOnly: true, usage: "KEYS <table>"},
+	"INCR":         {args: 2, optional: 1, readOnly: false, usage: "INCR <table> <key> [delta]"},
+	"APPEND":       {args: 3, readOnly: false, usage: "APPEND <table> <key> <value>"},
+	"HSET":         {args: 4, readOnly: false, usage: "HSET <table> <key> <field> <value>"},
+	"HGET":         {args: 3, readOnly: true, usage: "HGET <table> <key> <field>"},
+	"TYPE":         {args: 2, readOnly: true, usage: "TYPE <table> <key>"},
 	commandPromote: {args: 0, readOnly: false, admin: true, usage: commandPromote},
-	"REPLICATION": {args: 1, readOnly: true, admin: true, usage: "REPLICATION STATUS"},
+	"REPLICATION":  {args: 1, readOnly: true, admin: true, usage: "REPLICATION STATUS"},
 }
 
 // New creates a new Parser instance.
@@ -55,7 +60,7 @@ func (p *Parser) Parse(cmd string, args []string) (string, []string, error) {
 	if !ok {
 		return "", nil, errors.New("unknown command: " + cmd)
 	}
-	if len(args) != spec.args {
+	if len(args) < spec.args || len(args) > spec.args+spec.optional {
 		return "", nil, fmt.Errorf("%s requires %d arguments: %s", cmd, spec.args, spec.usage)
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -69,3 +69,34 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+// TestIsWrite pins down the classification the connection pool routes on: a mutation must reach a master, a read may go
+// anywhere, and a control-plane command is aimed at one node rather than at whichever server holds the master role.
+func TestIsWrite(t *testing.T) {
+	tests := map[string]bool{
+		"SET":         true,
+		"DEL":         true,
+		"INCR":        true,
+		"APPEND":      true,
+		"HSET":        true,
+		"GET":         false,
+		"HGET":        false,
+		"TYPE":        false,
+		"TABLES":      false,
+		"EXISTS":      false,
+		"KEYS":        false,
+		"PROMOTE":     false,
+		"REPLICATION": false,
+		"NONSENSE":    false,
+	}
+	for cmd, want := range tests {
+		if got := parser.IsWrite(cmd); got != want {
+			t.Errorf("IsWrite(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+
+	// The RESP decoder hands the command through as the client wrote it, so classification must survive case and padding.
+	if !parser.IsWrite("  set  ") {
+		t.Error(`IsWrite("  set  ") = false, want true`)
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -36,6 +36,17 @@ func TestParse(t *testing.T) {
 		{"", nil, "", nil, true},
 		{"GET", []string{"", "foo"}, "", nil, true},
 		{"GET", []string{"users", ""}, "", nil, true},
+		{"INCR", []string{"stats", "hits"}, "INCR", []string{"stats", "hits"}, false},
+		{"incr", []string{"stats", "hits", "5"}, "INCR", []string{"stats", "hits", "5"}, false},
+		{"INCR", []string{"stats"}, "", nil, true},
+		{"INCR", []string{"stats", "hits", "5", "extra"}, "", nil, true},
+		{"APPEND", []string{"t", "k", "v"}, "APPEND", []string{"t", "k", "v"}, false},
+		{"APPEND", []string{"t", "k"}, "", nil, true},
+		{"HSET", []string{"t", "k", "f", "v"}, "HSET", []string{"t", "k", "f", "v"}, false},
+		{"HSET", []string{"t", "k", "f"}, "", nil, true},
+		{"HGET", []string{"t", "k", "f"}, "HGET", []string{"t", "k", "f"}, false},
+		{"TYPE", []string{"t", "k"}, "TYPE", []string{"t", "k"}, false},
+		{"TYPE", []string{"t", ""}, "", nil, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/parser"
 	"github.com/OutOfStack/db/internal/protocol"
 )
 
@@ -58,11 +59,11 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	}, nil
 }
 
-// Send sends a command using the pool, with automatic failover. Writes (SET, DEL) route to a master; reads follow the
+// Send sends a command using the pool, with automatic failover. Mutating commands route to a master; reads follow the
 // configured strategy. A standby that replies "ERR readonly" to a write marks the routing stale, so the pool fails that
 // server over and retries against another master.
 func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
-	write := isWriteCommand(cmd)
+	write := parser.IsWrite(cmd)
 	var lastErr error
 	attempts := 0
 	maxAttempts := c.config.MaxRetries + 1 // initial attempt + retries
@@ -144,16 +145,6 @@ func noServersError(write bool) error {
 		return errors.New("no master servers available in pool")
 	}
 	return errors.New("no servers available in pool")
-}
-
-// isWriteCommand reports whether cmd mutates state and must route to a master.
-func isWriteCommand(cmd string) bool {
-	switch strings.ToUpper(strings.TrimSpace(cmd)) {
-	case "SET", "DEL":
-		return true
-	default:
-		return false
-	}
 }
 
 // isReadOnlyReply reports whether resp is a standby's "ERR readonly" response.

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -11,9 +11,8 @@ import (
 	"github.com/OutOfStack/db/internal/protocol"
 )
 
-// readOnlyReply is the error value a standby returns for a mutating command
-// (wire "-ERR readonly", decoded with the "ERR " prefix stripped). It signals
-// that the selected server is not actually a writable master.
+// readOnlyReply is the error value a standby returns for a mutating command (wire "-ERR readonly", decoded with the
+// "ERR " prefix stripped). It signals that the selected server is not actually a writable master.
 const readOnlyReply = "readonly"
 
 // syncedConnection wraps a TCPClient with a mutex to serialize Send() calls
@@ -59,10 +58,9 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	}, nil
 }
 
-// Send sends a command using the pool, with automatic failover. Writes (SET,
-// DEL) route to a master; reads follow the configured strategy. A standby that
-// replies "ERR readonly" to a write marks the routing stale, so the pool fails
-// that server over and retries against another master.
+// Send sends a command using the pool, with automatic failover. Writes (SET, DEL) route to a master; reads follow the
+// configured strategy. A standby that replies "ERR readonly" to a write marks the routing stale, so the pool fails that
+// server over and retries against another master.
 func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 	write := isWriteCommand(cmd)
 	var lastErr error
@@ -101,8 +99,8 @@ func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 			continue
 		}
 
-		// A write that reached a read-only server means our master routing is
-		// stale (the server was demoted); fail it over and retry elsewhere.
+		// A write that reached a read-only server means our master routing is stale (the server was demoted); fail it over
+		// and retry elsewhere.
 		if write && isReadOnlyReply(resp) {
 			c.selector.MarkFailed(server.Address)
 			lastErr = fmt.Errorf("server %s is read-only", server.Address)
@@ -123,8 +121,8 @@ func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 	return protocol.Reply{}, fmt.Errorf("all servers failed after %d attempts", attempts)
 }
 
-// selectServer picks a server for the command, resetting the selector once if
-// all candidates are currently marked failed.
+// selectServer picks a server for the command, resetting the selector once if all candidates are currently marked
+// failed.
 func (c *Client) selectServer(write bool) *ServerConfig {
 	server := c.pick(write)
 	if server == nil {

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -35,7 +35,6 @@ type PoolConfig struct {
 	SelectionStrategy SelectionStrategy `yaml:"selection_strategy"`
 	MaxRetries        int               `yaml:"max_retries"`
 	RetryDelay        time.Duration     `yaml:"retry_delay"`
-	HealthCheckPeriod time.Duration     `yaml:"health_check_period"`
 	FailureTimeout    time.Duration     `yaml:"failure_timeout"` // Time after which failed servers are retried
 }
 
@@ -47,7 +46,6 @@ func DefaultPoolConfig() *PoolConfig {
 		SelectionStrategy: StrategyMasterFirst,
 		MaxRetries:        3,
 		RetryDelay:        time.Second,
-		HealthCheckPeriod: 10 * time.Second,
 		FailureTimeout:    30 * time.Second, // Retry failed servers after 30 seconds
 	}
 }

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -75,8 +75,56 @@ func TestSelectWrite_OnlyMasters(t *testing.T) {
 	}
 }
 
-// TestClient_WritesSkipStandbys verifies writes route only to masters while reads may use standbys.
+// TestClient_WritesSkipStandbys verifies every mutating command routes only to masters while reads may use standbys.
+// Round-robin is the strategy that exposes a misclassified mutation: master_first would send it to a master anyway.
 func TestClient_WritesSkipStandbys(t *testing.T) {
+	t.Parallel()
+
+	mutations := []struct {
+		cmd  string
+		args []string
+	}{
+		{"SET", []string{"t", "k", "v"}},
+		{"DEL", []string{"t", "k"}},
+		{"INCR", []string{"t", "k"}},
+		{"INCR", []string{"t", "k", "2"}},
+		{"APPEND", []string{"t", "k", "v"}},
+		{"HSET", []string{"t", "k", "f", "v"}},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.cmd, func(t *testing.T) {
+			t.Parallel()
+			var masterHits, standbyHits atomic.Int32
+			masterAddr := startHandler(t, okHandler(&masterHits))
+			// A standby refuses a mutation, so a misrouted one is visible as a failure rather than a silent success.
+			standbyAddr := startHandler(t, func(_ context.Context, _ string, _ []string) protocol.Reply {
+				standbyHits.Add(1)
+				return protocol.Error("readonly")
+			})
+
+			client := newPool(t, []pool.ServerConfig{
+				{Address: masterAddr, Role: pool.RoleMaster},
+				{Address: standbyAddr, Role: pool.RoleStandby},
+			}, pool.StrategyRoundRobin)
+
+			for range 5 {
+				if _, err := client.Send(mutation.cmd, mutation.args); err != nil {
+					t.Fatalf("Send %s: %v", mutation.cmd, err)
+				}
+			}
+			if standbyHits.Load() != 0 {
+				t.Errorf("standby received %d %s commands, want 0", standbyHits.Load(), mutation.cmd)
+			}
+			if masterHits.Load() != 5 {
+				t.Errorf("master received %d %s commands, want 5", masterHits.Load(), mutation.cmd)
+			}
+		})
+	}
+}
+
+// TestClient_ReadsMayUseStandbys is the other half of the rule above: a read-only command must still be free to land on
+// a standby, or the pool spreads nothing.
+func TestClient_ReadsMayUseStandbys(t *testing.T) {
 	t.Parallel()
 	var masterHits, standbyHits atomic.Int32
 	masterAddr := startHandler(t, okHandler(&masterHits))
@@ -85,18 +133,17 @@ func TestClient_WritesSkipStandbys(t *testing.T) {
 	client := newPool(t, []pool.ServerConfig{
 		{Address: masterAddr, Role: pool.RoleMaster},
 		{Address: standbyAddr, Role: pool.RoleStandby},
-	}, pool.StrategyMasterFirst)
+	}, pool.StrategyRoundRobin)
 
-	for range 5 {
-		if _, err := client.Send("SET", []string{"t", "k", "v"}); err != nil {
-			t.Fatalf("Send SET: %v", err)
+	for _, cmd := range []string{"GET", "TYPE", "HGET", "KEYS", "EXISTS", "TABLES"} {
+		for range 4 {
+			if _, err := client.Send(cmd, []string{"t", "k", "f"}); err != nil {
+				t.Fatalf("Send %s: %v", cmd, err)
+			}
 		}
 	}
-	if standbyHits.Load() != 0 {
-		t.Errorf("standby received %d writes, want 0", standbyHits.Load())
-	}
-	if masterHits.Load() != 5 {
-		t.Errorf("master received %d writes, want 5", masterHits.Load())
+	if standbyHits.Load() == 0 {
+		t.Error("standby received no reads under round_robin")
 	}
 }
 

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/OutOfStack/db/internal/protocol"
 )
 
-// startHandler runs an in-process server with a custom handler on an ephemeral
-// port and returns its address.
+// startHandler runs an in-process server with a custom handler on an ephemeral port and returns its address.
 func startHandler(t *testing.T, handler network.RequestHandler) string {
 	t.Helper()
 	srv, err := network.NewTCPServer("127.0.0.1:0", slog.New(slog.DiscardHandler))
@@ -50,8 +49,7 @@ func newPool(t *testing.T, servers []pool.ServerConfig, strategy pool.SelectionS
 	return client
 }
 
-// TestSelectWrite_OnlyMasters verifies every strategy's SelectWrite returns a
-// master, never a standby.
+// TestSelectWrite_OnlyMasters verifies every strategy's SelectWrite returns a master, never a standby.
 func TestSelectWrite_OnlyMasters(t *testing.T) {
 	t.Parallel()
 	config := &pool.PoolConfig{
@@ -77,8 +75,7 @@ func TestSelectWrite_OnlyMasters(t *testing.T) {
 	}
 }
 
-// TestClient_WritesSkipStandbys verifies writes route only to masters while
-// reads may use standbys.
+// TestClient_WritesSkipStandbys verifies writes route only to masters while reads may use standbys.
 func TestClient_WritesSkipStandbys(t *testing.T) {
 	t.Parallel()
 	var masterHits, standbyHits atomic.Int32
@@ -103,8 +100,8 @@ func TestClient_WritesSkipStandbys(t *testing.T) {
 	}
 }
 
-// TestClient_ReadOnlyFailover verifies an "ERR readonly" reply to a write marks
-// the server stale and reroutes to another master.
+// TestClient_ReadOnlyFailover verifies an "ERR readonly" reply to a write marks the server stale and reroutes to
+// another master.
 func TestClient_ReadOnlyFailover(t *testing.T) {
 	t.Parallel()
 	var goodHits atomic.Int32

--- a/internal/pool/selector.go
+++ b/internal/pool/selector.go
@@ -8,13 +8,10 @@ import (
 
 // ServerSelector is responsible for selecting servers from the pool
 type ServerSelector interface {
-	// Select returns the next server to use, or nil if no servers available.
-	// It is equivalent to SelectRead and kept for backward compatibility.
-	Select() *ServerConfig
 	// SelectRead returns the next server for a read, following the strategy.
 	SelectRead() *ServerConfig
-	// SelectWrite returns the next master for a write, or nil if none available.
-	// Standbys are never returned: writes must reach a master.
+	// SelectWrite returns the next master for a write, or nil if none available. Standbys are never returned: writes must
+	// reach a master.
 	SelectWrite() *ServerConfig
 	// MarkFailed marks a server as failed
 	MarkFailed(address string)
@@ -44,7 +41,6 @@ func NewMasterFirstSelector(config *PoolConfig) *MasterFirstSelector {
 }
 
 // Select picks the next available server (master first, then standby)
-func (s *MasterFirstSelector) Select() *ServerConfig { return s.SelectRead() }
 
 // SelectRead picks the next available server (master first, then standby)
 func (s *MasterFirstSelector) SelectRead() *ServerConfig {
@@ -140,7 +136,6 @@ func NewRoundRobinSelector(config *PoolConfig) *RoundRobinSelector {
 }
 
 // Select picks the next server in round-robin order
-func (s *RoundRobinSelector) Select() *ServerConfig { return s.SelectRead() }
 
 // SelectRead picks the next server in round-robin order across all servers
 func (s *RoundRobinSelector) SelectRead() *ServerConfig {
@@ -156,8 +151,8 @@ func (s *RoundRobinSelector) SelectWrite() *ServerConfig {
 	return rotate(s.masters, &s.currentMaster, s.isFailed)
 }
 
-// rotate returns the next non-failed server from servers starting at *cursor,
-// advancing the cursor past the chosen server.
+// rotate returns the next non-failed server from servers starting at *cursor, advancing the cursor past the chosen
+// server.
 func rotate(servers []ServerConfig, cursor *int, isFailed func(string) bool) *ServerConfig {
 	for i := range servers {
 		idx := (*cursor + i) % len(servers)
@@ -220,7 +215,6 @@ func NewRandomSelector(config *PoolConfig) *RandomSelector {
 }
 
 // Select picks a random available server
-func (s *RandomSelector) Select() *ServerConfig { return s.SelectRead() }
 
 // SelectRead picks a random available server across all servers
 func (s *RandomSelector) SelectRead() *ServerConfig {

--- a/internal/pool/selector_test.go
+++ b/internal/pool/selector_test.go
@@ -23,7 +23,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	selector := pool.NewMasterFirstSelector(config)
 
 	// First select should return a master
-	server := selector.Select()
+	server := selector.SelectRead()
 	if server == nil {
 		t.Fatal("Expected server, got nil")
 	} else if server.Role != pool.RoleMaster {
@@ -35,7 +35,7 @@ func TestMasterFirstSelector(t *testing.T) {
 	selector.MarkFailed("master2")
 
 	// Should fall back to standby
-	server = selector.Select()
+	server = selector.SelectRead()
 	if server == nil {
 		t.Fatal("Expected standby server, got nil")
 	} else if server.Role != pool.RoleStandby {
@@ -47,14 +47,14 @@ func TestMasterFirstSelector(t *testing.T) {
 	selector.MarkFailed("standby2")
 
 	// Should return nil when all servers failed
-	server = selector.Select()
+	server = selector.SelectRead()
 	if server != nil {
 		t.Errorf("Expected nil when all servers failed, got %v", server)
 	}
 
 	// Reset should clear failures
 	selector.Reset()
-	server = selector.Select()
+	server = selector.SelectRead()
 	if server == nil {
 		t.Fatal("Expected server after reset, got nil")
 	} else if server.Role != pool.RoleMaster {
@@ -79,7 +79,7 @@ func TestRoundRobinSelector(t *testing.T) {
 	// Track which servers we get
 	seen := make(map[string]int)
 	for range 6 {
-		server := selector.Select()
+		server := selector.SelectRead()
 		if server == nil {
 			t.Fatal("Expected server, got nil")
 		}
@@ -111,7 +111,7 @@ func TestRandomSelector(t *testing.T) {
 
 	// Select multiple times and ensure we get valid servers
 	for range 10 {
-		server := selector.Select()
+		server := selector.SelectRead()
 		if server == nil {
 			t.Fatal("Expected server, got nil")
 		}
@@ -134,7 +134,7 @@ func TestRandomSelector(t *testing.T) {
 
 	// Should always return server3 now
 	for range 5 {
-		server := selector.Select()
+		server := selector.SelectRead()
 		if server == nil {
 			t.Fatal("Expected server3, got nil")
 		}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -59,9 +59,8 @@ func BulkStringArray(values []string) Reply {
 	return Array(replies)
 }
 
-// CommandSize returns the exact number of bytes WriteCommand emits for cmd/args.
-// It lets callers reject an over-limit command before writing it, matching the
-// cumulative-byte limit ReadCommand enforces on the way back in.
+// CommandSize returns the exact number of bytes WriteCommand emits for cmd/args. It lets callers reject an over-limit
+// command before writing it, matching the cumulative-byte limit ReadCommand enforces on the way back in.
 func CommandSize(cmd string, args []string) int {
 	size := 1 + intWidth(len(args)+1) + 2 // *<count>\r\n
 	size += bulkStringSize(cmd)
@@ -270,9 +269,8 @@ func readBulkStringBody(r *bufio.Reader, lenText string, maxMessageSize int, rea
 	if n < -1 {
 		return "", false, errors.New("invalid negative bulk string length")
 	}
-	// overflow-safe size check: n is non-negative here, so compare against the
-	// remaining budget instead of computing *read+n+2, which can overflow for
-	// lengths near math.MaxInt and bypass the limit.
+	// overflow-safe size check: n is non-negative here, so compare against the remaining budget instead of computing
+	// *read+n+2, which can overflow for lengths near math.MaxInt and bypass the limit.
 	if maxMessageSize > 0 && n > maxMessageSize-*read-2 {
 		return "", false, errors.New("message size exceeds limit")
 	}
@@ -313,15 +311,16 @@ func readLine(r *bufio.Reader, maxMessageSize int, read *int) (string, error) {
 	return string(out[:len(out)-2]), nil
 }
 
-// minArrayElemSize is the smallest possible wire encoding of one array element (e.g. "+\r\n"), used to bound declared array lengths.
-// maxPreallocElems caps slice preallocation so a declared length cannot force a huge allocation before any element is read.
+// minArrayElemSize is the smallest possible wire encoding of one array element (e.g. "+\r\n"), used to bound declared
+// array lengths. maxPreallocElems caps slice preallocation so a declared length cannot force a huge allocation before
+// any element is read.
 const (
 	minArrayElemSize = 3
 	maxPreallocElems = 1024
 )
 
-// checkArrayLen rejects array lengths that could not possibly be encoded
-// within maxMessageSize, before any per-element allocation happens
+// checkArrayLen rejects array lengths that could not possibly be encoded within maxMessageSize, before any per-element
+// allocation happens
 func checkArrayLen(count, maxMessageSize int) error {
 	if maxMessageSize > 0 && count > maxMessageSize/minArrayElemSize {
 		return errors.New("message size exceeds limit")
@@ -329,7 +328,8 @@ func checkArrayLen(count, maxMessageSize int) error {
 	return nil
 }
 
-// sanitizeLine makes a value safe for line-based RESP types (simple strings and errors), which must not contain CR or LF
+// sanitizeLine makes a value safe for line-based RESP types (simple strings and errors), which must not contain CR or
+// LF
 func sanitizeLine(value string) string {
 	if !strings.ContainsAny(value, "\r\n") {
 		return value

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -146,8 +146,8 @@ func TestReadReplyRejectsMalformedPrefix(t *testing.T) {
 func TestRejectsHugeArrayCount(t *testing.T) {
 	t.Parallel()
 
-	// declared counts that could never fit in the size limit must be rejected
-	// before any allocation happens (a naive prealloc panics or OOMs)
+	// declared counts that could never fit in the size limit must be rejected before any allocation happens (a naive
+	// prealloc panics or OOMs)
 	for _, input := range []string{
 		"*9223372036854775807\r\n",
 		"*1000000000\r\n$1\r\na\r\n",
@@ -164,8 +164,8 @@ func TestRejectsHugeArrayCount(t *testing.T) {
 func TestWriteReplySanitizesCRLF(t *testing.T) {
 	t.Parallel()
 
-	// CR/LF in line-based replies must not break framing: a crafted error
-	// message must decode as exactly one reply, not smuggle in a second one
+	// CR/LF in line-based replies must not break framing: a crafted error message must decode as exactly one reply, not
+	// smuggle in a second one
 	var buf bytes.Buffer
 	if err := protocol.WriteReply(&buf, protocol.Error("unknown command: FOO\r\n+OK")); err != nil {
 		t.Fatalf("WriteReply() error = %v", err)
@@ -222,8 +222,8 @@ func FuzzReadReply(f *testing.F) {
 		if err != nil {
 			return
 		}
-		// the first encode may normalize (ERR prefix, CR/LF sanitization);
-		// after that, encode/decode must be a stable round trip
+		// the first encode may normalize (ERR prefix, CR/LF sanitization); after that, encode/decode must be a stable round
+		// trip
 		r2, err := rewrite(r1)
 		if err != nil {
 			t.Fatalf("first re-encode of %#v error = %v", r1, err)

--- a/internal/protocol/value.go
+++ b/internal/protocol/value.go
@@ -1,0 +1,390 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Kind is the type tag of a stored value.
+type Kind byte
+
+// Value kinds. The numeric values are part of the on-disk encoding.
+const (
+	KindString Kind = iota
+	KindInt
+	KindFloat
+	KindBool
+	KindArray
+	KindMap
+)
+
+// maxDepth bounds nesting on both the parse and the decode side, so a corrupt or hostile value cannot drive Decode into
+// unbounded recursion. Operations that add a level of nesting (APPEND, HSET) check that their result still decodes
+// before storing it, so a value that reads back as an opaque string cannot be written in the first place.
+const maxDepth = 64
+
+const kindStringName = "string"
+
+func (k Kind) String() string {
+	switch k {
+	case KindInt:
+		return "int"
+	case KindFloat:
+		return "float"
+	case KindBool:
+		return "bool"
+	case KindArray:
+		return "array"
+	case KindMap:
+		return "map"
+	case KindString:
+		return kindStringName
+	default:
+		return kindStringName // an unknown tag never decodes, so it can only be a string
+	}
+}
+
+// Value is a typed value. Only the field matching Kind carries data.
+type Value struct {
+	Kind  Kind
+	Str   string
+	Int   int64
+	Float float64
+	Bool  bool
+	Array []Value
+	Map   map[string]Value
+}
+
+// StringValue returns a string Value.
+func StringValue(s string) Value { return Value{Kind: KindString, Str: s} }
+
+// IntValue returns an int Value.
+func IntValue(n int64) Value { return Value{Kind: KindInt, Int: n} }
+
+// FloatValue returns a float Value.
+func FloatValue(f float64) Value { return Value{Kind: KindFloat, Float: f} }
+
+// BoolValue returns a bool Value.
+func BoolValue(b bool) Value { return Value{Kind: KindBool, Bool: b} }
+
+// ArrayValue returns an array Value.
+func ArrayValue(items []Value) Value { return Value{Kind: KindArray, Array: items} }
+
+// MapValue returns a map Value.
+func MapValue(fields map[string]Value) Value { return Value{Kind: KindMap, Map: fields} }
+
+// Encode serializes v for storage, the WAL, and replication: a type tag byte followed by the payload (varint int,
+// IEEE-754 float, length-prefixed string, count plus recursive elements for array and map). Map keys are encoded in
+// sorted order, so a value always encodes to the same bytes.
+//
+// Strings are tagged too; otherwise arbitrary string bytes could be mistaken for another encoded type.
+func Encode(v Value) string {
+	return string(appendValue(nil, v))
+}
+
+func appendValue(buf []byte, v Value) []byte {
+	buf = append(buf, byte(v.Kind))
+	switch v.Kind {
+	case KindString:
+		buf = binary.AppendUvarint(buf, uint64(len(v.Str)))
+		buf = append(buf, v.Str...)
+	case KindInt:
+		buf = binary.AppendVarint(buf, v.Int)
+	case KindFloat:
+		buf = binary.BigEndian.AppendUint64(buf, math.Float64bits(v.Float))
+	case KindBool:
+		var b byte
+		if v.Bool {
+			b = 1
+		}
+		buf = append(buf, b)
+	case KindArray:
+		buf = binary.AppendUvarint(buf, uint64(len(v.Array)))
+		for _, item := range v.Array {
+			buf = appendValue(buf, item)
+		}
+	case KindMap:
+		buf = binary.AppendUvarint(buf, uint64(len(v.Map)))
+		for _, key := range sortedKeys(v.Map) {
+			buf = binary.AppendUvarint(buf, uint64(len(key)))
+			buf = append(buf, key...)
+			buf = appendValue(buf, v.Map[key])
+		}
+	}
+	return buf
+}
+
+// Decode returns the value stored in s. It is total: bytes that are not a well-formed encoding come back as the string
+// they are, rather than as an error every caller would have to handle. Persistence readers reject a file whose format
+// header is missing or unknown, so malformed bytes never reach here from a file this build wrote.
+func Decode(s string) Value {
+	v, rest, ok := decodeValue([]byte(s), 0)
+	if !ok || len(rest) != 0 {
+		return StringValue(s)
+	}
+	return v
+}
+
+func decodeValue(buf []byte, depth int) (Value, []byte, bool) {
+	if len(buf) == 0 || depth > maxDepth {
+		return Value{}, nil, false
+	}
+	kind, rest := Kind(buf[0]), buf[1:]
+	switch kind {
+	case KindString:
+		s, tail, ok := decodeString(rest)
+		if !ok {
+			return Value{}, nil, false
+		}
+		return StringValue(s), tail, true
+	case KindInt:
+		n, used := binary.Varint(rest)
+		if used <= 0 {
+			return Value{}, nil, false
+		}
+		return IntValue(n), rest[used:], true
+	case KindFloat:
+		if len(rest) < 8 {
+			return Value{}, nil, false
+		}
+		return FloatValue(math.Float64frombits(binary.BigEndian.Uint64(rest[:8]))), rest[8:], true
+	case KindBool:
+		if len(rest) == 0 || rest[0] > 1 {
+			return Value{}, nil, false
+		}
+		return BoolValue(rest[0] == 1), rest[1:], true
+	case KindArray:
+		return decodeArray(rest, depth)
+	case KindMap:
+		return decodeMap(rest, depth)
+	default:
+		return Value{}, nil, false
+	}
+}
+
+func decodeArray(buf []byte, depth int) (Value, []byte, bool) {
+	count, rest, ok := decodeCount(buf)
+	if !ok {
+		return Value{}, nil, false
+	}
+	items := make([]Value, 0, count)
+	for range count {
+		item, tail, itemOK := decodeValue(rest, depth+1)
+		if !itemOK {
+			return Value{}, nil, false
+		}
+		items = append(items, item)
+		rest = tail
+	}
+	return ArrayValue(items), rest, true
+}
+
+func decodeMap(buf []byte, depth int) (Value, []byte, bool) {
+	count, rest, ok := decodeCount(buf)
+	if !ok {
+		return Value{}, nil, false
+	}
+	fields := make(map[string]Value, count)
+	for range count {
+		key, tail, keyOK := decodeString(rest)
+		if !keyOK {
+			return Value{}, nil, false
+		}
+		value, next, valueOK := decodeValue(tail, depth+1)
+		if !valueOK {
+			return Value{}, nil, false
+		}
+		fields[key] = value
+		rest = next
+	}
+	return MapValue(fields), rest, true
+}
+
+// decodeCount reads a uvarint length or element count and rejects one larger than the bytes that remain, so a corrupt
+// length cannot force a huge allocation. Every element costs at least one byte.
+func decodeCount(buf []byte) (int, []byte, bool) {
+	count, used := binary.Uvarint(buf)
+	if used <= 0 {
+		return 0, nil, false
+	}
+	rest := buf[used:]
+	if count > uint64(len(rest)) { // #nosec G115 -- a length is never negative
+		return 0, nil, false
+	}
+	return int(count), rest, true // #nosec G115 -- bounded by len(rest) above
+}
+
+func decodeString(buf []byte) (string, []byte, bool) {
+	length, rest, ok := decodeCount(buf)
+	if !ok {
+		return "", nil, false
+	}
+	return string(rest[:length]), rest[length:], true
+}
+
+// ParseLiteral parses the client-facing literal syntax shared by the CLI, the client library, and any RESP client: 42
+// (int), 42.5 (float), true and false (bool), "quoted" (string), [1,2,3] (array), {"a":1} (map). Anything that is not a
+// single JSON literal is a plain string.
+func ParseLiteral(s string) (Value, error) {
+	// Leading or trailing space is never syntax here: a value that carries it is text the caller wants stored verbatim,
+	// not a literal to trim and reinterpret.
+	if s == "" || s != strings.TrimSpace(s) {
+		return StringValue(s), nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(s))
+	decoder.UseNumber()
+	var raw any
+	if err := decoder.Decode(&raw); err != nil {
+		return bareString(s)
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return bareString(s) // trailing content: not one literal
+	}
+	value, ok := fromJSON(raw, 0)
+	if !ok {
+		return bareString(s)
+	}
+	return value, nil
+}
+
+// bareString treats input as plain text, unless it opens with a structural character: there, falling back silently
+// would store a typo'd array, map, or quoted string as a string and hide the mistake.
+func bareString(s string) (Value, error) {
+	switch s[0] {
+	case '[', '{', '"':
+		return Value{}, fmt.Errorf("invalid value literal: %s", s)
+	default:
+		return StringValue(s), nil
+	}
+}
+
+func fromJSON(raw any, depth int) (Value, bool) {
+	if depth > maxDepth {
+		return Value{}, false
+	}
+	switch typed := raw.(type) {
+	case json.Number:
+		return fromNumber(typed)
+	case string:
+		return StringValue(typed), true
+	case bool:
+		return BoolValue(typed), true
+	case []any:
+		items := make([]Value, 0, len(typed))
+		for _, item := range typed {
+			value, ok := fromJSON(item, depth+1)
+			if !ok {
+				return Value{}, false
+			}
+			items = append(items, value)
+		}
+		return ArrayValue(items), true
+	case map[string]any:
+		fields := make(map[string]Value, len(typed))
+		for key, item := range typed {
+			value, ok := fromJSON(item, depth+1)
+			if !ok {
+				return Value{}, false
+			}
+			fields[key] = value
+		}
+		return MapValue(fields), true
+	default:
+		return Value{}, false // JSON null has no counterpart; it stays plain text
+	}
+}
+
+// fromNumber keeps the int/float distinction JSON itself does not make: a number that fits an int64 without a
+// fractional part is an int, everything else a float.
+func fromNumber(number json.Number) (Value, bool) {
+	if n, err := strconv.ParseInt(number.String(), 10, 64); err == nil {
+		return IntValue(n), true
+	}
+	f, err := strconv.ParseFloat(number.String(), 64)
+	if err != nil {
+		return Value{}, false
+	}
+	return FloatValue(f), true
+}
+
+// Render renders v in the literal syntax ParseLiteral accepts. A top-level string renders bare, so a plain SET/GET
+// round-trips to exactly the text that was stored; strings nested in an array or map are quoted, where bare text would
+// be ambiguous.
+func Render(v Value) string {
+	if v.Kind == KindString {
+		return v.Str
+	}
+	var out strings.Builder
+	render(&out, v)
+	return out.String()
+}
+
+func render(out *strings.Builder, v Value) {
+	switch v.Kind {
+	case KindString:
+		out.WriteString(quote(v.Str))
+	case KindInt:
+		out.WriteString(strconv.FormatInt(v.Int, 10))
+	case KindFloat:
+		out.WriteString(formatFloat(v.Float))
+	case KindBool:
+		out.WriteString(strconv.FormatBool(v.Bool))
+	case KindArray:
+		out.WriteByte('[')
+		for i, item := range v.Array {
+			if i > 0 {
+				out.WriteByte(',')
+			}
+			render(out, item)
+		}
+		out.WriteByte(']')
+	case KindMap:
+		out.WriteByte('{')
+		for i, key := range sortedKeys(v.Map) {
+			if i > 0 {
+				out.WriteByte(',')
+			}
+			out.WriteString(quote(key))
+			out.WriteByte(':')
+			render(out, v.Map[key])
+		}
+		out.WriteByte('}')
+	}
+}
+
+// quote renders a string as a JSON string literal. json.Marshal is used rather than strconv.Quote because only its
+// escaping is guaranteed to parse back.
+func quote(s string) string {
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return strconv.Quote(s) // unreachable: a string always marshals
+	}
+	return string(encoded)
+}
+
+// formatFloat keeps a float distinguishable from an int on the way back in: a whole float renders as 1.0, which
+// ParseLiteral reads as a float again. Text that is not int-shaped (exponents, NaN, ±Inf) is already unambiguous.
+func formatFloat(f float64) string {
+	text := strconv.FormatFloat(f, 'g', -1, 64)
+	if _, err := strconv.ParseInt(text, 10, 64); err == nil {
+		return text + ".0"
+	}
+	return text
+}
+
+func sortedKeys(fields map[string]Value) []string {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/internal/protocol/value.go
+++ b/internal/protocol/value.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"slices"
 	"strconv"
@@ -26,8 +27,8 @@ const (
 )
 
 // maxDepth bounds nesting on both the parse and the decode side, so a corrupt or hostile value cannot drive Decode into
-// unbounded recursion. Operations that add a level of nesting (APPEND, HSET) check that their result still decodes
-// before storing it, so a value that reads back as an opaque string cannot be written in the first place.
+// unbounded recursion. Operations that add a level of nesting (APPEND, HSET) refuse a result past the limit (TooDeep),
+// so a value that reads back as an opaque string cannot be written in the first place.
 const maxDepth = 64
 
 const kindStringName = "string"
@@ -112,7 +113,7 @@ func appendValue(buf []byte, v Value) []byte {
 		}
 	case KindMap:
 		buf = binary.AppendUvarint(buf, uint64(len(v.Map)))
-		for _, key := range sortedKeys(v.Map) {
+		for _, key := range slices.Sorted(maps.Keys(v.Map)) {
 			buf = binary.AppendUvarint(buf, uint64(len(key)))
 			buf = append(buf, key...)
 			buf = appendValue(buf, v.Map[key])
@@ -124,40 +125,43 @@ func appendValue(buf []byte, v Value) []byte {
 // Decode returns the value stored in s. It is total: bytes that are not a well-formed encoding come back as the string
 // they are, rather than as an error every caller would have to handle. Persistence readers reject a file whose format
 // header is missing or unknown, so malformed bytes never reach here from a file this build wrote.
+//
+// Decoding copies nothing: string leaves are substrings of s and share its backing memory, which is what makes GET on a
+// large value cheap. A caller that retains a leaf long-term keeps all of s alive with it.
 func Decode(s string) Value {
-	v, rest, ok := decodeValue([]byte(s), 0)
-	if !ok || len(rest) != 0 {
+	v, rest, ok := decodeValue(s, 0)
+	if !ok || rest != "" {
 		return StringValue(s)
 	}
 	return v
 }
 
-func decodeValue(buf []byte, depth int) (Value, []byte, bool) {
-	if len(buf) == 0 || depth > maxDepth {
-		return Value{}, nil, false
+func decodeValue(buf string, depth int) (Value, string, bool) {
+	if buf == "" || depth > maxDepth {
+		return Value{}, "", false
 	}
 	kind, rest := Kind(buf[0]), buf[1:]
 	switch kind {
 	case KindString:
 		s, tail, ok := decodeString(rest)
 		if !ok {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
 		return StringValue(s), tail, true
 	case KindInt:
-		n, used := binary.Varint(rest)
+		n, used := binary.Varint(varintPrefix(rest))
 		if used <= 0 {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
 		return IntValue(n), rest[used:], true
 	case KindFloat:
 		if len(rest) < 8 {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
-		return FloatValue(math.Float64frombits(binary.BigEndian.Uint64(rest[:8]))), rest[8:], true
+		return FloatValue(math.Float64frombits(binary.BigEndian.Uint64([]byte(rest[:8])))), rest[8:], true
 	case KindBool:
-		if len(rest) == 0 || rest[0] > 1 {
-			return Value{}, nil, false
+		if rest == "" || rest[0] > 1 {
+			return Value{}, "", false
 		}
 		return BoolValue(rest[0] == 1), rest[1:], true
 	case KindArray:
@@ -165,20 +169,26 @@ func decodeValue(buf []byte, depth int) (Value, []byte, bool) {
 	case KindMap:
 		return decodeMap(rest, depth)
 	default:
-		return Value{}, nil, false
+		return Value{}, "", false
 	}
 }
 
-func decodeArray(buf []byte, depth int) (Value, []byte, bool) {
+// varintPrefix returns the bytes a varint could occupy as a []byte for encoding/binary. Capping at the maximum varint
+// length keeps the conversion small enough to stay off the heap; converting all of s would copy the whole remainder.
+func varintPrefix(s string) []byte {
+	return []byte(s[:min(len(s), binary.MaxVarintLen64)])
+}
+
+func decodeArray(buf string, depth int) (Value, string, bool) {
 	count, rest, ok := decodeCount(buf)
 	if !ok {
-		return Value{}, nil, false
+		return Value{}, "", false
 	}
 	items := make([]Value, 0, count)
 	for range count {
 		item, tail, itemOK := decodeValue(rest, depth+1)
 		if !itemOK {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
 		items = append(items, item)
 		rest = tail
@@ -186,20 +196,20 @@ func decodeArray(buf []byte, depth int) (Value, []byte, bool) {
 	return ArrayValue(items), rest, true
 }
 
-func decodeMap(buf []byte, depth int) (Value, []byte, bool) {
+func decodeMap(buf string, depth int) (Value, string, bool) {
 	count, rest, ok := decodeCount(buf)
 	if !ok {
-		return Value{}, nil, false
+		return Value{}, "", false
 	}
 	fields := make(map[string]Value, count)
 	for range count {
 		key, tail, keyOK := decodeString(rest)
 		if !keyOK {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
 		value, next, valueOK := decodeValue(tail, depth+1)
 		if !valueOK {
-			return Value{}, nil, false
+			return Value{}, "", false
 		}
 		fields[key] = value
 		rest = next
@@ -209,24 +219,24 @@ func decodeMap(buf []byte, depth int) (Value, []byte, bool) {
 
 // decodeCount reads a uvarint length or element count and rejects one larger than the bytes that remain, so a corrupt
 // length cannot force a huge allocation. Every element costs at least one byte.
-func decodeCount(buf []byte) (int, []byte, bool) {
-	count, used := binary.Uvarint(buf)
+func decodeCount(buf string) (int, string, bool) {
+	count, used := binary.Uvarint(varintPrefix(buf))
 	if used <= 0 {
-		return 0, nil, false
+		return 0, "", false
 	}
 	rest := buf[used:]
 	if count > uint64(len(rest)) { // #nosec G115 -- a length is never negative
-		return 0, nil, false
+		return 0, "", false
 	}
 	return int(count), rest, true // #nosec G115 -- bounded by len(rest) above
 }
 
-func decodeString(buf []byte) (string, []byte, bool) {
+func decodeString(buf string) (string, string, bool) {
 	length, rest, ok := decodeCount(buf)
 	if !ok {
-		return "", nil, false
+		return "", "", false
 	}
-	return string(rest[:length]), rest[length:], true
+	return rest[:length], rest[length:], true
 }
 
 // ParseLiteral parses the client-facing literal syntax shared by the CLI, the client library, and any RESP client: 42
@@ -236,6 +246,10 @@ func ParseLiteral(s string) (Value, error) {
 	// Leading or trailing space is never syntax here: a value that carries it is text the caller wants stored verbatim,
 	// not a literal to trim and reinterpret.
 	if s == "" || s != strings.TrimSpace(s) {
+		return StringValue(s), nil
+	}
+	// Only these bytes can open a JSON literal; anything else is a plain string that need not pay for a decode attempt.
+	if strings.IndexByte("-0123456789tfn\"[{", s[0]) < 0 {
 		return StringValue(s), nil
 	}
 
@@ -315,6 +329,28 @@ func fromNumber(number json.Number) (Value, bool) {
 	return FloatValue(f), true
 }
 
+// TooDeep reports whether v nests deeper than Decode will read back. Operations that add a level of nesting (APPEND,
+// HSET) must refuse such a value before storing it: its encoding would come back as an opaque string on the next read.
+func TooDeep(v Value) bool { return tooDeep(v, 0) }
+
+// tooDeep ranges both containers unconditionally: only the field matching Kind is populated, so at most one is non-nil.
+func tooDeep(v Value, depth int) bool {
+	if depth > maxDepth {
+		return true
+	}
+	for _, item := range v.Array {
+		if tooDeep(item, depth+1) {
+			return true
+		}
+	}
+	for _, item := range v.Map {
+		if tooDeep(item, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
 // Render renders v in the literal syntax ParseLiteral accepts. A top-level string renders bare, so a plain SET/GET
 // round-trips to exactly the text that was stored; strings nested in an array or map are quoted, where bare text would
 // be ambiguous.
@@ -348,7 +384,7 @@ func render(out *strings.Builder, v Value) {
 		out.WriteByte(']')
 	case KindMap:
 		out.WriteByte('{')
-		for i, key := range sortedKeys(v.Map) {
+		for i, key := range slices.Sorted(maps.Keys(v.Map)) {
 			if i > 0 {
 				out.WriteByte(',')
 			}
@@ -378,13 +414,4 @@ func formatFloat(f float64) string {
 		return text + ".0"
 	}
 	return text
-}
-
-func sortedKeys(fields map[string]Value) []string {
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
 }

--- a/internal/protocol/value_test.go
+++ b/internal/protocol/value_test.go
@@ -1,0 +1,279 @@
+package protocol_test
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/protocol"
+)
+
+func TestValueCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	nested := protocol.ArrayValue([]protocol.Value{
+		protocol.MapValue(map[string]protocol.Value{
+			"id":    protocol.IntValue(-1),
+			"score": protocol.FloatValue(0.5),
+			"tags":  protocol.ArrayValue([]protocol.Value{protocol.StringValue("a"), protocol.BoolValue(true)}),
+		}),
+		protocol.ArrayValue(nil),
+	})
+
+	tests := []struct {
+		name  string
+		value protocol.Value
+	}{
+		{"string", protocol.StringValue("vlad has\nbytes\x00")},
+		{"empty string", protocol.StringValue("")},
+		{"int", protocol.IntValue(42)},
+		{"int min", protocol.IntValue(math.MinInt64)},
+		{"int max", protocol.IntValue(math.MaxInt64)},
+		{"float", protocol.FloatValue(42.5)},
+		{"float smallest", protocol.FloatValue(math.SmallestNonzeroFloat64)},
+		{"float max", protocol.FloatValue(math.MaxFloat64)},
+		{"bool true", protocol.BoolValue(true)},
+		{"bool false", protocol.BoolValue(false)},
+		{"empty array", protocol.ArrayValue(nil)},
+		{"empty map", protocol.MapValue(nil)},
+		{"nested", nested},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := protocol.Decode(protocol.Encode(tt.value))
+			if !equalValues(got, tt.value) {
+				t.Errorf("Decode(Encode(%v)) = %v", tt.value, got)
+			}
+		})
+	}
+}
+
+func TestEncodeIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first := protocol.MapValue(map[string]protocol.Value{
+		"a": protocol.IntValue(1), "b": protocol.IntValue(2), "c": protocol.IntValue(3),
+	})
+	second := protocol.MapValue(map[string]protocol.Value{
+		"c": protocol.IntValue(3), "b": protocol.IntValue(2), "a": protocol.IntValue(1),
+	})
+	if protocol.Encode(first) != protocol.Encode(second) {
+		t.Error("map encoding depends on insertion order")
+	}
+}
+
+// TestDecodeUntaggedIsString pins Decode's defensive default. It is total, so bytes that are not a well-formed encoding
+// come back as the string they are rather than as an error every caller would have to handle.
+func TestDecodeUntaggedIsString(t *testing.T) {
+	t.Parallel()
+
+	for _, untagged := range []string{"", "vlad", "42", "{not json", "\x07\x00\x00", strings.Repeat("x", 1000)} {
+		got := protocol.Decode(untagged)
+		if got.Kind != protocol.KindString || got.Str != untagged {
+			t.Errorf("Decode(%q) = %v, want string %q", untagged, got, untagged)
+		}
+	}
+}
+
+func TestDecodeRejectsCorruptEncoding(t *testing.T) {
+	t.Parallel()
+
+	encoded := protocol.Encode(protocol.ArrayValue([]protocol.Value{protocol.IntValue(1), protocol.IntValue(2)}))
+	corrupt := []string{
+		encoded[:len(encoded)-1],   // truncated
+		encoded + "x",              // trailing garbage
+		"\x04\xff\xff\xff\xff\x0f", // array tag with a huge element count
+		"\x01",                     // int tag with no payload
+		"\x02\x00",                 // float tag, short payload
+		"\x03\x09",                 // bool tag, invalid payload
+	}
+	for _, s := range corrupt {
+		got := protocol.Decode(s)
+		if got.Kind != protocol.KindString || got.Str != s {
+			t.Errorf("Decode(%q) = %v, want the raw string back", s, got)
+		}
+	}
+}
+
+func TestParseLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		literal string
+		want    protocol.Value
+	}{
+		{"42", protocol.IntValue(42)},
+		{"-7", protocol.IntValue(-7)},
+		{"42.5", protocol.FloatValue(42.5)},
+		{"1e3", protocol.FloatValue(1000)},
+		{"true", protocol.BoolValue(true)},
+		{"false", protocol.BoolValue(false)},
+		{`"42"`, protocol.StringValue("42")},
+		{`"quoted"`, protocol.StringValue("quoted")},
+		{"hello", protocol.StringValue("hello")},
+		{"hello world", protocol.StringValue("hello world")},
+		{"", protocol.StringValue("")},
+		{" 42 ", protocol.StringValue(" 42 ")}, // surrounding space is data, not syntax
+		{"007", protocol.StringValue("007")},   // not valid JSON, so plain text
+		{"null", protocol.StringValue("null")},
+		{"1 2", protocol.StringValue("1 2")},
+		{"9223372036854775808", protocol.FloatValue(9223372036854775808)}, // past int64
+		{"[1,2,3]", protocol.ArrayValue([]protocol.Value{
+			protocol.IntValue(1), protocol.IntValue(2), protocol.IntValue(3),
+		})},
+		{"[]", protocol.ArrayValue(nil)},
+		{`{"a":1}`, protocol.MapValue(map[string]protocol.Value{"a": protocol.IntValue(1)})},
+		{"{}", protocol.MapValue(nil)},
+		{`[{"a":[true,"x"]}]`, protocol.ArrayValue([]protocol.Value{
+			protocol.MapValue(map[string]protocol.Value{
+				"a": protocol.ArrayValue([]protocol.Value{protocol.BoolValue(true), protocol.StringValue("x")}),
+			}),
+		})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.literal, func(t *testing.T) {
+			t.Parallel()
+			got, err := protocol.ParseLiteral(tt.literal)
+			if err != nil {
+				t.Fatalf("ParseLiteral(%q) error = %v", tt.literal, err)
+			}
+			if !equalValues(got, tt.want) {
+				t.Errorf("ParseLiteral(%q) = %v, want %v", tt.literal, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLiteralRejectsMalformedStructure(t *testing.T) {
+	t.Parallel()
+
+	deeplyNested := strings.Repeat("[", 200) + "1" + strings.Repeat("]", 200) // valid JSON, past the depth cap
+	for _, literal := range []string{"[1,2", `{"a":`, `"unterminated`, deeplyNested} {
+		if _, err := protocol.ParseLiteral(literal); err == nil {
+			t.Errorf("ParseLiteral(%q) = nil error, want a parse error", literal)
+		}
+	}
+}
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value protocol.Value
+		want  string
+	}{
+		{"bare string", protocol.StringValue("hello world"), "hello world"},
+		{"string that looks numeric", protocol.StringValue("42"), "42"},
+		{"int", protocol.IntValue(-7), "-7"},
+		{"whole float keeps its type", protocol.FloatValue(1), "1.0"},
+		{"float", protocol.FloatValue(0.25), "0.25"},
+		{"bool", protocol.BoolValue(false), "false"},
+		{"array quotes nested strings", protocol.ArrayValue([]protocol.Value{
+			protocol.IntValue(1), protocol.StringValue("a b"),
+		}), `[1,"a b"]`},
+		{"map is sorted", protocol.MapValue(map[string]protocol.Value{
+			"b": protocol.IntValue(2), "a": protocol.StringValue("x"),
+		}), `{"a":"x","b":2}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := protocol.Render(tt.value); got != tt.want {
+				t.Errorf("Render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRenderParsesBack is the round-trip that matters to clients: what GET prints must parse back to the same value.
+// Only a top-level string is exempt, deliberately, so plain text keeps rendering bare.
+func TestRenderParsesBack(t *testing.T) {
+	t.Parallel()
+
+	values := []protocol.Value{
+		protocol.IntValue(math.MinInt64),
+		protocol.IntValue(math.MaxInt64),
+		protocol.FloatValue(1),
+		protocol.FloatValue(-0.125),
+		protocol.FloatValue(math.MaxFloat64),
+		protocol.BoolValue(true),
+		protocol.ArrayValue([]protocol.Value{protocol.StringValue(`quote " and \ backslash`), protocol.FloatValue(2)}),
+		protocol.MapValue(map[string]protocol.Value{"k\n": protocol.ArrayValue([]protocol.Value{protocol.IntValue(0)})}),
+	}
+
+	for _, value := range values {
+		rendered := protocol.Render(value)
+		got, err := protocol.ParseLiteral(rendered)
+		if err != nil {
+			t.Fatalf("ParseLiteral(%q) error = %v", rendered, err)
+		}
+		if !equalValues(got, value) {
+			t.Errorf("ParseLiteral(Render(%v)) = %v", value, got)
+		}
+	}
+}
+
+func FuzzValueCodec(f *testing.F) {
+	seeds := []string{"", "42", "-0.0", "true", `"x"`, "[1,[2,[3]]]", `{"a":{"b":[1,2]}}`, "\x00\x01\x02", "hello",
+		// Found by this fuzzer while strings were stored untagged: these bytes are also a valid encoding of int 24, so the
+		// string read back as that int.
+		"\x010",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, literal string) {
+		value, err := protocol.ParseLiteral(literal)
+		if err != nil {
+			return // malformed structure, rejected before it can be stored
+		}
+		got := protocol.Decode(protocol.Encode(value))
+		if !equalValues(got, value) {
+			t.Fatalf("Decode(Encode(%v)) = %v, from literal %q", value, got, literal)
+		}
+	})
+}
+
+// equalValues compares decoded values; reflect.DeepEqual is not enough because a nil and an empty array or map are the
+// same value here.
+func equalValues(a, b protocol.Value) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case protocol.KindArray:
+		if len(a.Array) != len(b.Array) {
+			return false
+		}
+		for i := range a.Array {
+			if !equalValues(a.Array[i], b.Array[i]) {
+				return false
+			}
+		}
+		return true
+	case protocol.KindMap:
+		if len(a.Map) != len(b.Map) {
+			return false
+		}
+		for key, value := range a.Map {
+			other, ok := b.Map[key]
+			if !ok || !equalValues(value, other) {
+				return false
+			}
+		}
+		return true
+	case protocol.KindFloat:
+		return math.Float64bits(a.Float) == math.Float64bits(b.Float)
+	case protocol.KindString, protocol.KindInt, protocol.KindBool:
+		return reflect.DeepEqual(a, b)
+	default:
+		return reflect.DeepEqual(a, b)
+	}
+}

--- a/internal/replication/master.go
+++ b/internal/replication/master.go
@@ -14,14 +14,13 @@ import (
 	"github.com/OutOfStack/db/internal/wal"
 )
 
-// defaultHeartbeatInterval is how often the master emits a heartbeat frame to an
-// otherwise-idle standby so it can keep its lag estimate current.
+// defaultHeartbeatInterval is how often the master emits a heartbeat frame to an otherwise-idle standby so it can keep
+// its lag estimate current.
 const defaultHeartbeatInterval = time.Second
 
-// Master streams the WAL to connecting standbys. It combines historical segment
-// files on disk with a live fan-out from the WAL writer, so a standby resumes
-// from any LSN: a fresh or lagging standby catches up from segments (or a
-// snapshot when its position was already truncated), then tails live commits.
+// Master streams the WAL to connecting standbys. It combines historical segment files on disk with a live fan-out from
+// the WAL writer, so a standby resumes from any LSN: a fresh or lagging standby catches up from segments (or a snapshot
+// when its position was already truncated), then tails live commits.
 type Master struct {
 	writer   *wal.Writer
 	dir      string
@@ -32,8 +31,8 @@ type Master struct {
 	wg                sync.WaitGroup
 }
 
-// NewMaster starts listening for standby connections on listenAddr. writer and
-// dir are the server's live WAL writer and its data directory.
+// NewMaster starts listening for standby connections on listenAddr. writer and dir are the server's live WAL writer and
+// its data directory.
 func NewMaster(listenAddr string, writer *wal.Writer, dir string, logger *slog.Logger) (*Master, error) {
 	if logger == nil {
 		logger = slog.New(slog.DiscardHandler)
@@ -110,10 +109,9 @@ func (m *Master) stream(ctx context.Context, w *bufio.Writer, requestedLSN uint6
 	defer ticker.Stop()
 
 	for {
-		// Re-check retention every iteration: the snapshot loop may have pruned
-		// the records this standby still needs since the last pass, so a gap
-		// recovery must resync from a snapshot rather than ship a non-contiguous
-		// LSN that the standby would reject.
+		// Re-check retention every iteration: the snapshot loop may have pruned the records this standby still needs since
+		// the last pass, so a gap recovery must resync from a snapshot rather than ship a non-contiguous LSN that the standby
+		// would reject.
 		oldest, err := wal.OldestRecordLSN(m.dir, m.writer.LastLSN()+1)
 		if err != nil {
 			return err
@@ -143,9 +141,8 @@ func (m *Master) stream(ctx context.Context, w *bufio.Writer, requestedLSN uint6
 	}
 }
 
-// consumeLive streams live records until a gap is detected (a record was dropped
-// from the buffered fan-out), the context ends, or a write fails. A returned
-// gap==true tells the caller to re-scan disk segments to recover the missed
+// consumeLive streams live records until a gap is detected (a record was dropped from the buffered fan-out), the
+// context ends, or a write fails. A returned gap==true tells the caller to re-scan disk segments to recover the missed
 // records before resuming the live tail.
 func (m *Master) consumeLive(
 	ctx context.Context,
@@ -165,10 +162,9 @@ func (m *Master) consumeLive(
 			if err := w.Flush(); err != nil {
 				return false, err
 			}
-			// A record can be dropped from the buffered fan-out during a burst; if
-			// the burst then stops, no later record arrives to reveal the gap. The
-			// heartbeat is our backstop: whenever the committed tail is ahead of
-			// what we have shipped, recover the missing records from disk.
+			// A record can be dropped from the buffered fan-out during a burst; if the burst then stops, no later record arrives
+			// to reveal the gap. The heartbeat is our backstop: whenever the committed tail is ahead of what we have shipped,
+			// recover the missing records from disk.
 			if m.writer.LastLSN() >= *nextLSN {
 				return true, nil
 			}

--- a/internal/replication/protocol.go
+++ b/internal/replication/protocol.go
@@ -1,16 +1,14 @@
-// Package replication implements master/standby log shipping. The master streams
-// its write-ahead log to standbys, which persist and apply it in order and serve
-// reads. Replication is asynchronous: the master acknowledges clients without
+// Package replication implements master/standby log shipping. The master streams its write-ahead log to standbys, which
+// persist and apply it in order and serve reads. Replication is asynchronous: the master acknowledges clients without
 // waiting for standbys. Failover is manual via the PROMOTE admin command.
 //
-// The wire protocol runs on a dedicated master listener, separate from the
-// client-facing TCP server. A standby opens a connection and sends a single
-// RESP command handshake:
+// The wire protocol runs on a dedicated master listener, separate from the client-facing TCP server. A standby opens a
+// connection and sends a single RESP command handshake:
 //
 //	REPLICATE <lsn>
 //
-// where <lsn> is the highest LSN the standby has already applied. The master
-// then streams framed messages, each prefixed by a one-byte frame type:
+// where <lsn> is the highest LSN the standby has already applied. The master then streams framed messages, each
+// prefixed by a one-byte frame type:
 //
 //	'R' record    — a WAL record (wal.EncodeRecord bytes; self-delimiting)
 //	'S' snapshot  — resync payload: 8-byte LSN, 8-byte length, then that many
@@ -84,8 +82,8 @@ func writeHeartbeatFrame(w io.Writer, lastLSN uint64) error {
 	return err
 }
 
-// writeSnapshotFrame streams a snapshot blob of the given byte length. The body
-// is copied from src (typically a snapshot file) after the header.
+// writeSnapshotFrame streams a snapshot blob of the given byte length. The body is copied from src (typically a
+// snapshot file) after the header.
 func writeSnapshotFrame(w io.Writer, lsn uint64, length int64, src io.Reader) error {
 	if length < 0 {
 		return fmt.Errorf("negative snapshot length %d", length)

--- a/internal/replication/replication_test.go
+++ b/internal/replication/replication_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/replication"
 	"github.com/OutOfStack/db/internal/storage"
 	"github.com/OutOfStack/db/internal/wal"
@@ -36,8 +37,8 @@ func newNode(t *testing.T, dir string) *node {
 	}
 }
 
-// reopen recovers a node from its data directory, returning the recovered
-// applied LSN. It simulates a restart: load the snapshot, replay the WAL tail.
+// reopen recovers a node from its data directory, returning the recovered applied LSN. It simulates a restart: load the
+// snapshot, replay the WAL tail.
 func reopenNode(t *testing.T, dir string) (*node, uint64) {
 	t.Helper()
 	eng := engine.New()
@@ -126,11 +127,11 @@ func mustGet(t *testing.T, n *node, table, key string) string {
 	if err != nil {
 		t.Fatalf("standby Get %s/%s: %v", table, key, err)
 	}
-	return value
+	return protocol.Render(protocol.Decode(value))
 }
 
-// TestReplication_StreamsWrites verifies a standby receives and applies live
-// writes from the master and reports zero lag once caught up.
+// TestReplication_StreamsWrites verifies a standby receives and applies live writes from the master and reports zero
+// lag once caught up.
 func TestReplication_StreamsWrites(t *testing.T) {
 	t.Parallel()
 	master := newNode(t, t.TempDir())
@@ -161,8 +162,8 @@ func TestReplication_StreamsWrites(t *testing.T) {
 	waitFor(t, "lag to settle to zero", func() bool { return sb.Lag() == 0 })
 }
 
-// TestReplication_ResumesFromLSN verifies a restarted standby resumes from its
-// persisted LSN instead of re-fetching the whole log.
+// TestReplication_ResumesFromLSN verifies a restarted standby resumes from its persisted LSN instead of re-fetching the
+// whole log.
 func TestReplication_ResumesFromLSN(t *testing.T) {
 	t.Parallel()
 	master := newNode(t, t.TempDir())
@@ -203,8 +204,8 @@ func TestReplication_ResumesFromLSN(t *testing.T) {
 	}
 }
 
-// TestReplication_SnapshotResync verifies a standby far enough behind that the
-// master has pruned its WAL bootstraps from a shipped snapshot.
+// TestReplication_SnapshotResync verifies a standby far enough behind that the master has pruned its WAL bootstraps
+// from a shipped snapshot.
 func TestReplication_SnapshotResync(t *testing.T) {
 	t.Parallel()
 	master := newNode(t, t.TempDir())
@@ -214,8 +215,8 @@ func TestReplication_SnapshotResync(t *testing.T) {
 	set(t, master, "t", "k1", "v1")
 	set(t, master, "t", "k2", "v2")
 	set(t, master, "t", "k3", "v3")
-	// Snapshot + prune removes the WAL segments below the snapshot LSN, so a
-	// fresh standby cannot be served from segments alone.
+	// Snapshot + prune removes the WAL segments below the snapshot LSN, so a fresh standby cannot be served from segments
+	// alone.
 	snapshot(t, master)
 	set(t, master, "t", "k4", "v4")
 

--- a/internal/replication/standby.go
+++ b/internal/replication/standby.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,13 +12,11 @@ import (
 	"time"
 
 	"github.com/OutOfStack/db/internal/engine"
-	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/wal"
 )
 
-// Applier persists and applies replicated records. It is satisfied by
-// *storage.Storage, which routes replicated writes through the same lock as
-// snapshots so a snapshot never captures a state ahead of the engine.
+// Applier persists and applies replicated records. It is satisfied by *storage.Storage, which routes replicated writes
+// through the same lock as snapshots so a snapshot never captures a state ahead of the engine.
 type Applier interface {
 	// ApplyReplicated persists a record and applies it to the engine.
 	ApplyReplicated(ctx context.Context, record wal.Record) error
@@ -30,17 +27,11 @@ type Applier interface {
 // defaultReconnectBackoff is the pause between replication reconnect attempts.
 const defaultReconnectBackoff = time.Second
 
-// maxSnapshotRecordSize bounds a single decoded SET command inside a snapshot
-// stream, mirroring the WAL's per-record limit. maxSnapshotBytes bounds the whole
-// snapshot blob so a malformed length cannot drive an unbounded read.
-const (
-	maxSnapshotRecordSize = 64 << 20
-	maxSnapshotBytes      = 1 << 40
-)
+// maxSnapshotBytes bounds the snapshot blob so a malformed length cannot drive an unbounded read.
+const maxSnapshotBytes = 1 << 40
 
-// Standby connects to a master, persists the streamed WAL to its own log, and
-// applies it to its engine in order. It reconnects with backoff and tracks the
-// applied LSN and lag so a promoted standby has a complete, contiguous log.
+// Standby connects to a master, persists the streamed WAL to its own log, and applies it to its engine in order. It
+// reconnects with backoff and tracks the applied LSN and lag so a promoted standby has a complete, contiguous log.
 type Standby struct {
 	masterAddr string
 	applier    Applier
@@ -57,9 +48,8 @@ type Standby struct {
 	done   chan struct{}
 }
 
-// NewStandby creates a standby that replicates from masterAddr into applier (the
-// server's storage). dir is the WAL/snapshot directory. appliedLSN is the last
-// LSN already durable, used as the resume point in the first handshake.
+// NewStandby creates a standby that replicates from masterAddr into applier (the server's storage). dir is the
+// WAL/snapshot directory. appliedLSN is the last LSN already durable, used as the resume point in the first handshake.
 func NewStandby(
 	masterAddr string,
 	applier Applier,
@@ -106,9 +96,8 @@ func (s *Standby) Stop() {
 // AppliedLSN returns the highest LSN this standby has persisted and applied.
 func (s *Standby) AppliedLSN() uint64 { return s.appliedLSN.Load() }
 
-// Lag returns how many LSNs the standby trails the master by, based on the
-// latest record or heartbeat seen. It is a best-effort, eventually-consistent
-// estimate given asynchronous replication.
+// Lag returns how many LSNs the standby trails the master by, based on the latest record or heartbeat seen. It is a
+// best-effort, eventually-consistent estimate given asynchronous replication.
 func (s *Standby) Lag() uint64 {
 	master := s.masterLSN.Load()
 	applied := s.appliedLSN.Load()
@@ -201,9 +190,8 @@ func (s *Standby) applyRecord(ctx context.Context, record wal.Record) error {
 	return nil
 }
 
-// applySnapshot handles a resync: the standby's log was truncated past its
-// position, so the master shipped a full snapshot. The standby persists it,
-// resets its WAL to the snapshot LSN, and replaces its engine state.
+// applySnapshot handles a resync: the standby's log was truncated past its position, so the master shipped a full
+// snapshot. The standby persists it, resets its WAL to the snapshot LSN, and replaces its engine state.
 func (s *Standby) applySnapshot(ctx context.Context, reader *bufio.Reader) error {
 	lsn, err := readUint64(reader)
 	if err != nil {
@@ -246,20 +234,11 @@ func (s *Standby) observeMasterLSN(lsn uint64) {
 func parseSnapshot(reader *bufio.Reader, length int64) ([]engine.Entry, error) {
 	limited := bufio.NewReader(io.LimitReader(reader, length))
 	var entries []engine.Entry
-	for {
-		command, args, err := protocol.ReadCommand(limited, maxSnapshotRecordSize)
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		if command != wal.CommandSet || len(args) != 3 {
-			return nil, fmt.Errorf("invalid snapshot record %q with %d args", command, len(args))
-		}
-		entries = append(entries, engine.Entry{Table: args[0], Key: args[1], Value: args[2]})
-	}
-	return entries, nil
+	err := wal.ReadSnapshot(limited, func(table, key, value string) error {
+		entries = append(entries, engine.Entry{Table: table, Key: key, Value: value})
+		return nil
+	})
+	return entries, err
 }
 
 func readUint64(reader *bufio.Reader) (uint64, error) {

--- a/internal/storage/mocks/storage.go
+++ b/internal/storage/mocks/storage.go
@@ -151,6 +151,20 @@ func (mr *MockEngineMockRecorder) Tables(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tables", reflect.TypeOf((*MockEngine)(nil).Tables), ctx)
 }
 
+// Update mocks base method.
+func (m *MockEngine) Update(ctx context.Context, table, key string, fn func(string, bool) (string, error)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", ctx, table, key, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockEngineMockRecorder) Update(ctx, table, key, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockEngine)(nil).Update), ctx, table, key, fn)
+}
+
 // MockWAL is a mock of WAL interface.
 type MockWAL struct {
 	ctrl     *gomock.Controller

--- a/internal/storage/ops.go
+++ b/internal/storage/ops.go
@@ -1,0 +1,187 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/wal"
+)
+
+var (
+	// ErrWrongType is returned when a typed operation meets a value of another type. It reaches the client as "ERR wrong
+	// type: ...".
+	ErrWrongType = errors.New("wrong type")
+	// ErrOverflow ErrNotFinite and ErrTooDeep are the other ways the command semantics refuse a value: arithmetic that
+	// leaves the int64 range or the finite floats, and nesting the codec could not read back.
+	ErrOverflow  = errors.New("increment would overflow int64")
+	ErrNotFinite = errors.New("increment result is not a finite number")
+	ErrTooDeep   = errors.New("value nests too deep to be stored")
+)
+
+const replyOK = "OK"
+
+// Apply mutates eng for a WAL command. Live writes, recovery, and replication share this path; value arguments are
+// already encoded.
+func Apply(ctx context.Context, eng Engine, cmd string, args []string) (protocol.Reply, error) {
+	switch cmd {
+	case wal.CommandSet:
+		if err := eng.Set(ctx, args[0], args[1], args[2]); err != nil {
+			return protocol.Reply{}, err
+		}
+		return protocol.SimpleString(replyOK), nil
+	case wal.CommandDel:
+		if err := eng.Del(ctx, args[0], args[1]); err != nil {
+			return protocol.Reply{}, err
+		}
+		return protocol.SimpleString(replyOK), nil
+	case wal.CommandIncr:
+		return applyIncr(ctx, eng, args)
+	case wal.CommandAppend:
+		return applyAppend(ctx, eng, args)
+	case wal.CommandHSet:
+		return applyHSet(ctx, eng, args)
+	default:
+		return protocol.Reply{}, fmt.Errorf("unsupported command %q", cmd)
+	}
+}
+
+// ApplyReplay treats deterministic no-ops as success so they do not abort recovery or replication.
+func ApplyReplay(ctx context.Context, eng Engine, cmd string, args []string) error {
+	_, err := Apply(ctx, eng, cmd, args)
+	if rejected(err) {
+		return nil
+	}
+	return err
+}
+
+// rejected reports whether err is the command semantics refusing a value rather than storage failing. A refusal is
+// deterministic — the record was logged before it failed, and replaying it fails identically — so recovery and
+// replication have to treat it as the no-op it already was. A storage failure must still stop them.
+func rejected(err error) bool {
+	return errors.Is(err, engine.ErrNotFound) ||
+		errors.Is(err, ErrWrongType) ||
+		errors.Is(err, ErrOverflow) ||
+		errors.Is(err, ErrNotFinite) ||
+		errors.Is(err, ErrTooDeep)
+}
+
+func applyIncr(ctx context.Context, eng Engine, args []string) (protocol.Reply, error) {
+	delta := protocol.Decode(args[2])
+	var result protocol.Value
+	err := eng.Update(ctx, args[0], args[1], func(old string, exists bool) (string, error) {
+		current := protocol.IntValue(0)
+		if exists {
+			current = protocol.Decode(old)
+		}
+		sum, aErr := add(current, delta)
+		if aErr != nil {
+			return "", aErr
+		}
+		result = sum
+		return protocol.Encode(sum), nil
+	})
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.BulkString(protocol.Render(result)), nil
+}
+
+func applyAppend(ctx context.Context, eng Engine, args []string) (protocol.Reply, error) {
+	element := protocol.Decode(args[2])
+	var length int
+	err := eng.Update(ctx, args[0], args[1], func(old string, exists bool) (string, error) {
+		var items []protocol.Value
+		if exists {
+			current := protocol.Decode(old)
+			if current.Kind != protocol.KindArray {
+				return "", wrongType(wal.CommandAppend, current.Kind, protocol.KindArray)
+			}
+			items = current.Array
+		}
+		items = append(items, element)
+		length = len(items)
+		return encodeStorable(protocol.ArrayValue(items))
+	})
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.Integer(int64(length)), nil
+}
+
+func applyHSet(ctx context.Context, eng Engine, args []string) (protocol.Reply, error) {
+	value := protocol.Decode(args[3])
+	err := eng.Update(ctx, args[0], args[1], func(old string, exists bool) (string, error) {
+		fields := make(map[string]protocol.Value, 1)
+		if exists {
+			current := protocol.Decode(old)
+			if current.Kind != protocol.KindMap {
+				return "", wrongType(wal.CommandHSet, current.Kind, protocol.KindMap)
+			}
+			fields = current.Map
+		}
+		fields[args[2]] = value
+		return encodeStorable(protocol.MapValue(fields))
+	})
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.SimpleString(replyOK), nil
+}
+
+// encodeStorable encodes a value only if it reads back as the value it was. APPEND and HSET wrap their argument in one
+// more level of nesting, which can push the result past the depth the codec will decode; storing it would turn the key
+// into an opaque string on the very next read.
+func encodeStorable(v protocol.Value) (string, error) {
+	encoded := protocol.Encode(v)
+	if protocol.Decode(encoded).Kind != v.Kind {
+		return "", ErrTooDeep
+	}
+	return encoded, nil
+}
+
+// add sums two numbers, keeping int arithmetic exact: int + int stays an int unless it would overflow, and any float
+// operand makes the result a float.
+func add(current, delta protocol.Value) (protocol.Value, error) {
+	if !numeric(current) {
+		return protocol.Value{}, wrongType(wal.CommandIncr, current.Kind, protocol.KindInt)
+	}
+	if !numeric(delta) {
+		return protocol.Value{}, wrongType(wal.CommandIncr, delta.Kind, protocol.KindInt)
+	}
+	if current.Kind == protocol.KindInt && delta.Kind == protocol.KindInt {
+		sum := current.Int + delta.Int
+		// Signed overflow wraps silently in Go: a counter that would pass math.MaxInt64 must fail loudly instead of turning
+		// negative.
+		if (delta.Int > 0 && sum < current.Int) || (delta.Int < 0 && sum > current.Int) {
+			return protocol.Value{}, ErrOverflow
+		}
+		return protocol.IntValue(sum), nil
+	}
+	sum := asFloat(current) + asFloat(delta)
+	if math.IsNaN(sum) || math.IsInf(sum, 0) {
+		return protocol.Value{}, ErrNotFinite
+	}
+	return protocol.FloatValue(sum), nil
+}
+
+func numeric(v protocol.Value) bool {
+	return v.Kind == protocol.KindInt || v.Kind == protocol.KindFloat
+}
+
+func asFloat(v protocol.Value) float64 {
+	if v.Kind == protocol.KindInt {
+		return float64(v.Int)
+	}
+	return v.Float
+}
+
+func wrongType(cmd string, got, want protocol.Kind) error {
+	if cmd == wal.CommandIncr {
+		return fmt.Errorf("%w: key holds %s, %s requires int or float", ErrWrongType, got, cmd)
+	}
+	return fmt.Errorf("%w: key holds %s, %s requires %s", ErrWrongType, got, cmd, want)
+}

--- a/internal/storage/ops.go
+++ b/internal/storage/ops.go
@@ -11,15 +11,21 @@ import (
 	"github.com/OutOfStack/db/internal/wal"
 )
 
+// rejection is the type of every error with which the command semantics refuse a value. rejected() classifies by this
+// type, so a newly added refusal cannot be forgotten there — forgetting would abort recovery on replay (see rejected).
+type rejection string
+
+func (r rejection) Error() string { return string(r) }
+
 var (
 	// ErrWrongType is returned when a typed operation meets a value of another type. It reaches the client as "ERR wrong
 	// type: ...".
-	ErrWrongType = errors.New("wrong type")
+	ErrWrongType = rejection("wrong type")
 	// ErrOverflow ErrNotFinite and ErrTooDeep are the other ways the command semantics refuse a value: arithmetic that
 	// leaves the int64 range or the finite floats, and nesting the codec could not read back.
-	ErrOverflow  = errors.New("increment would overflow int64")
-	ErrNotFinite = errors.New("increment result is not a finite number")
-	ErrTooDeep   = errors.New("value nests too deep to be stored")
+	ErrOverflow  = rejection("increment would overflow int64")
+	ErrNotFinite = rejection("increment result is not a finite number")
+	ErrTooDeep   = rejection("value nests too deep to be stored")
 )
 
 const replyOK = "OK"
@@ -62,11 +68,8 @@ func ApplyReplay(ctx context.Context, eng Engine, cmd string, args []string) err
 // deterministic — the record was logged before it failed, and replaying it fails identically — so recovery and
 // replication have to treat it as the no-op it already was. A storage failure must still stop them.
 func rejected(err error) bool {
-	return errors.Is(err, engine.ErrNotFound) ||
-		errors.Is(err, ErrWrongType) ||
-		errors.Is(err, ErrOverflow) ||
-		errors.Is(err, ErrNotFinite) ||
-		errors.Is(err, ErrTooDeep)
+	var r rejection
+	return errors.Is(err, engine.ErrNotFound) || errors.As(err, &r)
 }
 
 func applyIncr(ctx context.Context, eng Engine, args []string) (protocol.Reply, error) {
@@ -98,7 +101,7 @@ func applyAppend(ctx context.Context, eng Engine, args []string) (protocol.Reply
 		if exists {
 			current := protocol.Decode(old)
 			if current.Kind != protocol.KindArray {
-				return "", wrongType(wal.CommandAppend, current.Kind, protocol.KindArray)
+				return "", wrongType(wal.CommandAppend, current.Kind, protocol.KindArray.String())
 			}
 			items = current.Array
 		}
@@ -119,7 +122,7 @@ func applyHSet(ctx context.Context, eng Engine, args []string) (protocol.Reply, 
 		if exists {
 			current := protocol.Decode(old)
 			if current.Kind != protocol.KindMap {
-				return "", wrongType(wal.CommandHSet, current.Kind, protocol.KindMap)
+				return "", wrongType(wal.CommandHSet, current.Kind, protocol.KindMap.String())
 			}
 			fields = current.Map
 		}
@@ -132,25 +135,24 @@ func applyHSet(ctx context.Context, eng Engine, args []string) (protocol.Reply, 
 	return protocol.SimpleString(replyOK), nil
 }
 
-// encodeStorable encodes a value only if it reads back as the value it was. APPEND and HSET wrap their argument in one
-// more level of nesting, which can push the result past the depth the codec will decode; storing it would turn the key
-// into an opaque string on the very next read.
+// encodeStorable encodes a value only if the codec will read it back. APPEND and HSET wrap their argument in one more
+// level of nesting, which can push the result past the depth the codec will decode; storing it would turn the key into
+// an opaque string on the very next read.
 func encodeStorable(v protocol.Value) (string, error) {
-	encoded := protocol.Encode(v)
-	if protocol.Decode(encoded).Kind != v.Kind {
+	if protocol.TooDeep(v) {
 		return "", ErrTooDeep
 	}
-	return encoded, nil
+	return protocol.Encode(v), nil
 }
 
 // add sums two numbers, keeping int arithmetic exact: int + int stays an int unless it would overflow, and any float
 // operand makes the result a float.
 func add(current, delta protocol.Value) (protocol.Value, error) {
 	if !numeric(current) {
-		return protocol.Value{}, wrongType(wal.CommandIncr, current.Kind, protocol.KindInt)
+		return protocol.Value{}, wrongType(wal.CommandIncr, current.Kind, "int or float")
 	}
 	if !numeric(delta) {
-		return protocol.Value{}, wrongType(wal.CommandIncr, delta.Kind, protocol.KindInt)
+		return protocol.Value{}, wrongType(wal.CommandIncr, delta.Kind, "int or float")
 	}
 	if current.Kind == protocol.KindInt && delta.Kind == protocol.KindInt {
 		sum := current.Int + delta.Int
@@ -179,9 +181,6 @@ func asFloat(v protocol.Value) float64 {
 	return v.Float
 }
 
-func wrongType(cmd string, got, want protocol.Kind) error {
-	if cmd == wal.CommandIncr {
-		return fmt.Errorf("%w: key holds %s, %s requires int or float", ErrWrongType, got, cmd)
-	}
+func wrongType(cmd string, got protocol.Kind, want string) error {
 	return fmt.Errorf("%w: key holds %s, %s requires %s", ErrWrongType, got, cmd, want)
 }

--- a/internal/storage/ops_test.go
+++ b/internal/storage/ops_test.go
@@ -1,0 +1,307 @@
+package storage_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/engine"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/storage"
+	"github.com/OutOfStack/db/internal/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func exec(t *testing.T, store *storage.Storage, cmd string, args ...string) protocol.Reply {
+	t.Helper()
+	reply, err := store.Execute(context.Background(), cmd, args)
+	require.NoError(t, err, "%s %v", cmd, args)
+	return reply
+}
+
+func execErr(t *testing.T, store *storage.Storage, cmd string, args ...string) error {
+	t.Helper()
+	_, err := store.Execute(context.Background(), cmd, args)
+	require.Error(t, err, "%s %v", cmd, args)
+	return err
+}
+
+func TestTypedSetGetType(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	tests := []struct {
+		literal  string
+		wantType string
+		wantGet  string
+	}{
+		{"vlad", "string", "vlad"},
+		{`"42"`, "string", "42"},
+		{"hello world", "string", "hello world"},
+		{"42", "int", "42"},
+		{"-7", "int", "-7"},
+		{"42.5", "float", "42.5"},
+		{"1", "int", "1"},
+		{"true", "bool", "true"},
+		{"[1,2,3]", "array", "[1,2,3]"},
+		{`{"a":1,"b":"x"}`, "map", `{"a":1,"b":"x"}`},
+	}
+
+	for i, tt := range tests {
+		key := fmt.Sprintf("k%d", i)
+		exec(t, store, "SET", "t", key, tt.literal)
+		assert.Equal(t, protocol.SimpleString(tt.wantType), exec(t, store, "TYPE", "t", key), "TYPE of %s", tt.literal)
+		assert.Equal(t, protocol.BulkString(tt.wantGet), exec(t, store, "GET", "t", key), "GET of %s", tt.literal)
+	}
+}
+
+func TestSetRejectsMalformedLiteral(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	err := execErr(t, store, "SET", "t", "k", `{"a":`)
+	assert.Contains(t, err.Error(), "invalid value literal")
+	_, getErr := store.Execute(context.Background(), "GET", []string{"t", "k"})
+	require.ErrorIs(t, getErr, storage.ErrNotFound)
+}
+
+func TestIncr(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	assert.Equal(t, protocol.BulkString("1"), exec(t, store, "INCR", "t", "hits"))
+	assert.Equal(t, protocol.BulkString("11"), exec(t, store, "INCR", "t", "hits", "10"))
+	assert.Equal(t, protocol.BulkString("9"), exec(t, store, "INCR", "t", "hits", "-2"))
+	assert.Equal(t, protocol.SimpleString("int"), exec(t, store, "TYPE", "t", "hits"))
+
+	assert.Equal(t, protocol.BulkString("9.5"), exec(t, store, "INCR", "t", "hits", "0.5"))
+	assert.Equal(t, protocol.SimpleString("float"), exec(t, store, "TYPE", "t", "hits"))
+
+	assert.Equal(t, protocol.BulkString("10.5"), exec(t, store, "INCR", "t", "hits", "1"))
+
+	exec(t, store, "SET", "t", "big", "9223372036854775807")
+	require.ErrorContains(t, execErr(t, store, "INCR", "t", "big"), "overflow")
+	assert.Equal(t, protocol.BulkString("9223372036854775807"), exec(t, store, "GET", "t", "big"),
+		"a rejected increment must not change the value")
+
+	assert.ErrorContains(t, execErr(t, store, "INCR", "t", "hits", "abc"), "must be int or float")
+}
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	assert.Equal(t, protocol.Integer(1), exec(t, store, "APPEND", "t", "list", "1"))
+	assert.Equal(t, protocol.Integer(2), exec(t, store, "APPEND", "t", "list", "two"))
+	assert.Equal(t, protocol.Integer(3), exec(t, store, "APPEND", "t", "list", `{"a":true}`))
+
+	assert.Equal(t, protocol.SimpleString("array"), exec(t, store, "TYPE", "t", "list"))
+	assert.Equal(t, protocol.BulkString(`[1,"two",{"a":true}]`), exec(t, store, "GET", "t", "list"))
+}
+
+func TestHSetHGet(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	exec(t, store, "HSET", "t", "user", "name", "vlad")
+	exec(t, store, "HSET", "t", "user", "age", "42")
+	exec(t, store, "HSET", "t", "user", "age", "43") // overwrite
+
+	assert.Equal(t, protocol.SimpleString("map"), exec(t, store, "TYPE", "t", "user"))
+	assert.Equal(t, protocol.BulkString("vlad"), exec(t, store, "HGET", "t", "user", "name"))
+	assert.Equal(t, protocol.BulkString("43"), exec(t, store, "HGET", "t", "user", "age"))
+	assert.Equal(t, protocol.BulkString(`{"age":43,"name":"vlad"}`), exec(t, store, "GET", "t", "user"))
+
+	_, err := store.Execute(context.Background(), "HGET", []string{"t", "user", "nope"})
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestWrongTypeMatrix(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{
+		"string": "vlad",
+		"int":    "42",
+		"float":  "42.5",
+		"bool":   "true",
+		"array":  "[1]",
+		"map":    `{"a":1}`,
+	}
+	commands := []struct {
+		cmd    string
+		args   []string
+		accept []string
+	}{
+		{"INCR", nil, []string{"int", "float"}},
+		{"APPEND", []string{"x"}, []string{"array"}},
+		{"HSET", []string{"f", "x"}, []string{"map"}},
+		{"HGET", []string{"f"}, []string{"map"}},
+	}
+
+	for _, command := range commands {
+		for kind, literal := range values {
+			t.Run(command.cmd+"/"+kind, func(t *testing.T) {
+				t.Parallel()
+				store := storage.New(engine.New())
+				exec(t, store, "SET", "t", "k", literal)
+
+				args := append([]string{"t", "k"}, command.args...)
+				_, err := store.Execute(context.Background(), command.cmd, args)
+				if slices.Contains(command.accept, kind) {
+					if err != nil {
+						require.ErrorIs(t, err, storage.ErrNotFound)
+					}
+					return
+				}
+				require.ErrorIs(t, err, storage.ErrWrongType)
+				assert.Contains(t, err.Error(), "key holds "+kind)
+				assert.Contains(t, err.Error(), command.cmd+" requires")
+			})
+		}
+	}
+}
+
+func TestConcurrentIncrIsAtomic(t *testing.T) {
+	t.Parallel()
+	store := storage.New(engine.New())
+
+	const n = 200
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			_, err := store.Execute(context.Background(), "INCR", []string{"t", "hits"})
+			assert.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, protocol.BulkString(strconv.Itoa(n)), exec(t, store, "GET", "t", "hits"))
+}
+
+func TestReplayReproducesState(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var lsn uint64
+	var records []wal.Record
+	log := &fakeWAL{append: func(_ context.Context, command string, args []string) (uint64, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		lsn++
+		records = append(records, wal.Record{LSN: lsn, Command: command, Args: args})
+		return lsn, nil
+	}}
+
+	live := engine.New()
+	store := storage.New(live, storage.WithWAL(log))
+
+	exec(t, store, "SET", "t", "name", "vlad")
+	exec(t, store, "SET", "t", "cfg", `{"a":[1,2]}`)
+	exec(t, store, "SET", "t", "gone", "1")
+	exec(t, store, "DEL", "t", "gone")
+	exec(t, store, "INCR", "t", "hits", "5")
+	exec(t, store, "INCR", "t", "hits", "0.5")
+	exec(t, store, "APPEND", "t", "list", "x")
+	exec(t, store, "APPEND", "t", "list", "2")
+	exec(t, store, "HSET", "t", "user", "name", "vlad")
+	exec(t, store, "HSET", "t", "user", "n", "1")
+	exec(t, store, "SET", "t", "big", "9223372036854775807")
+	// Every mutation is logged before it is applied, so each of these failures is already durable when it fails. Replay
+	// has to reproduce the failure, not abort on it.
+	execErr(t, store, "INCR", "t", "name")              // wrong type
+	execErr(t, store, "DEL", "t", "missing")            // missing key
+	execErr(t, store, "INCR", "t", "big")               // int64 overflow
+	execErr(t, store, "APPEND", "t", "deep", tooDeep()) // nesting past what decodes
+	require.Len(t, records, 15, "every mutation is logged, including the failing ones")
+
+	replayed := engine.New()
+	for _, record := range records {
+		encoded, err := wal.EncodeRecord(record)
+		require.NoError(t, err, "record %d", record.LSN)
+		decoded, err := wal.ReadRecord(bufio.NewReader(bytes.NewReader(encoded)))
+		require.NoError(t, err, "record %d", record.LSN)
+		require.NoError(t, storage.ApplyReplay(context.Background(), replayed, decoded.Command, decoded.Args))
+	}
+
+	assert.Equal(t, snapshot(live), snapshot(replayed))
+}
+
+func snapshot(source storage.SnapshotSource) map[string]string {
+	state := make(map[string]string)
+	source.Range(func(table, key, value string) bool {
+		state[table+"/"+key] = value
+		return true
+	})
+	return state
+}
+
+// tooDeep returns a literal nested as deeply as the codec accepts: storing it is fine, but wrapping it in one more
+// array or map is not.
+func tooDeep() string {
+	const depth = 64
+	return strings.Repeat("[", depth) + "1" + strings.Repeat("]", depth)
+}
+
+// TestAppendAndHSetRejectUnreadableNesting pins the rule that nothing is stored that cannot be read back: APPEND and
+// HSET add a level of nesting, and the value that would exceed the codec's depth is refused instead of silently turning
+// the key into an opaque string.
+func TestAppendAndHSetRejectUnreadableNesting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("append", func(t *testing.T) {
+		t.Parallel()
+		store := storage.New(engine.New())
+
+		exec(t, store, "APPEND", "t", "list", "keeper")
+		err := execErr(t, store, "APPEND", "t", "list", tooDeep())
+		require.ErrorIs(t, err, storage.ErrTooDeep)
+		// The refused append left the array exactly as it was.
+		assert.Equal(t, protocol.SimpleString("array"), exec(t, store, "TYPE", "t", "list"))
+		assert.Equal(t, protocol.BulkString(`["keeper"]`), exec(t, store, "GET", "t", "list"))
+	})
+
+	t.Run("hset", func(t *testing.T) {
+		t.Parallel()
+		store := storage.New(engine.New())
+
+		exec(t, store, "HSET", "t", "user", "name", "vlad")
+		err := execErr(t, store, "HSET", "t", "user", "deep", tooDeep())
+		require.ErrorIs(t, err, storage.ErrTooDeep)
+		assert.Equal(t, protocol.SimpleString("map"), exec(t, store, "TYPE", "t", "user"))
+		assert.Equal(t, protocol.BulkString(`{"name":"vlad"}`), exec(t, store, "GET", "t", "user"))
+	})
+
+	t.Run("a value at the limit still stores", func(t *testing.T) {
+		t.Parallel()
+		store := storage.New(engine.New())
+
+		exec(t, store, "SET", "t", "k", tooDeep())
+		assert.Equal(t, protocol.SimpleString("array"), exec(t, store, "TYPE", "t", "k"))
+	})
+}
+
+// TestIncrOverflowReplaysAsNoOp is the recovery half of the overflow guard: the failing INCR is already in the log, so
+// replaying it must leave the counter at its ceiling rather than abort recovery.
+func TestIncrOverflowReplaysAsNoOp(t *testing.T) {
+	t.Parallel()
+
+	recovered := engine.New()
+	records := []wal.Record{
+		{LSN: 1, Command: wal.CommandSet, Args: []string{"t", "big", protocol.Encode(protocol.IntValue(math.MaxInt64))}},
+		{LSN: 2, Command: wal.CommandIncr, Args: []string{"t", "big", protocol.Encode(protocol.IntValue(1))}},
+	}
+	for _, record := range records {
+		require.NoError(t, storage.ApplyReplay(context.Background(), recovered, record.Command, record.Args))
+	}
+
+	store := storage.New(recovered)
+	assert.Equal(t, protocol.BulkString("9223372036854775807"), exec(t, store, "GET", "t", "big"))
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -166,7 +167,7 @@ func captureState(source SnapshotSource) captured {
 func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (protocol.Reply, error) {
 	switch cmd {
 	case "SET":
-		return s.set(ctx, args)
+		return s.literalMutation(ctx, wal.CommandSet, args)
 	case "GET":
 		return s.get(ctx, args)
 	case "DEL":
@@ -174,9 +175,9 @@ func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (proto
 	case "INCR":
 		return s.incr(ctx, args)
 	case "APPEND":
-		return s.appendItem(ctx, args)
+		return s.literalMutation(ctx, wal.CommandAppend, args)
 	case "HSET":
-		return s.hset(ctx, args)
+		return s.literalMutation(ctx, wal.CommandHSet, args)
 	case "HGET":
 		return s.hget(ctx, args)
 	case "TYPE":
@@ -192,12 +193,15 @@ func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (proto
 	}
 }
 
-func (s *Storage) set(ctx context.Context, args []string) (protocol.Reply, error) {
-	value, err := protocol.ParseLiteral(args[2])
+// literalMutation logs a mutation whose last argument is a value literal (SET, APPEND, HSET), replacing the literal
+// with its encoding.
+func (s *Storage) literalMutation(ctx context.Context, cmd string, args []string) (protocol.Reply, error) {
+	last := len(args) - 1
+	value, err := protocol.ParseLiteral(args[last])
 	if err != nil {
 		return protocol.Reply{}, err
 	}
-	return s.mutation(ctx, wal.CommandSet, []string{args[0], args[1], protocol.Encode(value)})
+	return s.mutation(ctx, cmd, append(slices.Clone(args[:last]), protocol.Encode(value)))
 }
 
 func (s *Storage) get(ctx context.Context, args []string) (protocol.Reply, error) {
@@ -223,22 +227,6 @@ func (s *Storage) incr(ctx context.Context, args []string) (protocol.Reply, erro
 	return s.mutation(ctx, wal.CommandIncr, []string{args[0], args[1], protocol.Encode(delta)})
 }
 
-func (s *Storage) appendItem(ctx context.Context, args []string) (protocol.Reply, error) {
-	element, err := protocol.ParseLiteral(args[2])
-	if err != nil {
-		return protocol.Reply{}, err
-	}
-	return s.mutation(ctx, wal.CommandAppend, []string{args[0], args[1], protocol.Encode(element)})
-}
-
-func (s *Storage) hset(ctx context.Context, args []string) (protocol.Reply, error) {
-	value, err := protocol.ParseLiteral(args[3])
-	if err != nil {
-		return protocol.Reply{}, err
-	}
-	return s.mutation(ctx, wal.CommandHSet, []string{args[0], args[1], args[2], protocol.Encode(value)})
-}
-
 func (s *Storage) hget(ctx context.Context, args []string) (protocol.Reply, error) {
 	stored, err := s.load(ctx, args[0], args[1])
 	if err != nil {
@@ -246,7 +234,7 @@ func (s *Storage) hget(ctx context.Context, args []string) (protocol.Reply, erro
 	}
 	value := protocol.Decode(stored)
 	if value.Kind != protocol.KindMap {
-		return protocol.Reply{}, wrongType("HGET", value.Kind, protocol.KindMap)
+		return protocol.Reply{}, wrongType("HGET", value.Kind, protocol.KindMap.String())
 	}
 	field, ok := value.Map[args[2]]
 	if !ok {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -60,8 +60,8 @@ func WithWAL(log WAL) Option {
 	return func(storage *Storage) { storage.wal = log }
 }
 
-// WithReadOnly starts the storage in read-only mode, rejecting SET/DEL with ErrReadOnly. Replication standbys use it;
-// Promote lifts it.
+// WithReadOnly starts the storage in read-only mode, rejecting every mutating command with ErrReadOnly. Replication
+// standbys use it; Promote lifts it.
 func WithReadOnly(readOnly bool) Option {
 	return func(storage *Storage) { storage.readOnly.Store(readOnly) }
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -14,9 +15,8 @@ import (
 var (
 	// ErrNotFound is the error returned when a key is not found
 	ErrNotFound = errors.New("not found")
-	// ErrReadOnly is returned for mutating commands on a replication standby.
-	// It maps to the "ERR readonly" wire reply so a pool client can re-route
-	// the write to a master.
+	// ErrReadOnly is returned for mutating commands on a replication standby. It maps to the "ERR readonly" wire reply so
+	// a pool client can re-route the write to a master.
 	ErrReadOnly = errors.New("readonly")
 )
 
@@ -25,6 +25,9 @@ type Engine interface {
 	Set(ctx context.Context, table, key, value string) error
 	Get(ctx context.Context, table, key string) (string, error)
 	Del(ctx context.Context, table, key string) error
+	// Update atomically replaces a value with the result of fn, which sees the current value and whether it exists. It is
+	// the read-modify-write primitive behind INCR, APPEND and HSET.
+	Update(ctx context.Context, table, key string, fn func(old string, exists bool) (string, error)) error
 	Tables(ctx context.Context) []string
 	TableExists(ctx context.Context, table string) bool
 	Keys(ctx context.Context, table string) []string
@@ -57,8 +60,8 @@ func WithWAL(log WAL) Option {
 	return func(storage *Storage) { storage.wal = log }
 }
 
-// WithReadOnly starts the storage in read-only mode, rejecting SET/DEL with
-// ErrReadOnly. Replication standbys use it; Promote lifts it.
+// WithReadOnly starts the storage in read-only mode, rejecting SET/DEL with ErrReadOnly. Replication standbys use it;
+// Promote lifts it.
 func WithReadOnly(readOnly bool) Option {
 	return func(storage *Storage) { storage.readOnly.Store(readOnly) }
 }
@@ -67,9 +70,8 @@ func WithReadOnly(readOnly bool) Option {
 type Storage struct {
 	engine Engine
 	wal    WAL
-	// mu serializes snapshots (write lock) against mutations (read lock); many
-	// mutations may run concurrently so their WAL appends can be group-committed.
-	// It also serializes Promote's gate swap against in-flight mutations.
+	// mu serializes snapshots (write lock) against mutations (read lock); many mutations may run concurrently so their WAL
+	// appends can be group-committed. It also serializes Promote's gate swap against in-flight mutations.
 	mu       sync.RWMutex
 	gate     *applyGate
 	readOnly atomic.Bool
@@ -87,9 +89,9 @@ func New(engine Engine, options ...Option) *Storage {
 	return storage
 }
 
-// applyGate applies engine mutations in strictly increasing LSN order. Concurrent
-// mutations append to the WAL in parallel (enabling group commit) but must land in
-// the engine in the same order the WAL assigned, so replay reproduces the state.
+// applyGate applies engine mutations in strictly increasing LSN order. Concurrent mutations append to the WAL in
+// parallel (enabling group commit) but must land in the engine in the same order the WAL assigned, so replay reproduces
+// the state.
 type applyGate struct {
 	mu   sync.Mutex
 	cond *sync.Cond
@@ -102,9 +104,8 @@ func newApplyGate(next uint64) *applyGate {
 	return gate
 }
 
-// run waits until lsn is the next LSN to apply, runs fn, then releases the next
-// LSN. The gate always advances: the WAL record is already durable, so a benign
-// engine error (e.g. deleting a missing key) must not stall later mutations.
+// run waits until lsn is the next LSN to apply, runs fn, then releases the next LSN. The gate always advances: the WAL
+// record is already durable, so a benign engine error (e.g. deleting a missing key) must not stall later mutations.
 func (g *applyGate) run(lsn uint64, fn func() error) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -117,9 +118,8 @@ func (g *applyGate) run(lsn uint64, fn func() error) error {
 	return err
 }
 
-// Snapshot writes a state/LSN-consistent snapshot, then prunes incorporated WAL
-// segments. Mutations are paused only long enough to copy the state and capture
-// its LSN; the disk write and prune run without blocking mutations or reads.
+// Snapshot writes a state/LSN-consistent snapshot, then prunes incorporated WAL segments. Mutations are paused only
+// long enough to copy the state and capture its LSN; the disk write and prune run without blocking mutations or reads.
 func (s *Storage) Snapshot(
 	ctx context.Context,
 	write func(context.Context, uint64, SnapshotSource) error,
@@ -139,8 +139,8 @@ func (s *Storage) Snapshot(
 	return s.wal.Prune(ctx, lsn)
 }
 
-// snapshotEntry is one captured value; captured is a point-in-time copy of the
-// engine used so snapshot disk I/O happens without holding the mutation lock.
+// snapshotEntry is one captured value; captured is a point-in-time copy of the engine used so snapshot disk I/O happens
+// without holding the mutation lock.
 type snapshotEntry struct{ table, key, value string }
 
 type captured []snapshotEntry
@@ -170,7 +170,17 @@ func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (proto
 	case "GET":
 		return s.get(ctx, args)
 	case "DEL":
-		return s.del(ctx, args)
+		return s.mutation(ctx, wal.CommandDel, args)
+	case "INCR":
+		return s.incr(ctx, args)
+	case "APPEND":
+		return s.appendItem(ctx, args)
+	case "HSET":
+		return s.hset(ctx, args)
+	case "HGET":
+		return s.hget(ctx, args)
+	case "TYPE":
+		return s.valueType(ctx, args)
 	case "TABLES":
 		return protocol.BulkStringArray(s.engine.Tables(ctx)), nil
 	case "EXISTS":
@@ -183,38 +193,107 @@ func (s *Storage) Execute(ctx context.Context, cmd string, args []string) (proto
 }
 
 func (s *Storage) set(ctx context.Context, args []string) (protocol.Reply, error) {
-	apply := func() error { return s.engine.Set(ctx, args[0], args[1], args[2]) }
-	if err := s.mutate(ctx, "SET", args, apply); err != nil {
+	value, err := protocol.ParseLiteral(args[2])
+	if err != nil {
 		return protocol.Reply{}, err
 	}
-	return protocol.SimpleString("OK"), nil
+	return s.mutation(ctx, wal.CommandSet, []string{args[0], args[1], protocol.Encode(value)})
 }
 
 func (s *Storage) get(ctx context.Context, args []string) (protocol.Reply, error) {
-	val, err := s.engine.Get(ctx, args[0], args[1])
+	stored, err := s.load(ctx, args[0], args[1])
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.BulkString(protocol.Render(protocol.Decode(stored))), nil
+}
+
+func (s *Storage) incr(ctx context.Context, args []string) (protocol.Reply, error) {
+	literal := "1"
+	if len(args) == 3 {
+		literal = args[2]
+	}
+	delta, err := protocol.ParseLiteral(literal)
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	if delta.Kind != protocol.KindInt && delta.Kind != protocol.KindFloat {
+		return protocol.Reply{}, fmt.Errorf("INCR delta must be int or float, got %s", delta.Kind)
+	}
+	return s.mutation(ctx, wal.CommandIncr, []string{args[0], args[1], protocol.Encode(delta)})
+}
+
+func (s *Storage) appendItem(ctx context.Context, args []string) (protocol.Reply, error) {
+	element, err := protocol.ParseLiteral(args[2])
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return s.mutation(ctx, wal.CommandAppend, []string{args[0], args[1], protocol.Encode(element)})
+}
+
+func (s *Storage) hset(ctx context.Context, args []string) (protocol.Reply, error) {
+	value, err := protocol.ParseLiteral(args[3])
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return s.mutation(ctx, wal.CommandHSet, []string{args[0], args[1], args[2], protocol.Encode(value)})
+}
+
+func (s *Storage) hget(ctx context.Context, args []string) (protocol.Reply, error) {
+	stored, err := s.load(ctx, args[0], args[1])
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	value := protocol.Decode(stored)
+	if value.Kind != protocol.KindMap {
+		return protocol.Reply{}, wrongType("HGET", value.Kind, protocol.KindMap)
+	}
+	field, ok := value.Map[args[2]]
+	if !ok {
+		return protocol.Reply{}, ErrNotFound
+	}
+	return protocol.BulkString(protocol.Render(field)), nil
+}
+
+func (s *Storage) valueType(ctx context.Context, args []string) (protocol.Reply, error) {
+	stored, err := s.load(ctx, args[0], args[1])
+	if err != nil {
+		return protocol.Reply{}, err
+	}
+	return protocol.SimpleString(protocol.Decode(stored).Kind.String()), nil
+}
+
+func (s *Storage) load(ctx context.Context, table, key string) (string, error) {
+	value, err := s.engine.Get(ctx, table, key)
+	if err != nil {
+		if errors.Is(err, engine.ErrNotFound) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	return value, nil
+}
+
+// mutation logs encoded arguments before applying them to the engine.
+func (s *Storage) mutation(ctx context.Context, cmd string, args []string) (protocol.Reply, error) {
+	var reply protocol.Reply
+	err := s.mutate(ctx, cmd, args, func() error {
+		var applyErr error
+		reply, applyErr = Apply(ctx, s.engine, cmd, args)
+		return applyErr
+	})
 	if err != nil {
 		if errors.Is(err, engine.ErrNotFound) {
 			return protocol.Reply{}, ErrNotFound
 		}
 		return protocol.Reply{}, err
 	}
-	return protocol.BulkString(val), nil
+	return reply, nil
 }
 
-func (s *Storage) del(ctx context.Context, args []string) (protocol.Reply, error) {
-	apply := func() error { return s.engine.Del(ctx, args[0], args[1]) }
-	if err := s.mutate(ctx, "DEL", args, apply); err != nil {
-		if errors.Is(err, engine.ErrNotFound) {
-			return protocol.Reply{}, ErrNotFound
-		}
-		return protocol.Reply{}, err
-	}
-	return protocol.SimpleString("OK"), nil
-}
-
-// mutate durably logs a mutation, then applies it to the engine. When the WAL is
-// enabled, appends run concurrently (under the shared read lock) so the writer can
-// group-commit them, while the apply gate replays them into the engine in LSN order.
+// mutate durably logs a mutation, then applies it to the engine. When the WAL is enabled, appends run concurrently
+// (under the shared read lock) so the writer can group-commit them, while the apply gate replays them into the engine
+// in LSN order.
 func (s *Storage) mutate(ctx context.Context, command string, args []string, apply func() error) error {
 	if s.readOnly.Load() {
 		return ErrReadOnly
@@ -236,9 +315,8 @@ func (s *Storage) mutate(ctx context.Context, command string, args []string, app
 // ReadOnly reports whether mutating commands are currently rejected.
 func (s *Storage) ReadOnly() bool { return s.readOnly.Load() }
 
-// Promote lifts read-only mode so the storage accepts writes. It resets the
-// apply gate to the WAL's current tail, because replication advanced LastLSN
-// past the value captured when the storage was created. Client writes are still
+// Promote lifts read-only mode so the storage accepts writes. It resets the apply gate to the WAL's current tail,
+// because replication advanced LastLSN past the value captured when the storage was created. Client writes are still
 // rejected while the gate is swapped, so no mutation observes a stale gate.
 func (s *Storage) Promote() {
 	s.mu.Lock()
@@ -249,11 +327,9 @@ func (s *Storage) Promote() {
 	s.readOnly.Store(false)
 }
 
-// ApplyReplicated persists a record streamed from a master and applies it to the
-// engine. It holds the shared read lock so a concurrent Snapshot cannot capture
-// a state whose LSN is ahead of the engine (which would drop the record on
-// recovery). It bypasses the apply gate: a single master stream is already
-// ordered by LSN.
+// ApplyReplicated persists a record streamed from a master and applies it to the engine. It holds the shared read lock
+// so a concurrent Snapshot cannot capture a state whose LSN is ahead of the engine (which would drop the record on
+// recovery). It bypasses the apply gate: a single master stream is already ordered by LSN.
 func (s *Storage) ApplyReplicated(ctx context.Context, record wal.Record) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -261,31 +337,18 @@ func (s *Storage) ApplyReplicated(ctx context.Context, record wal.Record) error 
 	if err := s.wal.AppendRecord(ctx, record); err != nil {
 		return err
 	}
-	switch record.Command {
-	case wal.CommandSet:
-		return s.engine.Set(ctx, record.Args[0], record.Args[1], record.Args[2])
-	case wal.CommandDel:
-		if err := s.engine.Del(ctx, record.Args[0], record.Args[1]); err != nil && !errors.Is(err, engine.ErrNotFound) {
-			return err
-		}
-		return nil
-	default:
-		return errors.New("unsupported replicated command: " + record.Command)
-	}
+	return ApplyReplay(ctx, s.engine, record.Command, record.Args)
 }
 
-// ResetToSnapshot replaces all state with a snapshot received during resync: it
-// persists the snapshot, resets the WAL to lsn, and reloads the engine, all
-// under the exclusive lock so it is atomic against Snapshot.
+// ResetToSnapshot replaces all state with a snapshot received during resync: it persists the snapshot, resets the WAL
+// to lsn, and reloads the engine, all under the exclusive lock so it is atomic against Snapshot.
 func (s *Storage) ResetToSnapshot(ctx context.Context, dir string, lsn uint64, entries []engine.Entry) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Reset the WAL before publishing the snapshot. If we crash between the two,
-	// recovery falls back to the previous snapshot plus an empty WAL and re-syncs
-	// — safe. The reverse order would leave a high-LSN snapshot alongside old
-	// low-LSN segments, so the reopened writer appends a non-contiguous tail that
-	// recovery refuses.
+	// Reset the WAL before publishing the snapshot. If we crash between the two, recovery falls back to the previous
+	// snapshot plus an empty WAL and re-syncs — safe. The reverse order would leave a high-LSN snapshot alongside old
+	// low-LSN segments, so the reopened writer appends a non-contiguous tail that recovery refuses.
 	if err := s.wal.Reset(ctx, lsn); err != nil {
 		return err
 	}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -18,8 +18,12 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// newStorageWithMock creates a storage instance with its own mock engine so
-// subtests stay independent and can run in parallel
+func encoded(value string) string {
+	return protocol.Encode(protocol.StringValue(value))
+}
+
+// newStorageWithMock creates a storage instance with its own mock engine so subtests stay independent and can run in
+// parallel
 func newStorageWithMock(t *testing.T) (*storage.Storage, *mocks.MockEngine) {
 	t.Helper()
 	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
@@ -57,11 +61,11 @@ func TestStorage_WALBeforeMutation(t *testing.T) {
 	appended := false
 	log := &fakeWAL{append: func(_ context.Context, command string, args []string) (uint64, error) {
 		assert.Equal(t, "SET", command)
-		assert.Equal(t, []string{"t", "k", "v"}, args)
+		assert.Equal(t, []string{"t", "k", encoded("v")}, args)
 		appended = true
 		return 1, nil
 	}}
-	mockEngine.EXPECT().Set(ctx, "t", "k", "v").DoAndReturn(func(context.Context, string, string, string) error {
+	mockEngine.EXPECT().Set(ctx, "t", "k", encoded("v")).DoAndReturn(func(context.Context, string, string, string) error {
 		assert.True(t, appended, "engine mutation happened before WAL append")
 		return nil
 	})
@@ -82,9 +86,8 @@ func TestStorage_WALFailurePreventsMutation(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-// TestStorage_ConcurrentMutationsApplyInLSNOrder verifies that when many
-// mutations append concurrently (so the WAL can group-commit them), they still
-// land in the engine in LSN order: the surviving value is the highest-LSN write.
+// TestStorage_ConcurrentMutationsApplyInLSNOrder verifies that when many mutations append concurrently (so the WAL can
+// group-commit them), they still land in the engine in LSN order: the surviving value is the highest-LSN write.
 func TestStorage_ConcurrentMutationsApplyInLSNOrder(t *testing.T) {
 	t.Parallel()
 	eng := engine.New()
@@ -98,8 +101,8 @@ func TestStorage_ConcurrentMutationsApplyInLSNOrder(t *testing.T) {
 		assigned := lsn
 		valueByLSN[assigned] = args[2]
 		mu.Unlock()
-		// Jitter so appends return out of order relative to their LSNs; the apply
-		// gate must still serialize the engine writes by LSN.
+		// Jitter so appends return out of order relative to their LSNs; the apply gate must still serialize the engine writes
+		// by LSN.
 		time.Sleep(time.Duration(assigned%3) * time.Millisecond)
 		return assigned, nil
 	}}
@@ -160,8 +163,7 @@ func TestStorage_Execute(t *testing.T) {
 		key := "test_key"
 		value := "test_value"
 
-		// Mock the Set call
-		mockEngine.EXPECT().Set(ctx, table, key, value).Return(nil)
+		mockEngine.EXPECT().Set(ctx, table, key, encoded(value)).Return(nil)
 
 		result, err := s.Execute(ctx, "SET", []string{table, key, value})
 		require.NoError(t, err)
@@ -252,7 +254,7 @@ func TestStorage_Execute(t *testing.T) {
 		expectedErr := errors.New("engine error")
 
 		// Mock the Set call to return an error
-		mockEngine.EXPECT().Set(ctx, table, key, value).Return(expectedErr)
+		mockEngine.EXPECT().Set(ctx, table, key, encoded(value)).Return(expectedErr)
 
 		result, err := s.Execute(ctx, "SET", []string{table, key, value})
 		require.Error(t, err)
@@ -319,8 +321,8 @@ func TestStorage_Promote(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
-	// Replication advanced the WAL to LSN 5 while the standby was read-only; the
-	// gate must reset to 6 on promotion so the first client write applies.
+	// Replication advanced the WAL to LSN 5 while the standby was read-only; the gate must reset to 6 on promotion so the
+	// first client write applies.
 	log := &fakeWAL{last: 5, append: func(context.Context, string, []string) (uint64, error) { return 6, nil }}
 	store := storage.New(mockEngine, storage.WithWAL(log), storage.WithReadOnly(true))
 
@@ -330,7 +332,7 @@ func TestStorage_Promote(t *testing.T) {
 	store.Promote()
 	require.False(t, store.ReadOnly())
 
-	mockEngine.EXPECT().Set(ctx, "t", "k", "v").Return(nil)
+	mockEngine.EXPECT().Set(ctx, "t", "k", encoded("v")).Return(nil)
 	res, err := store.Execute(ctx, "SET", []string{"t", "k", "v"})
 	require.NoError(t, err)
 	assert.Equal(t, "OK", res.Value)

--- a/internal/wal/format.go
+++ b/internal/wal/format.go
@@ -1,0 +1,100 @@
+package wal
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Format headers identify the files this package writes; the trailing byte is the format version. A non-empty file that
+// does not carry the current header is rejected at open rather than parsed: misreading one would look like a torn tail
+// and get truncated away.
+const (
+	walHeader      = "DBWAL\x00\x02"
+	snapshotHeader = "DBSNP\x00\x02"
+)
+
+// ErrUnsupportedFormat is returned for a file written in a format this build does not read.
+var ErrUnsupportedFormat = errors.New("unsupported wal file format")
+
+// requireHeader verifies that file starts with header and returns the offset its records begin at. An empty file is
+// accepted as one with no records: a crash between creating a segment and writing its header leaves exactly that.
+func requireHeader(file *os.File, header string) (int64, error) {
+	buf := make([]byte, len(header))
+	n, err := file.ReadAt(buf, 0)
+	if n == 0 && errors.Is(err, io.EOF) {
+		return 0, nil
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return 0, err
+	}
+	if string(buf[:n]) != header {
+		return 0, ErrUnsupportedFormat
+	}
+	return int64(len(header)), nil
+}
+
+// consumeHeader verifies and skips the header on a buffered reader.
+func consumeHeader(reader *bufio.Reader, header string) error {
+	buf, err := reader.Peek(len(header))
+	if len(buf) == 0 && errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if string(buf) != header {
+		return ErrUnsupportedFormat
+	}
+	_, err = reader.Discard(len(header))
+	return err
+}
+
+// openTailSegment opens the newest segment for appending and returns it with the size to append at. An empty file is a
+// crash between creating a segment and writing its header: the header is written now, since records appended into it
+// would otherwise sit where the header belongs and the next open would reject the whole segment.
+func openTailSegment(path string) (*os.File, int64, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0o600) // #nosec G304 -- path comes from the WAL directory listing
+	if err != nil {
+		return nil, 0, fmt.Errorf("open WAL segment: %w", err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("stat WAL segment: %w", err)
+	}
+	if size := info.Size(); size > 0 {
+		if _, err = requireHeader(file, walHeader); err != nil {
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("read WAL segment header: %w", err)
+		}
+		return file, size, nil
+	}
+	written, err := file.WriteString(walHeader)
+	if err == nil && written != len(walHeader) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("write WAL segment header: %w", err)
+	}
+	return file, int64(len(walHeader)), nil
+}
+
+func openWALSegment(path string) (*os.File, *bufio.Reader, error) {
+	file, err := os.Open(path) // #nosec G304 -- path comes from the WAL directory listing
+	if err != nil {
+		return nil, nil, err
+	}
+	offset, err := requireHeader(file, walHeader)
+	if err == nil {
+		_, err = file.Seek(offset, io.SeekStart)
+	}
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("read WAL segment header: %w", err)
+	}
+	return file, bufio.NewReader(file), nil
+}

--- a/internal/wal/format.go
+++ b/internal/wal/format.go
@@ -17,11 +17,12 @@ const (
 )
 
 // ErrUnsupportedFormat is returned for a file written in a format this build does not read.
-var ErrUnsupportedFormat = errors.New("unsupported wal file format")
+var ErrUnsupportedFormat = errors.New("unsupported file format")
 
-// requireHeader verifies that file starts with header and returns the offset its records begin at. An empty file is
+// RequireHeader verifies that file starts with header and returns the offset its records begin at. An empty file is
 // accepted as one with no records: a crash between creating a segment and writing its header leaves exactly that.
-func requireHeader(file *os.File, header string) (int64, error) {
+// The tiered engine shares it (and WriteHeader) so both packages enforce the same format-header contract.
+func RequireHeader(file *os.File, header string) (int64, error) {
 	buf := make([]byte, len(header))
 	n, err := file.ReadAt(buf, 0)
 	if n == 0 && errors.Is(err, io.EOF) {
@@ -52,6 +53,15 @@ func consumeHeader(reader *bufio.Reader, header string) error {
 	return err
 }
 
+// WriteHeader writes a format header at the start of a freshly opened, empty file, treating a short write as an error.
+func WriteHeader(file *os.File, header string) error {
+	written, err := file.WriteString(header)
+	if err == nil && written != len(header) {
+		err = io.ErrShortWrite
+	}
+	return err
+}
+
 // openTailSegment opens the newest segment for appending and returns it with the size to append at. An empty file is a
 // crash between creating a segment and writing its header: the header is written now, since records appended into it
 // would otherwise sit where the header belongs and the next open would reject the whole segment.
@@ -66,17 +76,13 @@ func openTailSegment(path string) (*os.File, int64, error) {
 		return nil, 0, fmt.Errorf("stat WAL segment: %w", err)
 	}
 	if size := info.Size(); size > 0 {
-		if _, err = requireHeader(file, walHeader); err != nil {
+		if _, err = RequireHeader(file, walHeader); err != nil {
 			_ = file.Close()
 			return nil, 0, fmt.Errorf("read WAL segment header: %w", err)
 		}
 		return file, size, nil
 	}
-	written, err := file.WriteString(walHeader)
-	if err == nil && written != len(walHeader) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
+	if err = WriteHeader(file, walHeader); err != nil {
 		_ = file.Close()
 		return nil, 0, fmt.Errorf("write WAL segment header: %w", err)
 	}
@@ -88,7 +94,7 @@ func openWALSegment(path string) (*os.File, *bufio.Reader, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	offset, err := requireHeader(file, walHeader)
+	offset, err := RequireHeader(file, walHeader)
 	if err == nil {
 		_, err = file.Seek(offset, io.SeekStart)
 	}

--- a/internal/wal/reader.go
+++ b/internal/wal/reader.go
@@ -1,7 +1,6 @@
 package wal
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -23,9 +22,8 @@ func NewReader(dir string, logger *slog.Logger) *Reader {
 	return &Reader{dir: dir, logger: logger}
 }
 
-// Replay applies records newer than afterLSN and returns the last valid LSN.
-// A partial or checksum-invalid record in the final segment is truncated as a
-// crash tail; the same damage in an earlier segment is a startup error.
+// Replay applies records newer than afterLSN and returns the last valid LSN. A partial or checksum-invalid record in
+// the final segment is truncated as a crash tail; the same damage in an earlier segment is a startup error.
 func (r *Reader) Replay(afterLSN uint64, apply func(Record) error) (uint64, error) {
 	segments, err := listNumberedFiles(r.dir, walPrefix, walSuffix)
 	if err != nil {
@@ -59,11 +57,10 @@ func (r *Reader) replaySegment( //nolint:gocyclo // recovery deliberately keeps 
 	lastApplied uint64,
 	apply func(Record) error,
 ) (replayPosition, error) {
-	file, err := os.Open(segment.path)
+	file, reader, err := openWALSegment(segment.path)
 	if err != nil {
 		return replayPosition{}, fmt.Errorf("open WAL segment %s: %w", segment.path, err)
 	}
-	reader := bufio.NewReader(file)
 	position := replayPosition{seen: lastSeen, applied: lastApplied}
 
 	for {

--- a/internal/wal/record.go
+++ b/internal/wal/record.go
@@ -20,6 +20,10 @@ const (
 	// CommandSet and CommandDel are the mutating operations accepted by the WAL.
 	CommandSet = "SET"
 	CommandDel = "DEL"
+
+	CommandIncr   = "INCR"
+	CommandAppend = "APPEND"
+	CommandHSet   = "HSET"
 )
 
 var (
@@ -36,16 +40,14 @@ type Record struct {
 	Args    []string
 }
 
-// EncodeRecord serializes a record to its on-disk/on-wire form (LSN, protocol
-// command, CRC32). Replication reuses this so the master ships the exact bytes a
-// standby persists to its own WAL.
+// EncodeRecord serializes a record to its on-disk/on-wire form (LSN, protocol command, CRC32). Replication reuses this
+// so the master ships the exact bytes a standby persists to its own WAL.
 func EncodeRecord(record Record) ([]byte, error) {
 	return encodeRecord(record)
 }
 
-// ReadRecord decodes a single record previously written by EncodeRecord. It is
-// used by standbys reading the master's replication stream. A partial or
-// checksum-invalid record returns ErrPartialRecord/ErrChecksum.
+// ReadRecord decodes a single record previously written by EncodeRecord. It is used by standbys reading the master's
+// replication stream. A partial or checksum-invalid record returns ErrPartialRecord/ErrChecksum.
 func ReadRecord(reader *bufio.Reader) (Record, error) {
 	return readRecord(reader)
 }
@@ -107,17 +109,19 @@ func readRecord(reader *bufio.Reader) (Record, error) {
 }
 
 func validateRecord(record Record) error {
+	var want int
 	switch record.Command {
-	case CommandSet:
-		if len(record.Args) != 3 {
-			return fmt.Errorf("invalid SET WAL record: got %d arguments", len(record.Args))
-		}
+	case CommandSet, CommandIncr, CommandAppend:
+		want = 3
 	case CommandDel:
-		if len(record.Args) != 2 {
-			return fmt.Errorf("invalid DEL WAL record: got %d arguments", len(record.Args))
-		}
+		want = 2
+	case CommandHSet:
+		want = 4
 	default:
 		return fmt.Errorf("invalid WAL record command %q", record.Command)
+	}
+	if len(record.Args) != want {
+		return fmt.Errorf("invalid %s WAL record: got %d arguments, want %d", record.Command, len(record.Args), want)
 	}
 	return nil
 }

--- a/internal/wal/snapshot.go
+++ b/internal/wal/snapshot.go
@@ -30,6 +30,14 @@ func WriteSnapshot(ctx context.Context, dir string, lsn uint64, source SnapshotS
 	temporaryName := temporary.Name()
 	defer func() { _ = os.Remove(temporaryName) }()
 
+	var written int
+	if written, err = temporary.WriteString(snapshotHeader); err == nil && written != len(snapshotHeader) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write snapshot header: %w", err)
+	}
 	if err = writeSnapshotRecords(ctx, temporary, source); err != nil {
 		_ = temporary.Close()
 		return err
@@ -106,20 +114,31 @@ func LoadLatestSnapshot(dir string, apply func(table, key, value string) error) 
 	defer func() { _ = file.Close() }()
 
 	reader := bufio.NewReader(file)
+	if err = ReadSnapshot(reader, apply); err != nil {
+		return 0, fmt.Errorf("read snapshot %s: %w", latest.path, err)
+	}
+	return latest.number, nil
+}
+
+// ReadSnapshot applies every record of a snapshot in order.
+func ReadSnapshot(reader *bufio.Reader, apply func(table, key, value string) error) error {
+	if err := consumeHeader(reader, snapshotHeader); err != nil {
+		return fmt.Errorf("read snapshot header: %w", err)
+	}
 	for {
 		command, args, readErr := protocol.ReadCommand(reader, maxRecordSize)
 		if errors.Is(readErr, io.EOF) {
 			break
 		}
 		if readErr != nil {
-			return 0, fmt.Errorf("read snapshot %s: %w", latest.path, readErr)
+			return readErr
 		}
 		if command != CommandSet || len(args) != 3 {
-			return 0, fmt.Errorf("invalid snapshot record %q with %d arguments", command, len(args))
+			return fmt.Errorf("invalid snapshot record %q with %d arguments", command, len(args))
 		}
-		if err = apply(args[0], args[1], args[2]); err != nil {
-			return 0, fmt.Errorf("apply snapshot: %w", err)
+		if err := apply(args[0], args[1], args[2]); err != nil {
+			return fmt.Errorf("apply snapshot: %w", err)
 		}
 	}
-	return latest.number, nil
+	return nil
 }

--- a/internal/wal/snapshot.go
+++ b/internal/wal/snapshot.go
@@ -30,11 +30,7 @@ func WriteSnapshot(ctx context.Context, dir string, lsn uint64, source SnapshotS
 	temporaryName := temporary.Name()
 	defer func() { _ = os.Remove(temporaryName) }()
 
-	var written int
-	if written, err = temporary.WriteString(snapshotHeader); err == nil && written != len(snapshotHeader) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
+	if err = WriteHeader(temporary, snapshotHeader); err != nil {
 		_ = temporary.Close()
 		return fmt.Errorf("write snapshot header: %w", err)
 	}

--- a/internal/wal/stream.go
+++ b/internal/wal/stream.go
@@ -1,16 +1,13 @@
 package wal
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 )
 
-// OldestRecordLSN returns the LSN of the oldest record still retained on disk.
-// It is the first LSN of the earliest WAL segment; when no segments exist it
-// returns fallback (the caller passes LastLSN+1, meaning "nothing on disk").
+// OldestRecordLSN returns the LSN of the oldest record still retained on disk. It is the first LSN of the earliest WAL
+// segment; when no segments exist it returns fallback (the caller passes LastLSN+1, meaning "nothing on disk").
 func OldestRecordLSN(dir string, fallback uint64) (uint64, error) {
 	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
 	if err != nil {
@@ -22,8 +19,7 @@ func OldestRecordLSN(dir string, fallback uint64) (uint64, error) {
 	return segments[0].number, nil
 }
 
-// LatestSnapshotInfo returns the LSN and path of the newest snapshot on disk.
-// ok is false when no snapshot exists.
+// LatestSnapshotInfo returns the LSN and path of the newest snapshot on disk. ok is false when no snapshot exists.
 func LatestSnapshotInfo(dir string) (lsn uint64, path string, ok bool, err error) {
 	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
 	if err != nil {
@@ -36,12 +32,10 @@ func LatestSnapshotInfo(dir string) (lsn uint64, path string, ok bool, err error
 	return latest.number, latest.path, true, nil
 }
 
-// ReadRecordsFrom streams records with LSN >= fromLSN from the on-disk segments
-// to fn, in LSN order. It is used by the replication master to catch a standby
-// up from segment files. Because the master appends concurrently, a partial or
-// checksum-invalid record at the tail of the final segment is treated as a
-// half-written live record and ends iteration cleanly (the caller streams the
-// rest from the live fan-out); the same damage in an earlier segment is an error.
+// ReadRecordsFrom streams records with LSN >= fromLSN from the on-disk segments to fn, in LSN order. It is used by the
+// replication master to catch a standby up from segment files. Because the master appends concurrently, a partial or
+// checksum-invalid record at the tail of the final segment is treated as a half-written live record and ends iteration
+// cleanly (the caller streams the rest from the live fan-out); the same damage in an earlier segment is an error.
 func ReadRecordsFrom(dir string, fromLSN uint64, fn func(Record) error) error {
 	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
 	if err != nil {
@@ -57,13 +51,12 @@ func ReadRecordsFrom(dir string, fromLSN uint64, fn func(Record) error) error {
 }
 
 func readSegmentRecords(segment numberedFile, isLast bool, fromLSN uint64, fn func(Record) error) error {
-	file, err := os.Open(segment.path)
+	file, reader, err := openWALSegment(segment.path)
 	if err != nil {
 		return fmt.Errorf("open WAL segment %s: %w", segment.path, err)
 	}
 	defer func() { _ = file.Close() }()
 
-	reader := bufio.NewReader(file)
 	for {
 		record, readErr := readRecord(reader)
 		if errors.Is(readErr, io.EOF) {

--- a/internal/wal/syncdir_unix.go
+++ b/internal/wal/syncdir_unix.go
@@ -4,8 +4,8 @@ package wal
 
 import "os"
 
-// SyncDirectory fsyncs a directory so entries created in it (a new segment
-// file) survive a crash, not just the file contents.
+// SyncDirectory fsyncs a directory so entries created in it (a new segment file) survive a crash, not just the file
+// contents.
 func SyncDirectory(path string) error {
 	// #nosec G304 -- path is the operator-configured WAL directory
 	directory, err := os.Open(path)

--- a/internal/wal/syncdir_windows.go
+++ b/internal/wal/syncdir_windows.go
@@ -2,8 +2,6 @@
 
 package wal
 
-// SyncDirectory is a no-op on Windows.
-// Go's portable os API cannot open a Windows directory with the flags needed
-// by FlushFileBuffers. NTFS journals rename/create metadata; file contents are
-// still explicitly synced before publication.
+// SyncDirectory is a no-op on Windows. Go's portable os API cannot open a Windows directory with the flags needed by
+// FlushFileBuffers. NTFS journals rename/create metadata; file contents are still explicitly synced before publication.
 func SyncDirectory(string) error { return nil }

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OutOfStack/db/internal/protocol"
 	"github.com/OutOfStack/db/internal/wal"
 )
 
@@ -54,6 +55,96 @@ func TestRecordRoundTripAndChecksum(t *testing.T) {
 	_, err = wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { return nil })
 	if !errors.Is(err, wal.ErrChecksum) {
 		t.Fatalf("Replay() error = %v, want ErrChecksum", err)
+	}
+}
+
+// TestHeaderlessFilesAreRejected covers files written before this format version. They are refused at open rather than
+// parsed: their records would decode as garbage, and a garbage tail is indistinguishable from a crash tail that
+// recovery truncates away.
+func TestHeaderlessFilesAreRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wal segment", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		record, err := wal.EncodeRecord(wal.Record{
+			LSN: 1, Command: wal.CommandSet, Args: []string{"t", "k", "v"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(filepath.Join(dir, "wal-00000000000000000001.log"), record, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { return nil })
+		if !errors.Is(err, wal.ErrUnsupportedFormat) {
+			t.Fatalf("Replay() error = %v, want ErrUnsupportedFormat", err)
+		}
+	})
+
+	t.Run("snapshot", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		file, err := os.Create(filepath.Join(dir, "snapshot-00000000000000000007.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = protocol.WriteCommand(file, wal.CommandSet, []string{"t", "k", "v"}); err != nil {
+			t.Fatal(err)
+		}
+		if err = file.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = wal.LoadLatestSnapshot(dir, func(_, _, _ string) error { return nil })
+		if !errors.Is(err, wal.ErrUnsupportedFormat) {
+			t.Fatalf("LoadLatestSnapshot() error = %v, want ErrUnsupportedFormat", err)
+		}
+	})
+
+	t.Run("an empty segment is not a format error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// A crash between creating a segment and writing its header leaves this.
+		if err := os.WriteFile(filepath.Join(dir, "wal-00000000000000000001.log"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := wal.NewReader(dir, nil).Replay(0, func(wal.Record) error { return nil }); err != nil {
+			t.Fatalf("Replay() over an empty segment error = %v", err)
+		}
+	})
+}
+
+// TestAppendingToRecoveredEmptySegment covers the other side of the empty-segment case above: reopening one must give it
+// a header before appending, or the records land where the header belongs and the next open rejects the whole segment.
+func TestAppendingToRecoveredEmptySegment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "wal-00000000000000000001.log"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	writer, err := wal.OpenWriter(wal.WriterConfig{Dir: dir, Sync: wal.SyncAlways, SegmentSize: 1 << 20}, 0)
+	if err != nil {
+		t.Fatalf("OpenWriter() error = %v", err)
+	}
+	if _, err = writer.Append(t.Context(), wal.CommandSet, []string{"t", "k", "v"}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	var replayed []wal.Record
+	if _, err = wal.NewReader(dir, nil).Replay(0, func(record wal.Record) error {
+		replayed = append(replayed, record)
+		return nil
+	}); err != nil {
+		t.Fatalf("Replay() after reopening an empty segment error = %v", err)
+	}
+	if len(replayed) != 1 || replayed[0].Command != wal.CommandSet {
+		t.Fatalf("replayed = %#v, want one SET record", replayed)
 	}
 }
 

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -467,11 +467,7 @@ func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64)
 	if err != nil {
 		return err
 	}
-	written, err := file.WriteString(walHeader)
-	if err == nil && written != len(walHeader) {
-		err = io.ErrShortWrite
-	}
-	if err != nil {
+	if err = WriteHeader(file, walHeader); err != nil {
 		_ = file.Close()
 		return fmt.Errorf("write WAL segment header: %w", err)
 	}

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -52,9 +52,8 @@ type writerRequest struct {
 	result  chan writerResult
 }
 
-// subscriberBuffer bounds how many committed records the writer can queue for a
-// single replication subscriber before dropping. A dropped record is not lost:
-// the master streaming loop detects the LSN gap and re-reads it from the WAL
+// subscriberBuffer bounds how many committed records the writer can queue for a single replication subscriber before
+// dropping. A dropped record is not lost: the master streaming loop detects the LSN gap and re-reads it from the WAL
 // segments on disk, so a slow standby never blocks the writer goroutine.
 const subscriberBuffer = 1024
 
@@ -84,8 +83,7 @@ type Writer struct {
 	subs   map[*subscriber]struct{}
 }
 
-// OpenWriter opens a writer after recovery. lastLSN must be the last LSN
-// returned by snapshot loading plus WAL replay.
+// OpenWriter opens a writer after recovery. lastLSN must be the last LSN returned by snapshot loading plus WAL replay.
 func OpenWriter(config WriterConfig, lastLSN uint64) (*Writer, error) {
 	if config.Dir == "" {
 		return nil, errors.New("WAL directory cannot be empty")
@@ -108,17 +106,9 @@ func OpenWriter(config WriterConfig, lastLSN uint64) (*Writer, error) {
 	var file *os.File
 	var size int64
 	if len(segments) > 0 {
-		last := segments[len(segments)-1]
-		file, err = os.OpenFile(last.path, os.O_WRONLY|os.O_APPEND, 0o600)
-		if err != nil {
-			return nil, fmt.Errorf("open WAL segment: %w", err)
+		if file, size, err = openTailSegment(segments[len(segments)-1].path); err != nil {
+			return nil, err
 		}
-		info, statErr := file.Stat()
-		if statErr != nil {
-			_ = file.Close()
-			return nil, fmt.Errorf("stat WAL segment: %w", statErr)
-		}
-		size = info.Size()
 	}
 
 	writer := &Writer{
@@ -142,9 +132,8 @@ func (w *Writer) Append(ctx context.Context, command string, args []string) (uin
 	if err := validateRecord(Record{Command: command, Args: args}); err != nil {
 		return 0, err
 	}
-	// Reject records the recovery reader could not decode (its RESP limit is
-	// maxRecordSize). The network layer's max message size is configurable and
-	// may exceed this, so guard here rather than persisting an unreadable record.
+	// Reject records the recovery reader could not decode (its RESP limit is maxRecordSize). The network layer's max
+	// message size is configurable and may exceed this, so guard here rather than persisting an unreadable record.
 	if size := protocol.CommandSize(command, args); size > maxRecordSize {
 		return 0, fmt.Errorf("WAL record size %d exceeds maximum %d bytes", size, maxRecordSize)
 	}
@@ -157,9 +146,8 @@ func (w *Writer) Append(ctx context.Context, command string, args []string) (uin
 	case <-w.done:
 		return 0, ErrClosed
 	}
-	// Once the request is enqueued the writer will assign it a durable LSN, so we
-	// must wait for that outcome rather than abandoning it on ctx cancellation:
-	// an orphaned LSN would stall the caller's in-order apply of later records.
+	// Once the request is enqueued the writer will assign it a durable LSN, so we must wait for that outcome rather than
+	// abandoning it on ctx cancellation: an orphaned LSN would stall the caller's in-order apply of later records.
 	select {
 	case response := <-result:
 		return response.lsn, response.err
@@ -173,10 +161,9 @@ func (w *Writer) Append(ctx context.Context, command string, args []string) (uin
 	}
 }
 
-// AppendRecord writes a record with a caller-assigned LSN. Standbys use it to
-// persist records received from the master's replication stream, preserving the
-// master's LSNs so a promoted standby continues the same log. The record's LSN
-// must be exactly the current LastLSN+1.
+// AppendRecord writes a record with a caller-assigned LSN. Standbys use it to persist records received from the
+// master's replication stream, preserving the master's LSNs so a promoted standby continues the same log. The record's
+// LSN must be exactly the current LastLSN+1.
 func (w *Writer) AppendRecord(ctx context.Context, record Record) error {
 	if w.closing.Load() {
 		return ErrClosed
@@ -190,17 +177,15 @@ func (w *Writer) AppendRecord(ctx context.Context, record Record) error {
 	return w.control(ctx, writerRequest{kind: requestAppendReplicated, record: record})
 }
 
-// Reset discards all WAL segments and sets LastLSN to lsn, so the next appended
-// record must be lsn+1. Standbys call it after loading a snapshot at lsn during
-// resync, when their existing log is entirely superseded by the snapshot.
+// Reset discards all WAL segments and sets LastLSN to lsn, so the next appended record must be lsn+1. Standbys call it
+// after loading a snapshot at lsn during resync, when their existing log is entirely superseded by the snapshot.
 func (w *Writer) Reset(ctx context.Context, lsn uint64) error {
 	return w.control(ctx, writerRequest{kind: requestReset, uptoLSN: lsn})
 }
 
-// Subscribe registers for committed records. The returned channel receives every
-// record the writer commits after the call; the returned function unsubscribes.
-// Sends are non-blocking (see subscriberBuffer): a subscriber that cannot keep up
-// misses records and must recover them by reading segments from disk.
+// Subscribe registers for committed records. The returned channel receives every record the writer commits after the
+// call; the returned function unsubscribes. Sends are non-blocking (see subscriberBuffer): a subscriber that cannot
+// keep up misses records and must recover them by reading segments from disk.
 func (w *Writer) Subscribe() (<-chan Record, func()) {
 	sub := &subscriber{ch: make(chan Record, subscriberBuffer)}
 	w.subsMu.Lock()
@@ -261,11 +246,10 @@ func (w *Writer) control(ctx context.Context, request writerRequest) error {
 	case <-w.done:
 		return ErrClosed
 	}
-	// Once enqueued, wait for the outcome regardless of ctx cancellation: the
-	// writer will still process this request and mutate durable state (assign an
-	// LSN, remove segments), so abandoning it here would desync a caller that
-	// applies records in LSN order — e.g. a standby whose context is cancelled by
-	// Stop() mid-append, leaving its engine one record behind its own WAL.
+	// Once enqueued, wait for the outcome regardless of ctx cancellation: the writer will still process this request and
+	// mutate durable state (assign an LSN, remove segments), so abandoning it here would desync a caller that applies
+	// records in LSN order — e.g. a standby whose context is cancelled by Stop() mid-append, leaving its engine one record
+	// behind its own WAL.
 	select {
 	case response := <-request.result:
 		return response.err
@@ -359,10 +343,9 @@ func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
 		wrote = true
 	}
 
-	// Sync whatever was written even when a later append in the batch failed:
-	// the earlier records are already on disk and will replay on restart, so
-	// their callers must be acked, not failed. Only a sync failure leaves those
-	// records non-durable, and only then do we fail the callers we would ack.
+	// Sync whatever was written even when a later append in the batch failed: the earlier records are already on disk and
+	// will replay on restart, so their callers must be acked, not failed. Only a sync failure leaves those records
+	// non-durable, and only then do we fail the callers we would ack.
 	if wrote && w.config.Sync == SyncAlways && state.file != nil {
 		if err := state.file.Sync(); err != nil {
 			state.terminalErr = fmt.Errorf("sync WAL: %w", err)
@@ -377,8 +360,8 @@ func (w *Writer) handleBatch(batch []writerRequest, state *writerState) {
 		request.result <- results[index]
 	}
 
-	// Publish only records the callers were acked for; a failed append or sync
-	// leaves the record non-durable, so it must not be streamed to standbys.
+	// Publish only records the callers were acked for; a failed append or sync leaves the record non-durable, so it must
+	// not be streamed to standbys.
 	for index, request := range batch {
 		if results[index].err == nil {
 			w.publish(Record{LSN: results[index].lsn, Command: request.command, Args: request.args})
@@ -407,9 +390,8 @@ func (w *Writer) appendOne(request writerRequest, state *writerState) (uint64, e
 	return lsn, nil
 }
 
-// appendReplicated writes a record with its own LSN, enforcing contiguity with
-// the current tail. Under a durable sync policy it fsyncs before returning so an
-// acked replicated record survives a standby crash, mirroring Append.
+// appendReplicated writes a record with its own LSN, enforcing contiguity with the current tail. Under a durable sync
+// policy it fsyncs before returning so an acked replicated record survives a standby crash, mirroring Append.
 func (w *Writer) appendReplicated(record Record, state *writerState) error {
 	expected := w.lastLSN.Load() + 1
 	if record.LSN != expected {
@@ -442,8 +424,8 @@ func (w *Writer) appendReplicated(record Record, state *writerState) error {
 	return nil
 }
 
-// reset removes every WAL segment and sets LastLSN to lsn, so the next record
-// appended must be lsn+1 into a fresh segment.
+// reset removes every WAL segment and sets LastLSN to lsn, so the next record appended must be lsn+1 into a fresh
+// segment.
 func (w *Writer) reset(state *writerState, lsn uint64) error {
 	if state.file != nil {
 		if err := state.file.Close(); err != nil {
@@ -469,15 +451,14 @@ func (w *Writer) reset(state *writerState, lsn uint64) error {
 }
 
 func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64) error {
-	if state.file != nil && (state.size == 0 || state.size+recordSize <= w.config.SegmentSize) {
+	if state.file != nil && (state.size == int64(len(walHeader)) || state.size+recordSize <= w.config.SegmentSize) {
 		return nil
 	}
 	if err := w.closeForRotation(state); err != nil {
 		return err
 	}
-	// The previous segment is closed and durably synced. Drop the handle so a
-	// failed open below cannot leave a stale, closed file that later code syncs
-	// (which would wrongly fail callers whose records are already durable).
+	// The previous segment is closed and durably synced. Drop the handle so a failed open below cannot leave a stale,
+	// closed file that later code syncs (which would wrongly fail callers whose records are already durable).
 	state.file = nil
 	state.size = 0
 	path := filepath.Join(w.config.Dir, walFilename(lsn))
@@ -486,14 +467,26 @@ func (w *Writer) ensureSegment(state *writerState, lsn uint64, recordSize int64)
 	if err != nil {
 		return err
 	}
+	written, err := file.WriteString(walHeader)
+	if err == nil && written != len(walHeader) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write WAL segment header: %w", err)
+	}
 	if w.config.Sync != SyncNo {
+		if err = file.Sync(); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("sync WAL segment header: %w", err)
+		}
 		if err = SyncDirectory(w.config.Dir); err != nil {
 			_ = file.Close()
 			return fmt.Errorf("sync WAL directory: %w", err)
 		}
 	}
 	state.file = file
-	state.size = 0
+	state.size = int64(len(walHeader))
 	return nil
 }
 
@@ -501,9 +494,8 @@ func (w *Writer) closeForRotation(state *writerState) error {
 	if state.file == nil {
 		return nil
 	}
-	// Sync the segment being closed for any durable policy. Under SyncAlways a
-	// batch that overflows into a new segment would otherwise close the old
-	// segment with its final records unsynced, even though they were acked.
+	// Sync the segment being closed for any durable policy. Under SyncAlways a batch that overflows into a new segment
+	// would otherwise close the old segment with its final records unsynced, even though they were acked.
 	if w.config.Sync != SyncNo {
 		if err := state.file.Sync(); err != nil {
 			return err


### PR DESCRIPTION
Values carry a type (string, int, float, bool, array, map) instead of being opaque text. The type comes from the literal syntax, parsed and rendered server-side.

Four commands operate on those types server-side, each atomic under a single engine primitive rather than a read-modify-write race in the client:
`INCR <table> <key> [delta]`  exact int arithmetic, error on overflow
`APPEND <table> <key> <value>`  push onto an array, returns new length
`HSET/HGET <table> <key> <field>` one map field
`TYPE <table> <key>` what a key holds
                                                                                                                                                                                                                                                                                              
Values are encoded before they reach an engine, so the WAL, snapshots, replication and the tiered segment store carry them unchanged. Failed  mutations (wrong type, overflow, missing key) are command-level refusals that  replay reproduces, so one bad record no longer aborts recovery or stalls a  standby.                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                              
 BREAKING CHANGE: the stored value slot means something different than it did,  so data written by an earlier build is unreadable.