### PR TITLE
Harden server startup and shutdown safety measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ network:
   max_connections: 100
   max_message_size: 4
   idle_timeout: 5m
+  shutdown_timeout: 10s
 logging:
   level: "info"
   output: "/log/output.log"
@@ -228,7 +229,8 @@ with `wal.enabled` or replication — the server refuses that combination at sta
 - **engine.compaction_interval**: How often to compact and log cache/disk stats
 
 - **wal.enabled**: Enable durable write-ahead logging (disabled by default)
-- **wal.data_dir**: Directory for WAL segments and snapshots
+- **wal.data_dir**: Directory for WAL segments and snapshots. Required for the in-memory engine even when WAL is
+  disabled, because startup scans it before allowing ephemeral mode
 - **wal.sync**: Fsync policy (`always`, `everysec`, or `no`)
 - **wal.segment_size**: WAL segment rollover size in MiB
 - **wal.snapshot_interval**: Interval between snapshots when data has changed
@@ -242,8 +244,16 @@ with `wal.enabled` or replication — the server refuses that combination at sta
 - **network.max_connections**: Maximum concurrent client connections (enforced by server)
 - **network.max_message_size**: Maximum message size in KB
 - **network.idle_timeout**: Client idle timeout duration
+- **network.shutdown_timeout**: Grace period for decoded commands before their contexts are cancelled (default `10s`).
+  Shutdown then waits for handlers to return before closing persistence, so this is not a hard process-exit deadline
 - **logging.level**: Log level (debug, info, warn, error)
 - **logging.output**: Log output file path (empty for stdout)
+
+Unknown YAML fields, unsupported log levels, and byte-size values that overflow are startup errors. Durable modes hold
+an OS lock on `.db.lock` in their data directory from before recovery until final close, so a second server using that
+directory fails immediately. The lock is advisory on Unix and requires a local filesystem; NFS and other network
+filesystems are unsupported. The lockfile remains after shutdown, but the OS lock is released automatically, including
+after a process crash.
 
 #### Environment Variable Overrides
 
@@ -270,6 +280,11 @@ make build
 ./bin/db -config config.yaml
 ```
 
+A non-empty `-config` path is exact and required: relative and absolute paths are accepted, while a missing or unreadable
+file aborts startup instead of falling back to defaults. Starting the ephemeral in-memory mode over recognized WAL,
+snapshot, or tiered files is also refused. To acknowledge that data will be ignored for one launch, pass
+`-allow-ephemeral-over-data`; this flag never permits opening one durable engine's files with the other engine.
+
 ### Using make:
 ```bash
 make run
@@ -290,9 +305,9 @@ published port, and logs to stdout for `docker logs`. Configure it with environm
 docker run --rm -p 3223:3223 -e DB_LOG_LEVEL=debug -e DB_MAX_CONNECTIONS=500 db
 ```
 
-Settings without an environment variable (engine type, WAL, replication) come from a YAML file. The `-config` path is
-resolved relative to the working directory, which is `/home/nonroot`, so mount the file there — an absolute path is
-rejected, and a path that resolves nowhere falls back to defaults silently:
+Settings without an environment variable (engine type, WAL, replication) come from a YAML file. A relative `-config`
+path is resolved from the working directory, which is `/home/nonroot`, so mount the file there; an absolute mounted path
+works as well. A path that does not exist aborts startup:
 
 ```bash
 docker run --rm -p 3223:3223 \

