### PR TITLE
feat!: freeze and enforce the v1 support boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Simple Database Server
+# Simple! Database Server
 
-A distributed key-value database with TCP server and CLI client written in Go.
+A networked key-value database with TCP server and CLI client written in Go. Replication is available as a preview
+feature (see [Support Boundary](#support-boundary)).
 
 ## Architecture
 
@@ -17,17 +18,40 @@ The project consists of three main components:
 - Structured logging with configurable levels
 - Graceful shutdown with proper resource cleanup
 - Command-line interface for database operations
-- Two storage engines: `in_memory` (RAM-only) and `tiered`, whose dataset grows past RAM by keeping values in on-disk
-  segments behind an LRU cache
+- Two storage engines: `in_memory` (RAM-only) and `tiered` (preview), whose dataset grows past RAM by keeping values
+  in on-disk segments behind an LRU cache
 - Tables: keys are scoped per table, created implicitly on first write
 - Typed values (string, int, float, bool, array, map) with server-side atomic operations: `INCR`, `APPEND`,
   `HSET`/`HGET`, `TYPE`
 - Durability: write-ahead log with `always`/`everysec`/`no` fsync policies, periodic snapshots, and crash recovery that
   truncates a torn tail
-- Replication: asynchronous master/standby WAL shipping with manual `PROMOTE`
+- Replication (preview): asynchronous master/standby WAL shipping with manual `PROMOTE`
 - Connection limiting to prevent resource exhaustion
-- **Master/Standby Connection Pooling** with automatic failover
+- **Master/Standby Connection Pooling** with read failover and retry; writes reroute only after a manual promotion
 - Configurable server selection strategies (master_first, round_robin, random)
+
+## Support Boundary
+
+Generally available, supported for production use:
+
+- The `in_memory` engine with WAL persistence and snapshots
+- The public Go client library and the CLI
+- The documented RESP2 command subset and typed literals
+- Deployment on loopback or an explicitly trusted private network
+
+Preview — limited support, marked by a startup warning:
+
+- The `tiered` engine
+- Replication: master/standby WAL shipping, standby reads, and `PROMOTE`
+- Ephemeral mode (the in-memory engine with `wal.enabled: false`): data lives only in RAM and is lost on shutdown.
+  Note this is the default configuration — durability is opted into by setting `wal.enabled: true`
+
+Preview caveats:
+
+- Standby reads may be stale: replication is asynchronous, with no read-your-writes guarantee
+- There is no automatic write failover. If the master fails, writes fail until an operator isolates the old master,
+  promotes a standby with `PROMOTE` (requires `replication.allow_remote_promote`), and points clients at the new master
+- A pool routes writes to its single configured master; configs listing more than one master are rejected
 
 ## Commands
 
@@ -213,6 +237,7 @@ with `wal.enabled` or replication — the server refuses that combination at sta
   start serving replication from this node
 - **replication.master_address**: Standby: the master to replicate from
 - **replication.reconnect_backoff**: Standby: pause between reconnect attempts
+- **replication.allow_remote_promote**: Standby: permit the `PROMOTE` command over the client port (default `false`)
 - **network.address**: Server listening address
 - **network.max_connections**: Maximum concurrent client connections (enforced by server)
 - **network.max_message_size**: Maximum message size in KB
@@ -297,7 +322,7 @@ network:
 
 ### Client with Connection Pool
 
-For distributed deployments with master/standby servers:
+For a master/standby deployment (exactly one master per pool):
 
 ```yaml
 network:
@@ -312,7 +337,7 @@ pool:
     - address: "127.0.0.1:3223"
       role: master
     - address: "127.0.0.1:3224"
-      role: master
+      role: standby
     - address: "127.0.0.1:3225"
       role: standby
 
@@ -440,7 +465,7 @@ err = c.HSet(ctx, "users", "u1", "name", "Alice")
 name, err := c.HGet(ctx, "users", "u1", "name") // ErrNotFound if the field is missing
 ```
 
-For distributed deployments, configure a connection pool instead of a single address:
+For master/standby deployments, configure a connection pool instead of a single address:
 
 ```go
 c, err := client.New(
@@ -560,10 +585,13 @@ The server implements connection limiting to prevent resource exhaustion:
 
 ## Connection Pooling (Client-side)
 
-The client supports connection pooling for distributed deployments:
+The client supports connection pooling for master/standby deployments:
 
-- **Multiple Servers**: Configure multiple server addresses with master/standby roles
-- **Automatic Failover**: Failed servers are temporarily excluded and automatically retried after a timeout
+- **Multiple Servers**: Configure multiple server addresses with master/standby roles (exactly one master)
+- **Read Failover**: Failed servers are temporarily excluded and retried after a timeout; reads fall back to other
+  servers, while writes fail with the master down until a standby is manually promoted and clients are reconfigured
+- **Admin Commands**: `PROMOTE` and `REPLICATION` are refused in pool mode — they target one specific node, so connect
+  to that server directly
 - **Selection Strategies**: Choose how servers are selected (master_first, round_robin, random)
 - **Connection Caching**: Established connections are reused to minimize overhead
 - **Concurrent Safety**: Serialized sends prevent TCP message corruption from concurrent requests

--- a/client/client.go
+++ b/client/client.go
@@ -43,8 +43,8 @@ type Client struct {
 }
 
 // New creates a new Client configured by the given options. With WithServers, connections are pooled across the given
-// servers with automatic failover; otherwise a single connection is established to the address set by WithAddress
-// (default 127.0.0.1:3223)
+// servers, with reads retried on another server on failure; otherwise a single connection is established to the
+// address set by WithAddress (default 127.0.0.1:3223)
 func New(opts ...Option) (*Client, error) {
 	o := defaultOptions()
 	for _, opt := range opts {

--- a/client/options.go
+++ b/client/options.go
@@ -12,15 +12,16 @@ const (
 	RoleStandby Role = "standby"
 )
 
-// Strategy defines how servers are selected from the pool
+// Strategy defines how servers are selected from the pool for reads. Writes always route to the master regardless of
+// strategy.
 type Strategy string
 
 const (
-	// MasterFirst tries master servers first, falls back to standby
+	// MasterFirst reads from the master first, falling back to standbys on failure
 	MasterFirst Strategy = "master_first"
-	// RoundRobin rotates through all servers
+	// RoundRobin rotates reads through all servers
 	RoundRobin Strategy = "round_robin"
-	// Random picks a random server
+	// Random picks a random server for each read
 	Random Strategy = "random"
 )
 
@@ -65,7 +66,7 @@ func WithAddress(addr string) Option {
 	}
 }
 
-// WithServers enables pool mode with the given servers. At least one server must have RoleMaster
+// WithServers enables pool mode with the given servers. Exactly one server must have RoleMaster
 func WithServers(servers ...Server) Option {
 	return func(o *options) {
 		o.servers = servers

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -80,6 +80,8 @@ func newLogger(cfg config.ServerLoggingConfig) (*slog.Logger, func() error, erro
 }
 
 func run(cfg *config.ServerConfig, logger *slog.Logger) error {
+	logSupportBoundary(cfg, logger)
+
 	dbEngine, walWriter, snapshotLSN, err := buildEngine(cfg, logger)
 	if err != nil {
 		return err
@@ -111,10 +113,27 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 
 	var computeOptions []compute.Option
 	if repl != nil {
-		computeOptions = append(computeOptions, compute.WithAdmin(repl.admin))
+		computeOptions = append(computeOptions,
+			compute.WithAdmin(repl.admin),
+			compute.WithPromoteEnabled(cfg.Replication.AllowRemotePromote))
 	}
 	comp := compute.New(parser.New(), store, logger, computeOptions...)
 	return serve(cfg, logger, comp, store, walWriter, repl, snapshotLSN)
+}
+
+// logSupportBoundary warns when the configuration selects features outside the GA support boundary: the tiered engine
+// and replication are previews with limited support, and an in-memory engine without a WAL holds data only until
+// shutdown. The tiered engine runs without a WAL by design (it keeps its own durable store), so it is not ephemeral.
+func logSupportBoundary(cfg *config.ServerConfig, logger *slog.Logger) {
+	if cfg.Engine.Type == engine.TypeTiered {
+		logger.Warn("Preview feature enabled: tiered engine")
+	}
+	if cfg.Replication.Role != config.RoleStandalone {
+		logger.Warn("Preview feature enabled: replication", "role", cfg.Replication.Role)
+	}
+	if !cfg.WAL.Enabled && cfg.Engine.Type == engine.TypeInMemory {
+		logger.Warn("Ephemeral mode: WAL disabled, data is lost on shutdown")
+	}
 }
 
 // buildEngine constructs the configured storage engine. The tiered engine keeps its own durable segment store (no WAL);

--- a/cmd/db/main_test.go
+++ b/cmd/db/main_test.go
@@ -47,27 +47,24 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 func TestLogSupportBoundary(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name    string
-		change  func(*config.ServerConfig)
-		want    []string
-		notWant []string
+		name      string
+		change    func(*config.ServerConfig)
+		preview   bool
+		ephemeral bool
 	}{
 		{
-			name:    "default in-memory without WAL is ephemeral",
-			change:  func(_ *config.ServerConfig) {},
-			want:    []string{"Ephemeral"},
-			notWant: []string{"Preview"},
+			name:      "default in-memory without WAL is ephemeral",
+			change:    func(_ *config.ServerConfig) {},
+			ephemeral: true,
 		},
 		{
-			name:    "in-memory with WAL is fully supported",
-			change:  func(c *config.ServerConfig) { c.WAL.Enabled = true },
-			notWant: []string{"Ephemeral", "Preview"},
+			name:   "in-memory with WAL is fully supported",
+			change: func(c *config.ServerConfig) { c.WAL.Enabled = true },
 		},
 		{
 			name:    "tiered engine is preview, not ephemeral",
 			change:  func(c *config.ServerConfig) { c.Engine.Type = engine.TypeTiered },
-			want:    []string{"Preview"},
-			notWant: []string{"Ephemeral"},
+			preview: true,
 		},
 		{
 			name: "replication is preview",
@@ -75,8 +72,7 @@ func TestLogSupportBoundary(t *testing.T) {
 				c.WAL.Enabled = true
 				c.Replication.Role = config.RoleStandby
 			},
-			want:    []string{"Preview"},
-			notWant: []string{"Ephemeral"},
+			preview: true,
 		},
 	}
 	for _, tt := range tests {
@@ -88,15 +84,12 @@ func TestLogSupportBoundary(t *testing.T) {
 			var buf bytes.Buffer
 			logSupportBoundary(cfg, slog.New(slog.NewTextHandler(&buf, nil)))
 
-			for _, want := range tt.want {
-				if !strings.Contains(buf.String(), want) {
-					t.Errorf("log output %q missing %q", buf.String(), want)
-				}
+			out := buf.String()
+			if got := strings.Contains(out, "Preview"); got != tt.preview {
+				t.Errorf("log output %q: preview warning = %v, want %v", out, got, tt.preview)
 			}
-			for _, notWant := range tt.notWant {
-				if strings.Contains(buf.String(), notWant) {
-					t.Errorf("log output %q contains unwanted %q", buf.String(), notWant)
-				}
+			if got := strings.Contains(out, "Ephemeral"); got != tt.ephemeral {
+				t.Errorf("log output %q: ephemeral warning = %v, want %v", out, got, tt.ephemeral)
 			}
 		})
 	}

--- a/cmd/db/main_test.go
+++ b/cmd/db/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +40,66 @@ func waitFor(t *testing.T, what string, cond func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestLogSupportBoundary verifies the startup warnings fire exactly when a preview feature (tiered engine,
+// replication) or ephemeral mode (in-memory without WAL) is selected.
+func TestLogSupportBoundary(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		change  func(*config.ServerConfig)
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "default in-memory without WAL is ephemeral",
+			change:  func(_ *config.ServerConfig) {},
+			want:    []string{"Ephemeral"},
+			notWant: []string{"Preview"},
+		},
+		{
+			name:    "in-memory with WAL is fully supported",
+			change:  func(c *config.ServerConfig) { c.WAL.Enabled = true },
+			notWant: []string{"Ephemeral", "Preview"},
+		},
+		{
+			name:    "tiered engine is preview, not ephemeral",
+			change:  func(c *config.ServerConfig) { c.Engine.Type = engine.TypeTiered },
+			want:    []string{"Preview"},
+			notWant: []string{"Ephemeral"},
+		},
+		{
+			name: "replication is preview",
+			change: func(c *config.ServerConfig) {
+				c.WAL.Enabled = true
+				c.Replication.Role = config.RoleStandby
+			},
+			want:    []string{"Preview"},
+			notWant: []string{"Ephemeral"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.DefaultServerConfig()
+			tt.change(cfg)
+
+			var buf bytes.Buffer
+			logSupportBoundary(cfg, slog.New(slog.NewTextHandler(&buf, nil)))
+
+			for _, want := range tt.want {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("log output %q missing %q", buf.String(), want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(buf.String(), notWant) {
+					t.Errorf("log output %q contains unwanted %q", buf.String(), notWant)
+				}
+			}
+		})
+	}
 }
 
 // TestPromoteServesReplication promotes a standby and verifies it both accepts writes and serves replication to a

--- a/config.server.example.yaml
+++ b/config.server.example.yaml
@@ -1,11 +1,12 @@
 # Example server configuration file. Copy this to config.yaml and modify as needed
 
 engine:
-  type: "in_memory"          # "in_memory" (RAM-only) or "tiered" (memory/disk)
+  type: "in_memory"          # "in_memory" (RAM-only) or "tiered" (memory/disk, preview)
 
-  # The "tiered" engine lets the dataset grow beyond RAM: an append-only on-disk segment store is the source of truth, a
-  # full in-memory keydir indexes every key, and an LRU cache holds hot values. It provides its own durability, so it
-  # cannot be combined with wal.enabled or replication. The fields below apply only when type is "tiered".
+  # The "tiered" engine (preview) lets the dataset grow beyond RAM: an append-only on-disk segment store is the source
+  # of truth, a full in-memory keydir indexes every key, and an LRU cache holds hot values. It provides its own
+  # durability, so it cannot be combined with wal.enabled or replication. The fields below apply only when type is
+  # "tiered".
   data_dir: "data"           # directory for the tiered segment store
   max_memory: 64             # MiB of hot values kept in RAM (LRU budget)
   max_storage: 1024          # MiB ceiling on live data; SET returns "ERR storage full" beyond it
@@ -14,8 +15,9 @@ engine:
   compaction_threshold: 0.5  # reclaim a sealed segment once this fraction is dead bytes
   compaction_interval: 30s   # how often to compact and log cache/disk stats
 
-# The WAL is off by default: the in-memory engine runs without touching disk until persistence is asked for. It cannot
-# be combined with engine.type tiered, which keeps its own durable store.
+# The WAL is off by default: the in-memory engine runs without touching disk until persistence is asked for. That is
+# ephemeral mode — data lives only in RAM and is lost on shutdown. The WAL cannot be combined with engine.type tiered,
+# which keeps its own durable store.
 wal:
   enabled: false
   data_dir: "data"
@@ -23,8 +25,9 @@ wal:
   segment_size: 64          # MiB
   snapshot_interval: 5m
 
-# Replication ships the WAL from a master to standbys (asynchronous). It requires wal.enabled. Leave role empty for a
-# standalone server.
+# Replication (preview) ships the WAL from a master to standbys (asynchronous). It requires wal.enabled. Leave role
+# empty for a standalone server. Standby reads may be stale, and failover is manual: isolate the old master, PROMOTE a
+# standby, and repoint clients.
 replication:
   role: ""                        # "", "master", or "standby"
   # master: address standbys connect to for the WAL stream. standby (optional): if set, PROMOTE starts serving
@@ -33,6 +36,9 @@ replication:
   # standby: the master's listen_address to replicate from.
   master_address: ""              # e.g. "127.0.0.1:3224"
   reconnect_backoff: 1s           # standby: pause between reconnect attempts
+  # standby: permit the PROMOTE command over the client port. Off by default — promotion changes which node accepts
+  # writes, so it has to be an explicit operator decision.
+  allow_remote_promote: false
 
 network:
   address: "127.0.0.1:3223"

--- a/example-pool-config.yaml
+++ b/example-pool-config.yaml
@@ -6,24 +6,25 @@ network:
   idle_timeout: 1m
 
 pool:
-  # Enable connection pool with master/standby servers
+  # Enable connection pool with master/standby servers. Replication is a preview feature: standby reads may be stale
+  # (WAL shipping is asynchronous), and writes always go to the single master — they fail while it is down.
   enabled: true
 
-  # List of servers in the pool
+  # List of servers in the pool: exactly one master, any number of standbys
   servers:
     - address: "127.0.0.1:3223"
       role: master
     - address: "127.0.0.1:3224"
-      role: master
+      role: standby
     - address: "127.0.0.1:3225"
       role: standby
     - address: "127.0.0.1:3226"
       role: standby
 
-  # Selection strategy: master_first, round_robin, or random
-  # - master_first: Try master servers first, fall back to standby on failure
-  # - round_robin: Rotate through all servers in order
-  # - random: Pick servers randomly
+  # Selection strategy for reads (writes always route to the master): master_first, round_robin, or random
+  # - master_first: Read from the master first, fall back to standbys on failure
+  # - round_robin: Rotate reads through all servers in order
+  # - random: Pick a server randomly for each read
   selection_strategy: master_first
 
   # Maximum number of retry attempts when a server fails

--- a/internal/compute/compute.go
+++ b/internal/compute/compute.go
@@ -28,10 +28,11 @@ type Admin interface {
 
 // Compute represents compute layer
 type Compute struct {
-	parser  Parser
-	storage Storage
-	admin   Admin
-	logger  *slog.Logger
+	parser         Parser
+	storage        Storage
+	admin          Admin
+	promoteEnabled bool
+	logger         *slog.Logger
 }
 
 // Option configures a Compute.
@@ -40,6 +41,12 @@ type Option func(*Compute)
 // WithAdmin wires a replication admin handler for PROMOTE and REPLICATION STATUS.
 func WithAdmin(admin Admin) Option {
 	return func(c *Compute) { c.admin = admin }
+}
+
+// WithPromoteEnabled permits PROMOTE when enabled is true. Off by default: promotion changes which node accepts
+// writes, so it has to be an explicit operator decision (replication.allow_remote_promote in the server config).
+func WithPromoteEnabled(enabled bool) Option {
+	return func(c *Compute) { c.promoteEnabled = enabled }
 }
 
 // New creates a new Compute with the given parser, storage, and logger
@@ -85,6 +92,9 @@ func (c *Compute) handleAdmin(ctx context.Context, cmd string, args []string) (p
 	case "PROMOTE":
 		if c.admin == nil {
 			return protocol.Reply{}, true, errors.New("replication not enabled")
+		}
+		if !c.promoteEnabled {
+			return protocol.Reply{}, true, errors.New("PROMOTE is disabled; set replication.allow_remote_promote to enable it")
 		}
 		reply, err := c.admin.Promote(ctx)
 		return reply, true, err

--- a/internal/compute/compute_test.go
+++ b/internal/compute/compute_test.go
@@ -121,7 +121,7 @@ func TestHandleRequest_AdminRouting(t *testing.T) {
 	mockStorage := mocks.NewMockStorage(ctrl)
 	admin := &fakeAdmin{}
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	c := compute.New(parser.New(), mockStorage, logger, compute.WithAdmin(admin))
+	c := compute.New(parser.New(), mockStorage, logger, compute.WithAdmin(admin), compute.WithPromoteEnabled(true))
 	ctx := t.Context()
 
 	res, err := c.HandleRequest(ctx, "PROMOTE", nil)
@@ -147,4 +147,26 @@ func TestHandleRequest_AdminDisabled(t *testing.T) {
 	_, err := c.HandleRequest(t.Context(), "PROMOTE", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "replication not enabled")
+}
+
+// TestHandleRequest_PromoteRefusedByDefault verifies remote promotion stays off unless the operator opts in via
+// replication.allow_remote_promote, while REPLICATION STATUS remains available.
+func TestHandleRequest_PromoteRefusedByDefault(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStorage := mocks.NewMockStorage(ctrl)
+	admin := &fakeAdmin{}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	c := compute.New(parser.New(), mockStorage, logger, compute.WithAdmin(admin))
+
+	_, err := c.HandleRequest(t.Context(), "PROMOTE", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allow_remote_promote")
+	require.False(t, admin.promoted)
+
+	res, err := c.HandleRequest(t.Context(), "REPLICATION", []string{"STATUS"})
+	require.NoError(t, err)
+	require.Equal(t, protocol.ReplyArray, res.Kind)
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -45,6 +45,9 @@ type ServerReplicationConfig struct {
 	ListenAddress    string        `yaml:"listen_address"`
 	MasterAddress    string        `yaml:"master_address"`
 	ReconnectBackoff time.Duration `yaml:"reconnect_backoff"`
+	// AllowRemotePromote permits the PROMOTE command over the client port. Off by default: promotion changes which node
+	// accepts writes, so it has to be an explicit operator decision.
+	AllowRemotePromote bool `yaml:"allow_remote_promote"`
 }
 
 // ServerWALConfig controls durable write-ahead logging and snapshots. SegmentSizeMB is measured in MiB.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -55,6 +55,13 @@ func IsWrite(cmd string) bool {
 	return ok && !spec.readOnly && !spec.admin
 }
 
+// IsAdmin reports whether cmd is a control-plane command aimed at one specific node (e.g. PROMOTE). The pool refuses
+// to route these: it cannot promise which server a pooled command reaches.
+func IsAdmin(cmd string) bool {
+	spec, ok := commands[strings.ToUpper(strings.TrimSpace(cmd))]
+	return ok && spec.admin
+}
+
 // New creates a new Parser instance.
 func New() *Parser {
 	return &Parser{}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -100,3 +100,23 @@ func TestIsWrite(t *testing.T) {
 		t.Error(`IsWrite("  set  ") = false, want true`)
 	}
 }
+
+// TestIsAdmin pins down which commands the pool refuses to route: control-plane commands target one specific node.
+func TestIsAdmin(t *testing.T) {
+	tests := map[string]bool{
+		"PROMOTE":     true,
+		"REPLICATION": true,
+		"SET":         false,
+		"GET":         false,
+		"NONSENSE":    false,
+	}
+	for cmd, want := range tests {
+		if got := parser.IsAdmin(cmd); got != want {
+			t.Errorf("IsAdmin(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+
+	if !parser.IsAdmin("  promote  ") {
+		t.Error(`IsAdmin("  promote  ") = false, want true`)
+	}
+}

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -65,8 +65,7 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 // the pool cannot promise which server a routed command reaches.
 func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 	if parser.IsAdmin(cmd) {
-		return protocol.Reply{}, fmt.Errorf("admin command %s cannot be sent through a pool; connect to the target server directly",
-			strings.ToUpper(strings.TrimSpace(cmd)))
+		return protocol.Reply{}, fmt.Errorf("admin command %s cannot be sent through a pool; connect to the target server directly", cmd)
 	}
 	write := parser.IsWrite(cmd)
 	var lastErr error
@@ -105,8 +104,9 @@ func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
 			continue
 		}
 
-		// A write that reached a read-only server means our master routing is stale (the server was demoted); fail it over
-		// and retry elsewhere.
+		// A write that reached a read-only server means our master routing is stale (the server was demoted); mark it
+		// failed and retry. A pool holds one master, so the retry revisits it: the attempts drain and the caller gets the
+		// read-only error rather than a false success.
 		if write && isReadOnlyReply(resp) {
 			c.selector.MarkFailed(server.Address)
 			lastErr = fmt.Errorf("server %s is read-only", server.Address)

--- a/internal/pool/client.go
+++ b/internal/pool/client.go
@@ -59,10 +59,15 @@ func NewClient(config *PoolConfig, options ...network.TCPClientOption) (*Client,
 	}, nil
 }
 
-// Send sends a command using the pool, with automatic failover. Mutating commands route to a master; reads follow the
-// configured strategy. A standby that replies "ERR readonly" to a write marks the routing stale, so the pool fails that
-// server over and retries against another master.
+// Send sends a command using the pool. Mutating commands route to the master; reads follow the configured strategy and
+// retry on another server after a failure. A server that replies "ERR readonly" to a write marks the routing stale, so
+// the pool treats it as failed and retries. Admin commands are refused client-side: they target one specific node, and
+// the pool cannot promise which server a routed command reaches.
 func (c *Client) Send(cmd string, args []string) (protocol.Reply, error) {
+	if parser.IsAdmin(cmd) {
+		return protocol.Reply{}, fmt.Errorf("admin command %s cannot be sent through a pool; connect to the target server directly",
+			strings.ToUpper(strings.TrimSpace(cmd)))
+	}
 	write := parser.IsWrite(cmd)
 	var lastErr error
 	attempts := 0

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -96,6 +96,9 @@ func (p *PoolConfig) validateServers() error {
 	if masterCount == 0 {
 		return errors.New("at least one master server is required")
 	}
+	if masterCount > 1 {
+		return errors.New("at most one master server is allowed")
+	}
 
 	return nil
 }

--- a/internal/pool/config_test.go
+++ b/internal/pool/config_test.go
@@ -57,6 +57,18 @@ func TestPoolConfig_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "pool with two masters",
+			config: &pool.PoolConfig{
+				Enabled: true,
+				Servers: []pool.ServerConfig{
+					{Address: "127.0.0.1:3223", Role: pool.RoleMaster},
+					{Address: "127.0.0.1:3224", Role: pool.RoleMaster},
+				},
+				SelectionStrategy: pool.StrategyMasterFirst,
+			},
+			wantErr: true,
+		},
+		{
 			name: "pool with empty address",
 			config: &pool.PoolConfig{
 				Enabled: true,

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -3,6 +3,7 @@ package pool_test
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -147,29 +148,56 @@ func TestClient_ReadsMayUseStandbys(t *testing.T) {
 	}
 }
 
-// TestClient_ReadOnlyFailover verifies an "ERR readonly" reply to a write marks the server stale and reroutes to
-// another master.
+// TestClient_ReadOnlyFailover verifies an "ERR readonly" reply to a write is treated as a failure and retried rather
+// than returned to the caller as success. With one master allowed per pool, the retries can only revisit the same
+// demoted server, so Send exhausts its attempts and reports the read-only error.
 func TestClient_ReadOnlyFailover(t *testing.T) {
 	t.Parallel()
-	var goodHits atomic.Int32
+	var hits atomic.Int32
 	readOnlyAddr := startHandler(t, func(_ context.Context, _ string, _ []string) protocol.Reply {
+		hits.Add(1)
 		return protocol.Error("readonly")
 	})
-	goodAddr := startHandler(t, okHandler(&goodHits))
 
 	client := newPool(t, []pool.ServerConfig{
 		{Address: readOnlyAddr, Role: pool.RoleMaster},
-		{Address: goodAddr, Role: pool.RoleMaster},
 	}, pool.StrategyMasterFirst)
 
-	resp, err := client.Send("SET", []string{"t", "k", "v"})
-	if err != nil {
-		t.Fatalf("Send SET: %v", err)
+	_, err := client.Send("SET", []string{"t", "k", "v"})
+	if err == nil {
+		t.Fatal("Send SET against a read-only master succeeded, want error")
 	}
-	if resp.Kind != protocol.ReplySimpleString || resp.Value != "OK" {
-		t.Fatalf("reply = %+v, want +OK", resp)
+	if !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("error = %v, want it to name the read-only server", err)
 	}
-	if goodHits.Load() == 0 {
-		t.Error("write never reached the writable master after readonly failover")
+	if hits.Load() != 4 {
+		t.Errorf("read-only master hit %d times, want 4 (initial attempt + 3 retries)", hits.Load())
+	}
+}
+
+// TestClient_RejectsAdminCommands verifies control-plane commands never leave the client: they target one specific
+// node, and the pool cannot promise which server a routed command reaches.
+func TestClient_RejectsAdminCommands(t *testing.T) {
+	t.Parallel()
+	var hits atomic.Int32
+	masterAddr := startHandler(t, okHandler(&hits))
+
+	client := newPool(t, []pool.ServerConfig{
+		{Address: masterAddr, Role: pool.RoleMaster},
+	}, pool.StrategyMasterFirst)
+
+	for _, tc := range []struct {
+		cmd  string
+		args []string
+	}{
+		{cmd: "PROMOTE"},
+		{cmd: "REPLICATION", args: []string{"STATUS"}},
+	} {
+		if _, err := client.Send(tc.cmd, tc.args); err == nil {
+			t.Errorf("Send %s through the pool succeeded, want error", tc.cmd)
+		}
+	}
+	if hits.Load() != 0 {
+		t.Errorf("server received %d admin commands, want 0", hits.Load())
 	}
 }

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -186,15 +186,9 @@ func TestClient_RejectsAdminCommands(t *testing.T) {
 		{Address: masterAddr, Role: pool.RoleMaster},
 	}, pool.StrategyMasterFirst)
 
-	for _, tc := range []struct {
-		cmd  string
-		args []string
-	}{
-		{cmd: "PROMOTE"},
-		{cmd: "REPLICATION", args: []string{"STATUS"}},
-	} {
-		if _, err := client.Send(tc.cmd, tc.args); err == nil {
-			t.Errorf("Send %s through the pool succeeded, want error", tc.cmd)
+	for _, cmd := range []string{"PROMOTE", "REPLICATION"} {
+		if _, err := client.Send(cmd, nil); err == nil {
+			t.Errorf("Send %s through the pool succeeded, want error", cmd)
 		}
 	}
 	if hits.Load() != 0 {


### PR DESCRIPTION
Make config, startup output, and docs agree on what v1 supports: the  in-memory engine with WAL/snapshots, the Go client, and the CLI are GA;  the tiered engine, replication/promotion/standby reads, and WAL-off  ephemeral mode are previews labeled at startup. 
- reject pool configs with more than one master                                                                                                                                                                                                                                             
- refuse PROMOTE unless replication.allow_remote_promote is set                                                                                                                                                                                                                             
- refuse admin commands (PROMOTE, REPLICATION) in the pool client: they  target one node, and the pool cannot promise which one it reaches
- warn at startup for preview (tiered, replication) and ephemeral (in-memory without WAL) modes
- reword "distributed" / "automatic failover" claims; document the GA/preview split, stale standby reads, and manual write failover 

BREAKING CHANGE: pool configs listing multiple masters now fail validation, and PROMOTE is refused unless the standby's config sets replication.allow_remote_promote: true.          