--- a/client/integration_test.go
+++ b/client/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,36 +43,36 @@ func startStoppableServer(t *testing.T, opts ...network.TCPServerOption) (addr s
 
 	comp := compute.New(parser.New(), storage.New(engine.New()), logger)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go srv.Start(ctx, func(ctx context.Context, cmd string, args []string) protocol.Reply {
-		res, rErr := comp.HandleRequest(ctx, cmd, args)
-		if rErr != nil {
-			if errors.Is(rErr, storage.ErrNotFound) {
-				return protocol.NullBulkString()
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Serve(func(ctx context.Context, cmd string, args []string) protocol.Reply {
+			res, rErr := comp.HandleRequest(ctx, cmd, args)
+			if rErr != nil {
+				if errors.Is(rErr, storage.ErrNotFound) {
+					return protocol.NullBulkString()
+				}
+				return protocol.Error(rErr.Error())
 			}
-			return protocol.Error(rErr.Error())
-		}
-		return res
-	})
+			return res
+		})
+	}()
 
 	addr = srv.Addr().String()
 
+	var once sync.Once
 	stop = func() {
-		cancel()
-		// wait until the listener is actually closed so new dials fail deterministically
-		dialer := &net.Dialer{}
-		for range 100 {
-			conn, dErr := dialer.DialContext(context.Background(), "tcp", addr)
-			if dErr != nil {
-				return
+		once.Do(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if sErr := srv.Shutdown(ctx); sErr != nil {
+				t.Errorf("Shutdown: %v", sErr)
 			}
-			_ = conn.Close()
-			time.Sleep(10 * time.Millisecond)
-		}
-		t.Fatalf("server at %s did not stop accepting connections", addr)
+			if sErr := <-done; sErr != nil {
+				t.Errorf("Serve: %v", sErr)
+			}
+		})
 	}
+	t.Cleanup(stop)
 
 	return addr, stop
 }

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -94,9 +94,7 @@ func run(cfg *config.ServerConfig, logger *slog.Logger, allowEphemeralOverData b
 	if err != nil {
 		return err
 	}
-	if lock != nil {
-		defer func() { err = errors.Join(err, lock.Close()) }()
-	}
+	defer func() { err = errors.Join(err, lock.Close()) }()
 
 	dbEngine, walWriter, snapshotLSN, err := buildEngine(cfg, logger)
 	if err != nil {
@@ -155,7 +153,7 @@ func prepareDataDir(cfg *config.ServerConfig, allowEphemeralOverData bool) (*dat
 	}
 	kind, err := datadir.Detect(dir)
 	if err != nil {
-		return nil, errors.Join(err, closeDataDirLock(lock))
+		return nil, errors.Join(err, lock.Close())
 	}
 	if !durable {
 		if kind != datadir.KindNone && !allowEphemeralOverData {
@@ -170,17 +168,10 @@ func prepareDataDir(cfg *config.ServerConfig, allowEphemeralOverData bool) (*dat
 	if kind != datadir.KindNone && kind != expected {
 		return nil, errors.Join(
 			fmt.Errorf("configured %s storage but found %s database files in %q", expected, kind, dir),
-			closeDataDirLock(lock),
+			lock.Close(),
 		)
 	}
 	return lock, nil
-}
-
-func closeDataDirLock(lock *datadir.Lock) error {
-	if lock == nil {
-		return nil
-	}
-	return lock.Close()
 }
 
 // logSupportBoundary warns when the configuration selects features outside the GA support boundary: the tiered engine

--- a/cmd/db/main.go
+++ b/cmd/db/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/OutOfStack/db/internal/compute"
 	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/datadir"
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/engine/tiered"
 	"github.com/OutOfStack/db/internal/network"
@@ -32,7 +33,10 @@ func main() {
 // the log file) runs before os.Exit.
 func execute() int {
 	var configPath string
+	var allowEphemeralOverData bool
 	flag.StringVar(&configPath, "config", "", "Path to configuration file")
+	flag.BoolVar(&allowEphemeralOverData, "allow-ephemeral-over-data", false,
+		"Allow ephemeral startup when durable database files already exist")
 	flag.Parse()
 
 	cfg, err := config.LoadServerConfig(configPath)
@@ -45,14 +49,19 @@ func execute() int {
 		log.Printf("Failed to configure logging: %v\n", err)
 		return 1
 	}
-	defer func() {
-		if closeErr := closeLog(); closeErr != nil {
-			log.Printf("Failed to close log file: %v", closeErr)
-		}
-	}()
+	runErr := run(cfg, logger, allowEphemeralOverData)
+	if runErr != nil {
+		logger.Error("Server stopped", "error", runErr)
+	}
+	closeErr := closeLog()
+	if closeErr != nil {
+		log.Printf("Failed to close log file: %v", closeErr)
+	}
+	return processExitCode(runErr, closeErr)
+}
 
-	if err = run(cfg, logger); err != nil {
-		logger.Error("Server stopped", "error", err)
+func processExitCode(errs ...error) int {
+	if errors.Join(errs...) != nil {
 		return 1
 	}
 	return 0
@@ -79,20 +88,25 @@ func newLogger(cfg config.ServerLoggingConfig) (*slog.Logger, func() error, erro
 	return slog.New(slog.NewJSONHandler(file, opts)), file.Close, nil
 }
 
-func run(cfg *config.ServerConfig, logger *slog.Logger) error {
+func run(cfg *config.ServerConfig, logger *slog.Logger, allowEphemeralOverData bool) (err error) {
 	logSupportBoundary(cfg, logger)
+	lock, err := prepareDataDir(cfg, allowEphemeralOverData)
+	if err != nil {
+		return err
+	}
+	if lock != nil {
+		defer func() { err = errors.Join(err, lock.Close()) }()
+	}
 
 	dbEngine, walWriter, snapshotLSN, err := buildEngine(cfg, logger)
 	if err != nil {
 		return err
 	}
-	// Only the tiered engine holds resources; the in-memory one is not an io.Closer. Deferred so an early return below
-	// still flushes it.
 	if closer, ok := dbEngine.(io.Closer); ok {
-		defer func() { _ = closer.Close() }()
+		defer func() { err = errors.Join(err, closer.Close()) }()
 	}
 	if walWriter != nil {
-		defer func() { _ = walWriter.Close() }() // the coordinated shutdown below reports the first close error
+		defer func() { err = errors.Join(err, walWriter.Close()) }()
 	}
 
 	var options []storage.Option
@@ -119,6 +133,54 @@ func run(cfg *config.ServerConfig, logger *slog.Logger) error {
 	}
 	comp := compute.New(parser.New(), store, logger, computeOptions...)
 	return serve(cfg, logger, comp, store, walWriter, repl, snapshotLSN)
+}
+
+func prepareDataDir(cfg *config.ServerConfig, allowEphemeralOverData bool) (*datadir.Lock, error) {
+	dir := cfg.WAL.DataDir
+	expected := datadir.KindWAL
+	durable := cfg.WAL.Enabled
+	if cfg.Engine.Type == engine.TypeTiered {
+		dir = cfg.Engine.DataDir
+		expected = datadir.KindTiered
+		durable = true
+	}
+
+	var lock *datadir.Lock
+	var err error
+	if durable {
+		lock, err = datadir.Acquire(dir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	kind, err := datadir.Detect(dir)
+	if err != nil {
+		return nil, errors.Join(err, closeDataDirLock(lock))
+	}
+	if !durable {
+		if kind != datadir.KindNone && !allowEphemeralOverData {
+			return nil, fmt.Errorf(
+				"refusing ephemeral startup over %s database files in %q; use -allow-ephemeral-over-data to proceed",
+				kind, dir,
+			)
+		}
+		//nolint:nilnil // Ephemeral mode does not own a directory lock.
+		return nil, nil
+	}
+	if kind != datadir.KindNone && kind != expected {
+		return nil, errors.Join(
+			fmt.Errorf("configured %s storage but found %s database files in %q", expected, kind, dir),
+			closeDataDirLock(lock),
+		)
+	}
+	return lock, nil
+}
+
+func closeDataDirLock(lock *datadir.Lock) error {
+	if lock == nil {
+		return nil
+	}
+	return lock.Close()
 }
 
 // logSupportBoundary warns when the configuration selects features outside the GA support boundary: the tiered engine
@@ -217,39 +279,36 @@ func serve(
 		network.WithServerMaxMessageSize(cfg.Network.MaxMessageSizeKB*1024),
 		network.WithServerMaxConnections(cfg.Network.MaxConnections))
 	if err != nil {
-		return err
+		return errors.Join(err, stopReplication(repl))
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	serverDone := make(chan struct{})
+	runtimeCtx, cancelRuntime := context.WithCancel(context.Background())
+	defer cancelRuntime()
+	serverDone := make(chan error, 1)
 	go func() {
-		defer close(serverDone)
-		srv.Start(ctx, requestHandler(comp))
+		serverDone <- srv.Serve(requestHandler(comp))
 	}()
 	// Snapshots run for every role: a standby applies replicated records through the storage layer under the same lock a
 	// snapshot takes, so its snapshots are consistent, and this keeps a promoted node's WAL bounded.
-	snapshotDone := startSnapshotLoop(ctx, cfg, logger, store, walWriter, recoveredSnapshotLSN)
-	replDone := startReplication(ctx, logger, repl)
+	snapshotDone := startSnapshotLoop(runtimeCtx, cfg, logger, store, walWriter, recoveredSnapshotLSN)
+	replDone := startReplication(runtimeCtx, logger, repl)
 
 	logger.Info("Server started", "address", cfg.Network.Address, "role", roleName(cfg.Replication.Role))
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
 	<-sigChan
-
 	logger.Info("Shutting down server...")
-	cancel()
-	stopReplication(logger, repl)
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), cfg.Network.ShutdownTimeout)
+	serveErr := srv.Shutdown(shutdownCtx)
+	cancelShutdown()
+	serveErr = errors.Join(serveErr, <-serverDone)
+
+	cancelRuntime()
+	replErr := stopReplication(repl)
 	<-replDone
-	<-serverDone
 	<-snapshotDone
-	if walWriter != nil {
-		if err = walWriter.Close(); err != nil {
-			return fmt.Errorf("close WAL: %w", err)
-		}
-	}
-	return nil
+	return errors.Join(serveErr, replErr)
 }
 
 func requestHandler(comp *compute.Compute) network.RequestHandler {

--- a/cmd/db/main_test.go
+++ b/cmd/db/main_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +18,8 @@ import (
 	"github.com/OutOfStack/db/internal/replication"
 	"github.com/OutOfStack/db/internal/storage"
 	"github.com/OutOfStack/db/internal/wal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // freeAddr returns a currently-free localhost address for a replication listener.
@@ -95,6 +99,89 @@ func TestLogSupportBoundary(t *testing.T) {
 	}
 }
 
+func TestProcessExitCodeReportsCloseFailure(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, processExitCode(nil, nil))
+	assert.Equal(t, 1, processExitCode(nil, errors.New("close failed")))
+}
+
+func TestPrepareDataDirRejectsUnsafeEngineDataCombinations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		engine   string
+		wal      bool
+		files    []string
+		override bool
+		wantErr  string
+	}{
+		{"ephemeral over WAL", engine.TypeInMemory, false, []string{"wal-00000000000000000001.log"}, false, "ephemeral"},
+		{"ephemeral override", engine.TypeInMemory, false, []string{"wal-00000000000000000001.log"}, true, ""},
+		{"WAL over tiered", engine.TypeInMemory, true, []string{"seg-0000000001.data"}, false, "tiered"},
+		{"tiered over WAL", engine.TypeTiered, false, []string{"snapshot-00000000000000000001.db"}, false, "wal"},
+		{"mixed formats", engine.TypeInMemory, true, []string{
+			"wal-00000000000000000001.log", "seg-0000000001.data",
+		}, false, "mixed"},
+		{"unrelated file", engine.TypeInMemory, true, []string{"notes.txt"}, false, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			for _, name := range test.files {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o600))
+			}
+			cfg := config.DefaultServerConfig()
+			cfg.Engine.Type = test.engine
+			cfg.Engine.DataDir = dir
+			cfg.WAL.Enabled = test.wal
+			cfg.WAL.DataDir = dir
+
+			lock, err := prepareDataDir(cfg, test.override)
+			if test.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, strings.ToLower(err.Error()), test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if lock != nil {
+				require.NoError(t, lock.Close())
+			}
+		})
+	}
+}
+
+func TestPrepareDataDirHoldsDurableLock(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultServerConfig()
+	cfg.WAL.Enabled = true
+	cfg.WAL.DataDir = t.TempDir()
+
+	lock, err := prepareDataDir(cfg, false)
+	require.NoError(t, err)
+	_, err = prepareDataDir(cfg, false)
+	require.Error(t, err)
+	require.NoError(t, lock.Close())
+
+	lock, err = prepareDataDir(cfg, false)
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
+}
+
+func TestStopReplicationBeforeStandbyStartsDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	standby := replication.NewStandby("127.0.0.1:1", nil, t.TempDir(), 0, time.Second, slog.New(slog.DiscardHandler))
+	done := make(chan error, 1)
+	go func() { done <- stopReplication(&replicationRuntime{standby: standby}) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("stopReplication blocked on a standby that never started")
+	}
+}
+
 // TestPromoteServesReplication promotes a standby and verifies it both accepts writes and serves replication to a
 // downstream standby.
 func TestPromoteServesReplication(t *testing.T) {
@@ -120,8 +207,8 @@ func TestPromoteServesReplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setupReplication() error = %v", err)
 	}
-	repl.standby.Start(t.Context())
-	defer stopReplication(logger, repl)
+	startReplication(t.Context(), logger, repl)
+	defer func() { _ = stopReplication(repl) }()
 
 	if _, err = store.Execute(t.Context(), "SET", []string{"t", "k", "v"}); !errors.Is(err, storage.ErrReadOnly) {
 		t.Fatalf("SET on standby error = %v, want ErrReadOnly", err)

--- a/cmd/db/replication.go
+++ b/cmd/db/replication.go
@@ -17,9 +17,10 @@ import (
 // replicationRuntime bundles the replication components for a server, exactly one of master/standby is non-nil (both
 // nil for a standalone server).
 type replicationRuntime struct {
-	master  *replication.Master
-	standby *replication.Standby
-	admin   *replicationAdmin
+	master         *replication.Master
+	standby        *replication.Standby
+	standbyStarted bool
+	admin          *replicationAdmin
 }
 
 // setupReplication builds the replication runtime for the configured role. It returns nil for a standalone server.
@@ -79,6 +80,7 @@ func startReplication(ctx context.Context, _ *slog.Logger, repl *replicationRunt
 			repl.master.Serve(ctx)
 		}()
 	case repl.standby != nil:
+		repl.standbyStarted = true
 		repl.standby.Start(ctx)
 		close(done)
 	default:
@@ -88,21 +90,21 @@ func startReplication(ctx context.Context, _ *slog.Logger, repl *replicationRunt
 }
 
 // stopReplication tears down replication during shutdown.
-func stopReplication(logger *slog.Logger, repl *replicationRuntime) {
+func stopReplication(repl *replicationRuntime) error {
 	if repl == nil {
-		return
+		return nil
 	}
+	var err error
 	if repl.master != nil {
-		if err := repl.master.Close(); err != nil {
-			logger.Error("Failed to close replication master", "error", err)
-		}
+		err = errors.Join(err, repl.master.Close())
 	}
-	if repl.standby != nil {
+	if repl.standbyStarted {
 		repl.standby.Stop()
 	}
 	if repl.admin != nil {
-		repl.admin.close() // stops a master started by promotion, if any
+		err = errors.Join(err, repl.admin.close()) // stops a master started by promotion, if any
 	}
+	return err
 }
 
 // replicationAdmin implements compute.Admin, handling PROMOTE and REPLICATION STATUS. Its role changes from standby to
@@ -162,17 +164,16 @@ func (a *replicationAdmin) startMasterLocked() error {
 }
 
 // close stops a replication listener started by promotion. It is called during server shutdown.
-func (a *replicationAdmin) close() {
+func (a *replicationAdmin) close() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.promotedCancel != nil {
 		a.promotedCancel()
 	}
 	if a.promoted != nil {
-		if err := a.promoted.Close(); err != nil {
-			a.logger.Error("Failed to close promoted replication master", "error", err)
-		}
+		return a.promoted.Close()
 	}
+	return nil
 }
 
 // Status returns role, applied LSN, lag, and connection state as a flat key/value array reply.

--- a/cmd/db/shutdown_unix_test.go
+++ b/cmd/db/shutdown_unix_test.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/db/internal/config"
+	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/OutOfStack/db/internal/wal"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	shutdownHelperAddress = "DB_TEST_SHUTDOWN_ADDRESS"
+	shutdownHelperDataDir = "DB_TEST_SHUTDOWN_DATA_DIR"
+)
+
+func TestSIGTERMPreservesAcknowledgedWrite(t *testing.T) {
+	dataDir := t.TempDir()
+	address := freeAddr(t)
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestShutdownHelperProcess$")
+	cmd.Env = append(os.Environ(), shutdownHelperAddress+"="+address, shutdownHelperDataDir+"="+dataDir)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	require.NoError(t, cmd.Start())
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	stopped := false
+	defer func() {
+		if !stopped {
+			_ = cmd.Process.Kill()
+			<-waitDone
+		}
+	}()
+
+	client := network.NewTCPClient(address, network.WithClientIdleTimeout(100*time.Millisecond))
+	defer func() { _ = client.Close() }()
+	waitFor(t, "server process to accept commands", func() bool {
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+		_, err := client.Send(ctx, "GET", []string{"health", "ready"})
+		return err == nil
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	reply, err := client.Send(ctx, "SET", []string{"users", "name", "vlad"})
+	cancel()
+	require.NoError(t, err)
+	require.Equal(t, protocol.SimpleString("OK"), reply)
+	require.NoError(t, client.Close())
+	require.NoError(t, cmd.Process.Signal(syscall.SIGTERM))
+
+	select {
+	case err = <-waitDone:
+		stopped = true
+		require.NoError(t, err, output.String())
+	case <-time.After(5 * time.Second):
+		t.Fatalf("server did not stop after SIGTERM: %s", output.String())
+	}
+
+	cfg := shutdownTestConfig(address, dataDir)
+	dbEngine, writer, _, err := recoverPersistence(cfg, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, writer.Close()) }()
+	value, err := dbEngine.Get(t.Context(), "users", "name")
+	require.NoError(t, err)
+	require.Equal(t, "vlad", stored(value))
+}
+
+func TestShutdownHelperProcess(t *testing.T) {
+	address := os.Getenv(shutdownHelperAddress)
+	if address == "" {
+		return
+	}
+	cfg := shutdownTestConfig(address, os.Getenv(shutdownHelperDataDir))
+	require.NoError(t, run(cfg, slog.New(slog.DiscardHandler), false))
+}
+
+func shutdownTestConfig(address, dataDir string) *config.ServerConfig {
+	cfg := config.DefaultServerConfig()
+	cfg.Network.Address = address
+	cfg.Network.ShutdownTimeout = time.Second
+	cfg.WAL.Enabled = true
+	cfg.WAL.DataDir = dataDir
+	cfg.WAL.Sync = wal.SyncAlways
+	cfg.WAL.SegmentSizeMB = 1
+	return cfg
+}

--- a/config.server.example.yaml
+++ b/config.server.example.yaml
@@ -45,6 +45,7 @@ network:
   max_connections: 100
   max_message_size: 4
   idle_timeout: 5m
+  shutdown_timeout: 10s  # grace period before cancelling decoded commands; handlers must still return before close
 
 logging:
   level: "info"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 
@@ -63,16 +65,10 @@ func LoadServerConfig(filename string) (*ServerConfig, error) {
 	cfg := DefaultServerConfig()
 
 	if filename != "" {
-		data, err := load(filename)
+		var err error
+		cfg, err = decodeServerConfig(filename)
 		if err != nil {
 			return nil, err
-		}
-		if data != nil {
-			fileCfg := *DefaultServerConfig()
-			if err = yaml.Unmarshal(data, &fileCfg); err != nil {
-				return nil, fmt.Errorf("failed to parse config file: %w", err)
-			}
-			cfg = &fileCfg
 		}
 	}
 
@@ -85,6 +81,29 @@ func LoadServerConfig(filename string) (*ServerConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+func decodeServerConfig(filename string) (*ServerConfig, error) {
+	// #nosec G304 -- the command-line config path is intentionally operator-controlled.
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %q: %w", filename, err)
+	}
+
+	cfg := DefaultServerConfig()
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err = decoder.Decode(cfg); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+	var extra any
+	if err = decoder.Decode(&extra); errors.Is(err, io.EOF) {
+		return cfg, nil
+	}
+	if err == nil {
+		return nil, errors.New("failed to parse config file: expected one YAML document")
+	}
+	return nil, fmt.Errorf("failed to parse config file: %w", err)
 }
 
 // LoadClientConfig loads the client configuration from a YAML file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,12 +15,12 @@ import (
 func TestLoadServerConfig(t *testing.T) {
 	t.Parallel()
 
-	t.Run("loads default config if file not found", func(t *testing.T) {
+	t.Run("rejects an explicitly missing file", func(t *testing.T) {
 		t.Parallel()
 
-		cfg, err := config.LoadServerConfig("non-existent-config.yaml")
-		require.NoError(t, err)
-		assert.Equal(t, config.DefaultServerConfig(), cfg)
+		_, err := config.LoadServerConfig("non-existent-config.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-existent-config.yaml")
 	})
 
 	t.Run("loads config from file", func(t *testing.T) {
@@ -53,13 +53,14 @@ wal:
 		err = tmpFile.Close()
 		require.NoError(t, err)
 
-		cfg, err := config.LoadServerConfig(filepath.Base(tmpFile.Name()))
+		cfg, err := config.LoadServerConfig(tmpFile.Name())
 		require.NoError(t, err)
 
 		assert.Equal(t, "0.0.0.0:8080", cfg.Network.Address)
 		assert.Equal(t, 50, cfg.Network.MaxConnections)
 		assert.Equal(t, 8, cfg.Network.MaxMessageSizeKB)
 		assert.Equal(t, 10*time.Minute, cfg.Network.IdleTimeout)
+		assert.Equal(t, 10*time.Second, cfg.Network.ShutdownTimeout)
 		assert.Equal(t, "debug", cfg.Logging.Level)
 		assert.Equal(t, "/tmp/test.log", cfg.Logging.Output)
 		assert.Equal(t, "in_memory", cfg.Engine.Type)
@@ -68,6 +69,36 @@ wal:
 		assert.Equal(t, wal.SyncAlways, cfg.WAL.Sync)
 		assert.Equal(t, int64(8), cfg.WAL.SegmentSizeMB)
 		assert.Equal(t, 30*time.Second, cfg.WAL.SnapshotInterval)
+	})
+
+	t.Run("rejects unreadable path", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := config.LoadServerConfig(t.TempDir())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read config file")
+	})
+
+	t.Run("rejects unknown fields", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "server.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("network:\n  typo: true\n"), 0o600))
+
+		_, err := config.LoadServerConfig(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field typo not found")
+	})
+
+	t.Run("rejects multiple documents", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "server.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("logging:\n  level: info\n---\nlogging:\n  level: debug\n"), 0o600))
+
+		_, err := config.LoadServerConfig(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "one YAML document")
 	})
 
 	t.Run("returns error for invalid config values", func(t *testing.T) {
@@ -93,6 +124,60 @@ network:
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid config: maxConnections must be positive")
 	})
+}
+
+func TestServerConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name   string
+		change func(*config.ServerConfig)
+		want   string
+	}{
+		{"unsupported log level", func(cfg *config.ServerConfig) { cfg.Logging.Level = "verbose" }, "logging level"},
+		{"empty ephemeral data directory", func(cfg *config.ServerConfig) { cfg.WAL.DataDir = "" }, "wal dataDir"},
+		{"zero shutdown timeout", func(cfg *config.ServerConfig) { cfg.Network.ShutdownTimeout = 0 }, "shutdownTimeout"},
+		{"message size overflow", func(cfg *config.ServerConfig) {
+			cfg.Network.MaxMessageSizeKB = maxInt/1024 + 1
+		}, "maxMessageSize overflows bytes"},
+		{"WAL segment overflow", func(cfg *config.ServerConfig) {
+			cfg.WAL.Enabled = true
+			cfg.WAL.SegmentSizeMB = int64(^uint64(0)>>1)/(1<<20) + 1
+		}, "wal segmentSize overflows bytes"},
+		{"tiered memory overflow", func(cfg *config.ServerConfig) {
+			cfg.Engine.Type = "tiered"
+			cfg.Engine.MaxMemoryMB = int64(^uint64(0)>>1)/(1<<20) + 1
+			cfg.Engine.MaxStorageMB = cfg.Engine.MaxMemoryMB
+		}, "engine max_memory overflows bytes"},
+		{"tiered storage overflow", func(cfg *config.ServerConfig) {
+			cfg.Engine.Type = "tiered"
+			cfg.Engine.MaxStorageMB = int64(^uint64(0)>>1)/(1<<20) + 1
+		}, "engine max_storage overflows bytes"},
+		{"tiered segment overflow", func(cfg *config.ServerConfig) {
+			cfg.Engine.Type = "tiered"
+			cfg.Engine.SegmentSizeMB = int64(^uint64(0)>>1)/(1<<20) + 1
+		}, "engine segment_size overflows bytes"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.DefaultServerConfig()
+			test.change(cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+func TestDefaultServerConfigUsesTenSecondShutdown(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.LoadServerConfig("")
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, cfg.Network.ShutdownTimeout)
 }
 
 func TestServerWALConfigValidation(t *testing.T) {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -21,6 +21,8 @@ const (
 	envLogOutput      = "DB_LOG_OUTPUT"
 )
 
+const defaultLogLevel = "info"
+
 // Replication roles.
 const (
 	RoleStandalone = ""
@@ -79,6 +81,7 @@ type ServerNetworkConfig struct {
 	MaxConnections   int           `yaml:"max_connections"`
 	MaxMessageSizeKB int           `yaml:"max_message_size"`
 	IdleTimeout      time.Duration `yaml:"idle_timeout"`
+	ShutdownTimeout  time.Duration `yaml:"shutdown_timeout"`
 }
 
 // ServerLoggingConfig - logging configuration including log level and output destination. Level can be "debug", "info",
@@ -118,9 +121,10 @@ func DefaultServerConfig() *ServerConfig {
 			MaxConnections:   100,
 			MaxMessageSizeKB: 4,
 			IdleTimeout:      time.Minute,
+			ShutdownTimeout:  10 * time.Second,
 		},
 		Logging: ServerLoggingConfig{
-			Level:  "info",
+			Level:  defaultLogLevel,
 			Output: "",
 		},
 	}
@@ -167,41 +171,71 @@ func (c *ServerConfig) Validate() error {
 	if err := c.Engine.validate(c.WAL.Enabled, c.Replication.Role); err != nil {
 		return err
 	}
+	if err := c.Network.validate(); err != nil {
+		return err
+	}
+	if err := c.Logging.validate(); err != nil {
+		return err
+	}
+	if c.Engine.Type == engine.TypeInMemory && c.WAL.DataDir == "" {
+		return errors.New("wal dataDir cannot be empty")
+	}
+	if err := c.WAL.validate(); err != nil {
+		return err
+	}
+	return c.Replication.validate(c.WAL.Enabled)
+}
 
-	if c.Network.Address == "" {
+func (c *ServerNetworkConfig) validate() error {
+	if c.Address == "" {
 		return errors.New("network address cannot be empty")
 	}
-
-	if c.Network.MaxConnections <= 0 {
+	if c.MaxConnections <= 0 {
 		return errors.New("maxConnections must be positive")
 	}
-
-	if c.Network.MaxMessageSizeKB <= 0 {
+	if c.MaxMessageSizeKB <= 0 {
 		return errors.New("maxMessageSize must be positive")
 	}
-
-	if c.Network.IdleTimeout <= 0 {
+	if c.MaxMessageSizeKB > int(^uint(0)>>1)/1024 {
+		return errors.New("maxMessageSize overflows bytes")
+	}
+	if c.IdleTimeout <= 0 {
 		return errors.New("idleTimeout must be positive")
 	}
-
-	if c.WAL.Enabled {
-		if c.WAL.DataDir == "" {
-			return errors.New("wal dataDir cannot be empty")
-		}
-		switch c.WAL.Sync {
-		case wal.SyncAlways, wal.SyncEverySec, wal.SyncNo:
-		default:
-			return fmt.Errorf("unsupported wal sync policy: %s", c.WAL.Sync)
-		}
-		if c.WAL.SegmentSizeMB <= 0 {
-			return errors.New("wal segmentSize must be positive")
-		}
-		if c.WAL.SnapshotInterval <= 0 {
-			return errors.New("wal snapshotInterval must be positive")
-		}
+	if c.ShutdownTimeout <= 0 {
+		return errors.New("shutdownTimeout must be positive")
 	}
+	return nil
+}
 
-	return c.Replication.validate(c.WAL.Enabled)
+func (c *ServerLoggingConfig) validate() error {
+	switch c.Level {
+	case "debug", defaultLogLevel, "warn", "error":
+		return nil
+	default:
+		return fmt.Errorf("unsupported logging level: %s", c.Level)
+	}
+}
+
+func (c *ServerWALConfig) validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	switch c.Sync {
+	case wal.SyncAlways, wal.SyncEverySec, wal.SyncNo:
+	default:
+		return fmt.Errorf("unsupported wal sync policy: %s", c.Sync)
+	}
+	if c.SegmentSizeMB <= 0 {
+		return errors.New("wal segmentSize must be positive")
+	}
+	if c.SegmentSizeMB > int64(^uint64(0)>>1)/(1<<20) {
+		return errors.New("wal segmentSize overflows bytes")
+	}
+	if c.SnapshotInterval <= 0 {
+		return errors.New("wal snapshotInterval must be positive")
+	}
+	return nil
 }
 
 // validate checks engine settings. The tiered engine keeps its own durable segment store, so it is mutually exclusive
@@ -224,17 +258,30 @@ func (c *ServerEngineConfig) validate(walEnabled bool, replicationRole string) e
 	if c.DataDir == "" {
 		return errors.New("engine data_dir cannot be empty")
 	}
+	return c.validateTieredStorage()
+}
+
+func (c *ServerEngineConfig) validateTieredStorage() error {
 	if c.MaxMemoryMB <= 0 {
 		return errors.New("engine max_memory must be positive")
 	}
+	if c.MaxMemoryMB > int64(^uint64(0)>>1)/(1<<20) {
+		return errors.New("engine max_memory overflows bytes")
+	}
 	if c.MaxStorageMB <= 0 {
 		return errors.New("engine max_storage must be positive")
+	}
+	if c.MaxStorageMB > int64(^uint64(0)>>1)/(1<<20) {
+		return errors.New("engine max_storage overflows bytes")
 	}
 	if c.MaxMemoryMB > c.MaxStorageMB {
 		return errors.New("engine max_memory must not exceed max_storage")
 	}
 	if c.SegmentSizeMB <= 0 {
 		return errors.New("engine segment_size must be positive")
+	}
+	if c.SegmentSizeMB > int64(^uint64(0)>>1)/(1<<20) {
+		return errors.New("engine segment_size overflows bytes")
 	}
 	if c.CompactionThreshold <= 0 || c.CompactionThreshold > 1 {
 		return errors.New("engine compaction_threshold must be in (0, 1]")

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -10,6 +11,9 @@ import (
 	"github.com/OutOfStack/db/internal/engine"
 	"github.com/OutOfStack/db/internal/wal"
 )
+
+// maxMB is the largest megabyte value that converts to bytes (mb << 20) without overflowing an int64.
+const maxMB = math.MaxInt64 / (1 << 20)
 
 // Environment variables that override server configuration values
 const (
@@ -196,7 +200,7 @@ func (c *ServerNetworkConfig) validate() error {
 	if c.MaxMessageSizeKB <= 0 {
 		return errors.New("maxMessageSize must be positive")
 	}
-	if c.MaxMessageSizeKB > int(^uint(0)>>1)/1024 {
+	if c.MaxMessageSizeKB > math.MaxInt/1024 {
 		return errors.New("maxMessageSize overflows bytes")
 	}
 	if c.IdleTimeout <= 0 {
@@ -229,7 +233,7 @@ func (c *ServerWALConfig) validate() error {
 	if c.SegmentSizeMB <= 0 {
 		return errors.New("wal segmentSize must be positive")
 	}
-	if c.SegmentSizeMB > int64(^uint64(0)>>1)/(1<<20) {
+	if c.SegmentSizeMB > maxMB {
 		return errors.New("wal segmentSize overflows bytes")
 	}
 	if c.SnapshotInterval <= 0 {
@@ -265,13 +269,13 @@ func (c *ServerEngineConfig) validateTieredStorage() error {
 	if c.MaxMemoryMB <= 0 {
 		return errors.New("engine max_memory must be positive")
 	}
-	if c.MaxMemoryMB > int64(^uint64(0)>>1)/(1<<20) {
+	if c.MaxMemoryMB > maxMB {
 		return errors.New("engine max_memory overflows bytes")
 	}
 	if c.MaxStorageMB <= 0 {
 		return errors.New("engine max_storage must be positive")
 	}
-	if c.MaxStorageMB > int64(^uint64(0)>>1)/(1<<20) {
+	if c.MaxStorageMB > maxMB {
 		return errors.New("engine max_storage overflows bytes")
 	}
 	if c.MaxMemoryMB > c.MaxStorageMB {
@@ -280,7 +284,7 @@ func (c *ServerEngineConfig) validateTieredStorage() error {
 	if c.SegmentSizeMB <= 0 {
 		return errors.New("engine segment_size must be positive")
 	}
-	if c.SegmentSizeMB > int64(^uint64(0)>>1)/(1<<20) {
+	if c.SegmentSizeMB > maxMB {
 		return errors.New("engine segment_size overflows bytes")
 	}
 	if c.CompactionThreshold <= 0 || c.CompactionThreshold > 1 {

--- a/internal/datadir/inspect.go
+++ b/internal/datadir/inspect.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/OutOfStack/db/internal/engine/tiered"
+	"github.com/OutOfStack/db/internal/wal"
 )
 
 // Kind identifies the durable database format present in a directory.
@@ -34,8 +37,10 @@ func Detect(dir string) (Kind, error) {
 			continue
 		}
 		name := entry.Name()
-		walFiles = walFiles || numbered(name, "wal-", ".log", 64) || numbered(name, "snapshot-", ".db", 64)
-		tieredFiles = tieredFiles || numbered(name, "seg-", ".data", 32)
+		walFiles = walFiles ||
+			numbered(name, wal.WALPrefix, wal.WALSuffix, 64) ||
+			numbered(name, wal.SnapshotPrefix, wal.SnapshotSuffix, 64)
+		tieredFiles = tieredFiles || numbered(name, tiered.SegPrefix, tiered.SegSuffix, 32)
 	}
 	switch {
 	case walFiles && tieredFiles:

--- a/internal/datadir/inspect.go
+++ b/internal/datadir/inspect.go
@@ -1,0 +1,59 @@
+package datadir
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Kind identifies the durable database format present in a directory.
+type Kind string
+
+const (
+	KindNone   Kind = "none"
+	KindWAL    Kind = "wal"
+	KindTiered Kind = "tiered"
+	KindMixed  Kind = "mixed"
+)
+
+// Detect classifies files written by the WAL-backed and tiered engines. A valid database filename counts even when its
+// header is empty or corrupt, so a damaged store cannot be mistaken for an unused directory.
+func Detect(dir string) (Kind, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return KindNone, nil
+		}
+		return KindNone, fmt.Errorf("read data directory %q: %w", dir, err)
+	}
+
+	var walFiles, tieredFiles bool
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		walFiles = walFiles || numbered(name, "wal-", ".log", 64) || numbered(name, "snapshot-", ".db", 64)
+		tieredFiles = tieredFiles || numbered(name, "seg-", ".data", 32)
+	}
+	switch {
+	case walFiles && tieredFiles:
+		return KindMixed, nil
+	case walFiles:
+		return KindWAL, nil
+	case tieredFiles:
+		return KindTiered, nil
+	default:
+		return KindNone, nil
+	}
+}
+
+func numbered(name, prefix, suffix string, bits int) bool {
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	number := strings.TrimSuffix(strings.TrimPrefix(name, prefix), suffix)
+	_, err := strconv.ParseUint(number, 10, bits)
+	return err == nil
+}

--- a/internal/datadir/inspect_test.go
+++ b/internal/datadir/inspect_test.go
@@ -1,0 +1,48 @@
+package datadir_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/datadir"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  datadir.Kind
+	}{
+		{"missing directory", nil, datadir.KindNone},
+		{"unrelated file", map[string]string{"notes.txt": "DBWAL\x00\x02"}, datadir.KindNone},
+		{"WAL segment", map[string]string{"wal-00000000000000000001.log": "DBWAL\x00\x02"}, datadir.KindWAL},
+		{"snapshot", map[string]string{"snapshot-00000000000000000001.db": "DBSNP\x00\x02"}, datadir.KindWAL},
+		{"tiered segment", map[string]string{"seg-0000000001.data": "DBSEG\x00\x02"}, datadir.KindTiered},
+		{"empty matching file", map[string]string{"wal-00000000000000000001.log": ""}, datadir.KindWAL},
+		{"invalid matching header", map[string]string{"seg-0000000001.data": "corrupt"}, datadir.KindTiered},
+		{"mixed formats", map[string]string{
+			"wal-00000000000000000001.log": "DBWAL\x00\x02",
+			"seg-0000000001.data":          "DBSEG\x00\x02",
+		}, datadir.KindMixed},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := filepath.Join(t.TempDir(), "data")
+			if test.files != nil {
+				require.NoError(t, os.Mkdir(dir, 0o750))
+				for name, contents := range test.files {
+					require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
+				}
+			}
+
+			got, err := datadir.Detect(dir)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/datadir/lock.go
+++ b/internal/datadir/lock.go
@@ -25,7 +25,11 @@ func Acquire(dir string) (*Lock, error) {
 }
 
 // Close releases ownership. The lockfile remains so another process cannot replace the locked inode by racing cleanup.
+// Close is nil-safe so callers that only conditionally acquired a lock don't need to guard the call themselves.
 func (l *Lock) Close() error {
+	if l == nil {
+		return nil
+	}
 	if err := l.file.Close(); err != nil {
 		return fmt.Errorf("release data directory lock: %w", err)
 	}

--- a/internal/datadir/lock.go
+++ b/internal/datadir/lock.go
@@ -1,0 +1,33 @@
+// Package datadir coordinates exclusive process ownership and identifies database files in a data directory.
+package datadir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const lockName = ".db.lock"
+
+// Lock holds exclusive process ownership of a data directory until Close.
+type Lock struct{ file *os.File }
+
+// Acquire takes the directory lock without waiting.
+func Acquire(dir string) (*Lock, error) {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, fmt.Errorf("create data directory %q: %w", dir, err)
+	}
+	file, err := lockFile(filepath.Join(dir, lockName))
+	if err != nil {
+		return nil, fmt.Errorf("lock data directory %q: %w", dir, err)
+	}
+	return &Lock{file: file}, nil
+}
+
+// Close releases ownership. The lockfile remains so another process cannot replace the locked inode by racing cleanup.
+func (l *Lock) Close() error {
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("release data directory lock: %w", err)
+	}
+	return nil
+}

--- a/internal/datadir/lock_test.go
+++ b/internal/datadir/lock_test.go
@@ -1,0 +1,63 @@
+package datadir_test
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/OutOfStack/db/internal/datadir"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockExcludesOtherOwnersAndReleases(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	lock, err := datadir.Acquire(dir)
+	require.NoError(t, err)
+	_, err = datadir.Acquire(dir)
+	require.Error(t, err)
+	require.NoError(t, lock.Close())
+
+	lock, err = datadir.Acquire(dir)
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
+	_, err = os.Stat(filepath.Join(dir, ".db.lock"))
+	require.NoError(t, err)
+}
+
+func TestLockReleasesWhenOwnerProcessDies(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestLockHelperProcess")
+	cmd.Env = append(os.Environ(), "DB_LOCK_HELPER="+dir)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	scanner := bufio.NewScanner(stdout)
+	require.True(t, scanner.Scan(), "helper exited before acquiring lock")
+	require.Equal(t, "locked", scanner.Text())
+	_, err = datadir.Acquire(dir)
+	require.Error(t, err)
+
+	require.NoError(t, cmd.Process.Kill())
+	require.Error(t, cmd.Wait())
+	lock, err := datadir.Acquire(dir)
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
+}
+
+func TestLockHelperProcess(t *testing.T) {
+	dir := os.Getenv("DB_LOCK_HELPER")
+	if dir == "" {
+		return
+	}
+	lock, err := datadir.Acquire(dir)
+	require.NoError(t, err)
+	defer func() { _ = lock.Close() }()
+	fmt.Println("locked")
+	select {}
+}

--- a/internal/datadir/lock_unix.go
+++ b/internal/datadir/lock_unix.go
@@ -1,0 +1,21 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package datadir
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(path string) (*os.File, error) {
+	// #nosec G304 -- path is the fixed lock filename inside the operator-configured data directory.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}

--- a/internal/datadir/lock_unsupported.go
+++ b/internal/datadir/lock_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !windows && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+
+package datadir
+
+import (
+	"errors"
+	"os"
+)
+
+func lockFile(string) (*os.File, error) {
+	return nil, errors.New("data directory locking is unsupported on this operating system")
+}

--- a/internal/datadir/lock_windows.go
+++ b/internal/datadir/lock_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package datadir
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(path string) (*os.File, error) {
+	name, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := syscall.CreateFile(
+		name,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		0,
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(handle), path), nil
+}

--- a/internal/engine/tiered/store.go
+++ b/internal/engine/tiered/store.go
@@ -32,8 +32,10 @@ const (
 	// maxValueLen keeps valLen distinct from the tombstone marker.
 	maxValueLen = tombstoneMarker - 1
 
-	segPrefix = "seg-"
-	segSuffix = ".data"
+	// SegPrefix and SegSuffix are exported so other packages (e.g. internal/datadir) can recognize segment files
+	// without duplicating the format.
+	SegPrefix = "seg-"
+	SegSuffix = ".data"
 )
 
 // segmentHeader identifies a segment written by this build; the trailing byte is the format version. A non-empty
@@ -445,7 +447,7 @@ func (s *store) close() error {
 }
 
 func segFilename(num uint32) string {
-	return fmt.Sprintf("%s%010d%s", segPrefix, num, segSuffix)
+	return fmt.Sprintf("%s%010d%s", SegPrefix, num, SegSuffix)
 }
 
 func listSegments(dir string) ([]uint32, error) {
@@ -459,10 +461,10 @@ func listSegments(dir string) ([]uint32, error) {
 	var nums []uint32
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || !strings.HasPrefix(name, segPrefix) || !strings.HasSuffix(name, segSuffix) {
+		if entry.IsDir() || !strings.HasPrefix(name, SegPrefix) || !strings.HasSuffix(name, SegSuffix) {
 			continue
 		}
-		text := strings.TrimSuffix(strings.TrimPrefix(name, segPrefix), segSuffix)
+		text := strings.TrimSuffix(strings.TrimPrefix(name, SegPrefix), SegSuffix)
 		num, parseErr := strconv.ParseUint(text, 10, 32)
 		if parseErr != nil {
 			continue

--- a/internal/network/client_test.go
+++ b/internal/network/client_test.go
@@ -90,24 +90,24 @@ func startServerAt(t *testing.T, address string, handler network.RequestHandler)
 	if err != nil {
 		t.Fatalf("NewTCPServer(%s): %v", address, err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	go srv.Start(ctx, handler)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(handler) }()
 
 	addr = srv.Addr().String()
+	var once sync.Once
 	stop = func() {
-		cancel()
-		var dialer net.Dialer
-		for range 200 {
-			conn, dErr := dialer.DialContext(context.Background(), "tcp", addr)
-			if dErr != nil {
-				return
+		once.Do(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if sErr := srv.Shutdown(ctx); sErr != nil {
+				t.Errorf("Shutdown(%s): %v", addr, sErr)
 			}
-			_ = conn.Close()
-			time.Sleep(10 * time.Millisecond)
-		}
-		t.Fatalf("server at %s did not stop accepting connections", addr)
+			if sErr := <-done; sErr != nil {
+				t.Errorf("Serve(%s): %v", addr, sErr)
+			}
+		})
 	}
+	t.Cleanup(stop)
 	return addr, stop
 }
 

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -33,6 +33,11 @@ type TCPServer struct {
 	listener            net.Listener
 	wg                  sync.WaitGroup
 	connectionSemaphore chan struct{}
+	mu                  sync.Mutex
+	connections         map[net.Conn]bool
+	draining            bool
+	cancelHandlers      context.CancelFunc
+	serveDone           chan struct{}
 
 	idleTimeout    time.Duration
 	maxMessageSize int
@@ -55,6 +60,8 @@ func NewTCPServer(address string, logger *slog.Logger, options ...TCPServerOptio
 		listener:            listener,
 		logger:              logger,
 		connectionSemaphore: make(chan struct{}, 100),
+		connections:         make(map[net.Conn]bool),
+		serveDone:           make(chan struct{}),
 		maxMessageSize:      defaultMaxMessageSize,
 		idleTimeout:         defaultTimeout,
 	}
@@ -71,51 +78,147 @@ func (s *TCPServer) Addr() net.Addr {
 	return s.listener.Addr()
 }
 
-// Start begins accepting connections
-func (s *TCPServer) Start(ctx context.Context, handler RequestHandler) {
-	s.wg.Go(func() {
-		for {
-			conn, err := s.listener.Accept()
-			if err != nil {
-				if errors.Is(err, net.ErrClosed) {
-					return
-				}
-				s.logger.Error("Failed to accept connection", "error", err)
+// Serve accepts connections until Shutdown closes the listener.
+func (s *TCPServer) Serve(handler RequestHandler) error {
+	handlerCtx, cancelHandlers := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.cancelHandlers = cancelHandlers
+	s.mu.Unlock()
+	defer func() {
+		if !s.isDraining() {
+			cancelHandlers()
+		}
+	}()
+	defer close(s.serveDone)
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			s.logger.Error("Failed to accept connection", "error", err)
+			continue
+		}
+
+		select {
+		case s.connectionSemaphore <- struct{}{}:
+			if !s.trackConnection(conn) {
+				<-s.connectionSemaphore
+				_ = conn.Close()
 				continue
 			}
-
-			// try to acquire connection slot
-			select {
-			case s.connectionSemaphore <- struct{}{}:
-				// connection slot acquired, handle the connection
-				s.wg.Add(1)
-				go s.handleConnection(ctx, conn, handler)
-			default:
-				// connection limit reached, reject the connection
-				s.logger.Warn("Connection limit reached, rejecting new connection", "client", conn.RemoteAddr())
-				if err = conn.Close(); err != nil {
-					s.logger.Error("Failed to close rejected connection", "error", err)
-				}
+			go s.handleConnection(handlerCtx, conn, handler)
+		default:
+			s.logger.Warn("Connection limit reached, rejecting new connection", "client", conn.RemoteAddr())
+			if err = conn.Close(); err != nil {
+				s.logger.Error("Failed to close rejected connection", "error", err)
 			}
 		}
-	})
-
-	<-ctx.Done()
-
-	if err := s.listener.Close(); err != nil {
-		s.logger.Error("Failed to stop server", "error", err)
 	}
-
-	s.wg.Wait()
 }
 
-func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler RequestHandler) {
+// Shutdown must be called while Serve is running. It stops accepting, closes idle connections, and gives active handlers
+// until ctx expires before cancelling their contexts and closing their sockets. The deadline bounds that grace period;
+// Shutdown still waits for every handler to return so persistence can be closed safely.
+func (s *TCPServer) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	s.draining = true
+	idle := make([]net.Conn, 0, len(s.connections))
+	for conn, active := range s.connections {
+		if !active {
+			idle = append(idle, conn)
+		}
+	}
+	s.mu.Unlock()
+
+	err := s.listener.Close()
+	if errors.Is(err, net.ErrClosed) {
+		err = nil
+	}
+	for _, conn := range idle {
+		if closeErr := conn.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			err = errors.Join(err, closeErr)
+		}
+	}
+	<-s.serveDone
+
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		s.cancelActiveHandlers()
+		return err
+	case <-ctx.Done():
+		s.logger.Warn("Shutdown grace period expired; cancelling active handlers", "error", ctx.Err())
+		s.cancelActiveHandlers()
+		s.mu.Lock()
+		active := make([]net.Conn, 0, len(s.connections))
+		for conn := range s.connections {
+			active = append(active, conn)
+		}
+		s.mu.Unlock()
+		for _, conn := range active {
+			if closeErr := conn.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+				err = errors.Join(err, closeErr)
+			}
+		}
+		<-done
+		return err
+	}
+}
+
+func (s *TCPServer) cancelActiveHandlers() {
+	s.mu.Lock()
+	cancel := s.cancelHandlers
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *TCPServer) trackConnection(conn net.Conn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.draining {
+		return false
+	}
+	s.connections[conn] = false
+	s.wg.Add(1)
+	return true
+}
+
+func (s *TCPServer) beginCommand(conn net.Conn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.draining {
+		// Shutdown won the race after this command was decoded, so it is not dispatched. The closed connection can make
+		// the client report ErrOutcomeUnknown even though the command did not execute.
+		return false
+	}
+	s.connections[conn] = true
+	return true
+}
+
+func (s *TCPServer) finishCommand(conn net.Conn) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connections[conn] = false
+	return s.draining
+}
+
+func (s *TCPServer) handleConnection(handlerCtx context.Context, conn net.Conn, handler RequestHandler) {
 	defer func() {
 		if err := conn.Close(); err != nil {
 			s.logger.Error("Failed to close connection", "error", err)
 		}
 		// release connection slot
 		<-s.connectionSemaphore
+		s.mu.Lock()
+		delete(s.connections, conn)
+		s.mu.Unlock()
 		s.wg.Done()
 	}()
 
@@ -124,53 +227,62 @@ func (s *TCPServer) handleConnection(ctx context.Context, conn net.Conn, handler
 	reader := bufio.NewReader(conn)
 
 	for {
-		// set the read deadline
-		if err := conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); err != nil {
-			s.logger.Error("Failed to set read deadline", "error", err)
-			return
-		}
-
-		// read one full RESP command from the connection
-		cmd, args, err := protocol.ReadCommand(reader, s.maxMessageSize)
-		if err != nil {
-			// client disconnected (possibly mid-frame): close quietly
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				return
-			}
-			// idle timeout is a normal disconnect, not an error
-			if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
-				s.logger.Info("Closing idle connection", "address", conn.RemoteAddr())
-				return
-			}
-			s.logger.Error("Error reading command from connection", "error", err)
-			if wErr := s.writeReply(conn, protocol.Error(err.Error())); wErr != nil {
-				s.logger.Error("Failed to send protocol error", "error", wErr)
-				return
-			}
-			// drain pending request bytes briefly: closing with unread input can trigger a TCP reset that discards the queued
-			// error reply
-			if dErr := conn.SetReadDeadline(time.Now().Add(errorDrainTimeout)); dErr == nil {
-				_, _ = io.Copy(io.Discard, reader)
-			}
+		cmd, args, ok := s.readCommand(conn, reader)
+		if !ok {
 			return
 		}
 
 		// Process the request. Dispatch happens only after ReadCommand has decoded the frame whole, so a truncated request
 		// returns above without ever reaching the handler. Clients rely on that to tell a failed send apart from a lost
 		// reply: a command they could not finish writing provably did not run.
-		response := handler(ctx, cmd, args)
-		if err = s.writeReply(conn, response); err != nil {
+		if !s.beginCommand(conn) {
+			return
+		}
+		response := handler(handlerCtx, cmd, args)
+		if err := s.writeReply(conn, response); err != nil {
 			s.logger.Error("Failed to send response", "error", err)
 			return
 		}
 
-		// check for context cancellation
-		select {
-		case <-ctx.Done():
+		if s.finishCommand(conn) {
 			return
-		default:
 		}
 	}
+}
+
+func (s *TCPServer) readCommand(conn net.Conn, reader *bufio.Reader) (string, []string, bool) {
+	if err := conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); err != nil {
+		s.logger.Error("Failed to set read deadline", "error", err)
+		return "", nil, false
+	}
+
+	cmd, args, err := protocol.ReadCommand(reader, s.maxMessageSize)
+	if err == nil {
+		return cmd, args, true
+	}
+	if s.isDraining() || errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", nil, false
+	}
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+		s.logger.Info("Closing idle connection", "address", conn.RemoteAddr())
+		return "", nil, false
+	}
+	s.logger.Error("Error reading command from connection", "error", err)
+	if writeErr := s.writeReply(conn, protocol.Error(err.Error())); writeErr != nil {
+		s.logger.Error("Failed to send protocol error", "error", writeErr)
+		return "", nil, false
+	}
+	// Closing with unread input can reset the connection before the queued error reply reaches the client.
+	if drainErr := conn.SetReadDeadline(time.Now().Add(errorDrainTimeout)); drainErr == nil {
+		_, _ = io.Copy(io.Discard, reader)
+	}
+	return "", nil, false
+}
+
+func (s *TCPServer) isDraining() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.draining
 }
 
 func (s *TCPServer) writeReply(conn net.Conn, reply protocol.Reply) error {

--- a/internal/network/server_test.go
+++ b/internal/network/server_test.go
@@ -1,0 +1,125 @@
+package network_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/OutOfStack/db/internal/network"
+	"github.com/OutOfStack/db/internal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func startTCPServer(t *testing.T, handler network.RequestHandler) (*network.TCPServer, <-chan error) {
+	t.Helper()
+	srv, err := network.NewTCPServer("127.0.0.1:0", slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(handler) }()
+	return srv, done
+}
+
+func TestShutdownClosesIdleAndPartialConnections(t *testing.T) {
+	t.Parallel()
+	for _, partial := range []bool{false, true} {
+		name := "idle"
+		if partial {
+			name = "partial frame"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			srv, serveDone := startTCPServer(t, func(context.Context, string, []string) protocol.Reply {
+				return protocol.SimpleString("OK")
+			})
+			dialer := net.Dialer{}
+			conn, err := dialer.DialContext(t.Context(), "tcp", srv.Addr().String())
+			require.NoError(t, err)
+			defer func() { _ = conn.Close() }()
+			if partial {
+				_, err = io.WriteString(conn, "*2\r\n$3\r\nGET\r\n$1\r\n")
+				require.NoError(t, err)
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			require.NoError(t, srv.Shutdown(ctx))
+			require.NoError(t, <-serveDone)
+			require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+			_, err = conn.Read(make([]byte, 1))
+			require.Error(t, err)
+
+			dialer.Timeout = 100 * time.Millisecond
+			_, err = dialer.DialContext(t.Context(), "tcp", srv.Addr().String())
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestShutdownDrainsDecodedCommand(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv, serveDone := startTCPServer(t, func(context.Context, string, []string) protocol.Reply {
+		close(started)
+		<-release
+		return protocol.SimpleString("OK")
+	})
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(t.Context(), "tcp", srv.Addr().String())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, protocol.WriteCommand(conn, "PING", nil))
+	<-started
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- srv.Shutdown(ctx) }()
+	select {
+	case err = <-shutdownDone:
+		t.Fatalf("Shutdown returned before active command completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	reply, err := protocol.ReadReply(bufio.NewReader(conn), 1024)
+	require.NoError(t, err)
+	require.Equal(t, protocol.SimpleString("OK"), reply)
+	require.NoError(t, <-shutdownDone)
+	require.NoError(t, <-serveDone)
+}
+
+func TestShutdownTimeoutCancelsStalledHandlerWithoutCloseError(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	srv, serveDone := startTCPServer(t, func(ctx context.Context, _ string, _ []string) protocol.Reply {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		return protocol.Error(ctx.Err().Error())
+	})
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(t.Context(), "tcp", srv.Addr().String())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, protocol.WriteCommand(conn, "PING", nil))
+	<-started
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	err = srv.Shutdown(ctx)
+	require.NoError(t, err)
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("handler context was not cancelled")
+	}
+	require.NoError(t, <-serveDone)
+	_, err = protocol.ReadReply(bufio.NewReader(conn), 1024)
+	require.True(t, errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed), "ReadReply() error = %v", err)
+}

--- a/internal/pool/routing_test.go
+++ b/internal/pool/routing_test.go
@@ -20,9 +20,14 @@ func startHandler(t *testing.T, handler network.RequestHandler) string {
 	if err != nil {
 		t.Fatalf("NewTCPServer: %v", err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	go srv.Start(ctx, handler)
+	go func() { _ = srv.Serve(handler) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			t.Errorf("Shutdown: %v", err)
+		}
+	})
 	return srv.Addr().String()
 }
 

--- a/internal/wal/files.go
+++ b/internal/wal/files.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 )
 
+// Segment and snapshot filename prefix/suffix, exported so other packages (e.g. internal/datadir) can recognize WAL
+// files without duplicating the format.
 const (
-	walPrefix      = "wal-"
-	walSuffix      = ".log"
-	snapshotPrefix = "snapshot-"
-	snapshotSuffix = ".db"
+	WALPrefix      = "wal-"
+	WALSuffix      = ".log"
+	SnapshotPrefix = "snapshot-"
+	SnapshotSuffix = ".db"
 )
 
 type numberedFile struct {
@@ -22,11 +24,11 @@ type numberedFile struct {
 }
 
 func walFilename(firstLSN uint64) string {
-	return fmt.Sprintf("%s%020d%s", walPrefix, firstLSN, walSuffix)
+	return fmt.Sprintf("%s%020d%s", WALPrefix, firstLSN, WALSuffix)
 }
 
 func snapshotFilename(lsn uint64) string {
-	return fmt.Sprintf("%s%020d%s", snapshotPrefix, lsn, snapshotSuffix)
+	return fmt.Sprintf("%s%020d%s", SnapshotPrefix, lsn, SnapshotSuffix)
 }
 
 func listNumberedFiles(dir, prefix, suffix string) ([]numberedFile, error) {

--- a/internal/wal/reader.go
+++ b/internal/wal/reader.go
@@ -25,7 +25,7 @@ func NewReader(dir string, logger *slog.Logger) *Reader {
 // Replay applies records newer than afterLSN and returns the last valid LSN. A partial or checksum-invalid record in
 // the final segment is truncated as a crash tail; the same damage in an earlier segment is a startup error.
 func (r *Reader) Replay(afterLSN uint64, apply func(Record) error) (uint64, error) {
-	segments, err := listNumberedFiles(r.dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(r.dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return afterLSN, fmt.Errorf("list WAL segments: %w", err)
 	}

--- a/internal/wal/snapshot.go
+++ b/internal/wal/snapshot.go
@@ -76,7 +76,7 @@ func writeSnapshotRecords(ctx context.Context, file io.Writer, source SnapshotSo
 }
 
 func removeOldSnapshots(dir string, lsn uint64) error {
-	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	snapshots, err := listNumberedFiles(dir, SnapshotPrefix, SnapshotSuffix)
 	if err != nil {
 		return fmt.Errorf("list old snapshots: %w", err)
 	}
@@ -95,7 +95,7 @@ func removeOldSnapshots(dir string, lsn uint64) error {
 
 // LoadLatestSnapshot loads the newest complete snapshot and returns its LSN.
 func LoadLatestSnapshot(dir string, apply func(table, key, value string) error) (uint64, error) {
-	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	snapshots, err := listNumberedFiles(dir, SnapshotPrefix, SnapshotSuffix)
 	if err != nil {
 		return 0, fmt.Errorf("list snapshots: %w", err)
 	}

--- a/internal/wal/stream.go
+++ b/internal/wal/stream.go
@@ -9,7 +9,7 @@ import (
 // OldestRecordLSN returns the LSN of the oldest record still retained on disk. It is the first LSN of the earliest WAL
 // segment; when no segments exist it returns fallback (the caller passes LastLSN+1, meaning "nothing on disk").
 func OldestRecordLSN(dir string, fallback uint64) (uint64, error) {
-	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return 0, fmt.Errorf("list WAL segments: %w", err)
 	}
@@ -21,7 +21,7 @@ func OldestRecordLSN(dir string, fallback uint64) (uint64, error) {
 
 // LatestSnapshotInfo returns the LSN and path of the newest snapshot on disk. ok is false when no snapshot exists.
 func LatestSnapshotInfo(dir string) (lsn uint64, path string, ok bool, err error) {
-	snapshots, err := listNumberedFiles(dir, snapshotPrefix, snapshotSuffix)
+	snapshots, err := listNumberedFiles(dir, SnapshotPrefix, SnapshotSuffix)
 	if err != nil {
 		return 0, "", false, fmt.Errorf("list snapshots: %w", err)
 	}
@@ -37,7 +37,7 @@ func LatestSnapshotInfo(dir string) (lsn uint64, path string, ok bool, err error
 // checksum-invalid record at the tail of the final segment is treated as a half-written live record and ends iteration
 // cleanly (the caller streams the rest from the live fan-out); the same damage in an earlier segment is an error.
 func ReadRecordsFrom(dir string, fromLSN uint64, fn func(Record) error) error {
-	segments, err := listNumberedFiles(dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return fmt.Errorf("list WAL segments: %w", err)
 	}

--- a/internal/wal/writer.go
+++ b/internal/wal/writer.go
@@ -99,7 +99,7 @@ func OpenWriter(config WriterConfig, lastLSN uint64) (*Writer, error) {
 	if err := os.MkdirAll(config.Dir, 0o750); err != nil {
 		return nil, fmt.Errorf("create WAL directory: %w", err)
 	}
-	segments, err := listNumberedFiles(config.Dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(config.Dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("list WAL segments: %w", err)
 	}
@@ -434,7 +434,7 @@ func (w *Writer) reset(state *writerState, lsn uint64) error {
 		state.file = nil
 		state.size = 0
 	}
-	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(w.config.Dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return fmt.Errorf("list WAL segments for reset: %w", err)
 	}
@@ -551,7 +551,7 @@ func (w *Writer) handleClose(state *writerState) error {
 }
 
 func (w *Writer) syncAllSegments() error {
-	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(w.config.Dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return fmt.Errorf("list WAL segments during close: %w", err)
 	}
@@ -578,7 +578,7 @@ func (w *Writer) prune(state *writerState, uptoLSN uint64) error {
 			return fmt.Errorf("sync WAL before prune: %w", err)
 		}
 	}
-	segments, err := listNumberedFiles(w.config.Dir, walPrefix, walSuffix)
+	segments, err := listNumberedFiles(w.config.Dir, WALPrefix, WALSuffix)
 	if err != nil {
 		return fmt.Errorf("list WAL segments for prune: %w", err)
 	}


### PR DESCRIPTION
- strictly validate config paths, fields, levels, timeouts, and sizes
- lock and identify durable data directories before recovery
- drain connections before ordered cleanup and report close failures